### PR TITLE
Fix disjoint_pool compilation error in C

### DIFF
--- a/include/pool/pool_disjoint.h
+++ b/include/pool/pool_disjoint.h
@@ -10,31 +10,44 @@ extern "C" {
 #include <umf/memory_pool.h>
 #include <umf/memory_provider.h>
 
-inline constexpr size_t MIN_BUCKET_DEFAULT_SIZE = 8;
+#define UMF_DISJOINT_POOL_MIN_BUCKET_DEFAULT_SIZE ((size_t)8)
 
 struct umf_disjoint_pool_params {
     // Minimum allocation size that will be requested from the system.
     // By default this is the minimum allocation size of each memory type.
-    size_t SlabMinSize = 0;
+    size_t SlabMinSize;
 
     // Allocations up to this limit will be subject to chunking/pooling
-    size_t MaxPoolableSize = 0;
+    size_t MaxPoolableSize;
 
-    // When pooling, each bucket will hold a max of 4 unfreed slabs
-    size_t Capacity = 0;
+    // When pooling, each bucket will hold a max of 'Capacity' unfreed slabs
+    size_t Capacity;
 
     // Holds the minimum bucket size valid for allocation of a memory type.
     // This value must be a power of 2.
-    size_t MinBucketSize = MIN_BUCKET_DEFAULT_SIZE;
+    size_t MinBucketSize;
 
     // Holds size of the pool managed by the allocator.
-    size_t CurPoolSize = 0;
+    size_t CurPoolSize;
 
     // Whether to print pool usage statistics
-    int PoolTrace = 0;
+    int PoolTrace;
 };
 
 extern struct umf_memory_pool_ops_t UMF_DISJOINT_POOL_OPS;
+
+static inline struct umf_disjoint_pool_params umfDisjointPoolParamsDefault() {
+    struct umf_disjoint_pool_params params = {
+        0,                                         /* SlabMinSize */
+        0,                                         /* MaxPoolableSize */
+        0,                                         /* Capacity */
+        UMF_DISJOINT_POOL_MIN_BUCKET_DEFAULT_SIZE, /* MinBucketSize */
+        0,                                         /* CurPoolSize */
+        0                                          /* PoolTrace */
+    };
+
+    return params;
+}
 
 #ifdef __cplusplus
 }

--- a/src/pool/disjoint/pool_disjoint_impl.cpp
+++ b/src/pool/disjoint/pool_disjoint_impl.cpp
@@ -291,7 +291,7 @@ class DisjointPool::AllocImpl {
         // Powers of 2 and the value halfway between the powers of 2.
         auto Size1 = params.MinBucketSize;
         // Buckets sized smaller than the bucket default size- 8 aren't needed.
-        Size1 = std::max(Size1, MIN_BUCKET_DEFAULT_SIZE);
+        Size1 = std::max(Size1, UMF_DISJOINT_POOL_MIN_BUCKET_DEFAULT_SIZE);
         auto Size2 = Size1 + Size1 / 2;
         for (; Size2 < CutOff; Size1 *= 2, Size2 *= 2) {
             Buckets.push_back(std::make_unique<Bucket>(Size1, *this));

--- a/src/pool/disjoint/pool_disjoint_impl.hpp
+++ b/src/pool/disjoint/pool_disjoint_impl.hpp
@@ -14,8 +14,6 @@
 
 namespace usm {
 
-inline constexpr size_t MIN_BUCKET_DEFAULT_SIZE = 8;
-
 // Configuration for specific USM allocator instance
 class DisjointPoolConfig : public umf_disjoint_pool_params {
   public:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,6 +41,8 @@ endfunction()
 
 add_subdirectory(common)
 
+add_umf_test(c_api_disjoint_pool c_api/disjoint_pool.c)
+
 add_umf_test(base base.cpp)
 add_umf_test(memoryPool memoryPoolAPI.cpp)
 add_umf_test(memoryProvider memoryProviderAPI.cpp)

--- a/test/c_api/disjoint_pool.c
+++ b/test/c_api/disjoint_pool.c
@@ -1,0 +1,30 @@
+// Copyright (C) 2023 Intel Corporation
+// Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <stdlib.h>
+
+#include "pool/pool_disjoint.h"
+#include "provider_null.h"
+#include "test_helpers.h"
+
+void test_disjoint_pool_default_params() {
+    umf_memory_provider_handle_t provider = nullProviderCreate();
+    enum umf_result_t retp;
+    umf_memory_pool_handle_t pool = NULL;
+    struct umf_disjoint_pool_params params = umfDisjointPoolParamsDefault();
+    retp = umfPoolCreate(&UMF_DISJOINT_POOL_OPS, provider, &params, &pool);
+
+    // TODO: use asserts
+    if (retp != UMF_RESULT_SUCCESS) {
+        abort();
+    }
+
+    umfPoolDestroy(pool);
+    umfMemoryProviderDestroy(provider);
+}
+
+int main() {
+    test_disjoint_pool_default_params();
+    return 0;
+}

--- a/test/common/test_helpers.h
+++ b/test/common/test_helpers.h
@@ -7,6 +7,7 @@
 #define UMF_TEST_HELPERS_H 1
 
 #include <umf/base.h>
+#include <umf/memory_pool.h>
 #include <umf/memory_provider_ops.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
C does not allow setting default values as part of struct definition.