### PR TITLE
Include CMakePackageConfigHelpers module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 include(CTest)
+include(CMakePackageConfigHelpers)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(helpers)


### PR DESCRIPTION
Include `CMakePackageConfigHelpers ` module,
because we use the `write_basic_package_version_file()` function.

**Fix required by oneCCL.**