### PR TITLE
Add missing target_include_directories

### DIFF
--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -11,3 +11,5 @@ set(COMMON_SOURCES
 )
 
 add_umf_library(test_common STATIC ${COMMON_SOURCES})
+
+target_include_directories(test_common PRIVATE ../../include)


### PR DESCRIPTION
The `test/common/CMakeLists.txt` file has to contain `target_include_directories()` pointing relatively to `/include`, so that UMF is compatible with `FetchContent`.