### PR TITLE
Refactor umfPoolCreate to accept only one provider

### DIFF
--- a/include/umf/memory_pool.h
+++ b/include/umf/memory_pool.h
@@ -24,16 +24,14 @@ struct umf_memory_pool_ops_t;
 ///
 /// \brief Creates new memory pool.
 /// \param ops instance of umf_memory_pool_ops_t
-/// \param providers array of memory providers that will be used for coarse-grain allocations.
-///        Should contain at least one memory provider.
-/// \param numProvider number of elements in the providers array
+/// \param provider memory provider that will be used for coarse-grain allocations.
 /// \param params pointer to pool-specific parameters
 /// \param hPool [out] handle to the newly created memory pool
 /// \return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
 ///
 enum umf_result_t umfPoolCreate(const struct umf_memory_pool_ops_t *ops,
-                                umf_memory_provider_handle_t *providers,
-                                size_t numProviders, void *params,
+                                umf_memory_provider_handle_t provider,
+                                void *params,
                                 umf_memory_pool_handle_t *hPool);
 
 ///
@@ -135,17 +133,14 @@ enum umf_result_t umfPoolGetLastAllocationError(umf_memory_pool_handle_t hPool);
 umf_memory_pool_handle_t umfPoolByPtr(const void *ptr);
 
 ///
-/// \brief Retrieve memory providers associated with a given pool.
+/// \brief Retrieve memory provider associated with a given pool.
 /// \param hPool specified memory pool
-/// \param hProviders [out] pointer to an array of memory providers. If numProviders is not equal to or
-///        greater than the real number of providers, UMF_RESULT_ERROR_INVALID_ARGUMENT is returned.
-/// \param numProviders [in] number of memory providers to return
-/// \param numProvidersRet pointer to the actual number of memory providers
+/// \param hProvider [out] memory providers handle.
 /// \return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
+///         UMF_RESULT_ERROR_INVALID_ARGUMENT if hProvider is NULL
 enum umf_result_t
-umfPoolGetMemoryProviders(umf_memory_pool_handle_t hPool, size_t numProviders,
-                          umf_memory_provider_handle_t *hProviders,
-                          size_t *numProvidersRet);
+umfPoolGetMemoryProvider(umf_memory_pool_handle_t hPool,
+                          umf_memory_provider_handle_t *hProvider);
 
 #ifdef __cplusplus
 }

--- a/include/umf/memory_pool_ops.h
+++ b/include/umf/memory_pool_ops.h
@@ -33,8 +33,8 @@ struct umf_memory_pool_ops_t {
     /// \param params pool-specific params
     /// \param pool [out] returns pointer to the pool
     /// \return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
-    enum umf_result_t (*initialize)(umf_memory_provider_handle_t *providers,
-                                    size_t numProviders, void *params,
+    enum umf_result_t (*initialize)(umf_memory_provider_handle_t provider,
+                                    void *params,
                                     void **pool);
 
     ///

--- a/src/memory_pool_internal.h
+++ b/src/memory_pool_internal.h
@@ -22,11 +22,8 @@ struct umf_memory_pool_t {
     void *pool_priv;
     struct umf_memory_pool_ops_t ops;
 
-    // Holds array of memory providers. All providers are wrapped
-    // by memory tracking providers (owned and released by UMF).
-    umf_memory_provider_handle_t *providers;
-
-    size_t numProviders;
+    // Memory provider used by the pool.
+    umf_memory_provider_handle_t provider;
 };
 
 #ifdef __cplusplus

--- a/src/pool/pool_null.c
+++ b/src/pool/pool_null.c
@@ -9,13 +9,12 @@
 #include <umf/memory_pool_ops.h>
 #include <pool/pool_null.h>
 
-static enum umf_result_t nullInitialize(umf_memory_provider_handle_t *providers,
-                                        size_t numProviders, void *params,
+static enum umf_result_t nullInitialize(umf_memory_provider_handle_t provider,
+                                        void *params,
                                         void **pool) {
-    (void)providers;
-    (void)numProviders;
+    (void)provider;
     (void)params;
-    assert(providers && numProviders);
+    assert(provider);
     *pool = NULL;
     return UMF_RESULT_SUCCESS;
 }

--- a/src/pool/pool_trace.c
+++ b/src/pool/pool_trace.c
@@ -18,7 +18,7 @@ struct trace_pool {
 };
 
 static enum umf_result_t
-traceInitialize(umf_memory_provider_handle_t *providers, size_t numProviders,
+traceInitialize(umf_memory_provider_handle_t provider,
                 void *params, void **pool)
 {
     struct trace_pool *trace_pool =
@@ -30,9 +30,8 @@ traceInitialize(umf_memory_provider_handle_t *providers, size_t numProviders,
     trace_pool->params.hUpstreamPool = pub_params->hUpstreamPool;
     trace_pool->params.trace = pub_params->trace;
 
-    (void)providers;
-    (void)numProviders;
-    assert(providers && numProviders);
+    (void)provider;
+    assert(provider);
 
     *pool = trace_pool;
     return UMF_RESULT_SUCCESS;


### PR DESCRIPTION
Pool is a combination of memory provider and pool manager. The umfPoolCreate function s is refactored to accept only a single memory provider as we agreed.