### PR TITLE
Remove DisjointPoolConfig and use umf_helpers to expose DisjointPool ops

### DIFF
--- a/include/pool/pool_disjoint.h
+++ b/include/pool/pool_disjoint.h
@@ -60,7 +60,9 @@ static inline struct umf_disjoint_pool_params umfDisjointPoolParamsDefault() {
         0,                                         /* Capacity */
         UMF_DISJOINT_POOL_MIN_BUCKET_DEFAULT_SIZE, /* MinBucketSize */
         0,                                         /* CurPoolSize */
-        0                                          /* PoolTrace */
+        0,                                         /* PoolTrace */
+        NULL,                                      /* SharedLimits */
+        "disjoint_pool"                            /* Name */
     };
 
     return params;

--- a/src/pool/disjoint/pool_disjoint.cpp
+++ b/src/pool/disjoint/pool_disjoint.cpp
@@ -2,15 +2,9 @@
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <stdbool.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-
-#include <umf/memory_pool_ops.h>
-#include <umf/memory_provider.h>
-
+#include "pool/pool_disjoint.h"
 #include "pool_disjoint_impl.hpp"
+#include "umf_helpers.hpp"
 
 struct umf_disjoint_pool_shared_limits *
 umfDisjointPoolSharedLimitsCreate(size_t MaxSize) {
@@ -22,84 +16,5 @@ void umfDisjointPoolSharedLimitsDestroy(
     delete limits;
 }
 
-struct disjoint_memory_pool {
-    usm::DisjointPool *disjoint_pool;
-};
-
-enum umf_result_t
-disjoint_pool_initialize(umf_memory_provider_handle_t provider, void *params,
-                         void **pool) try {
-    struct disjoint_memory_pool *pool_data = new struct disjoint_memory_pool;
-    pool_data->disjoint_pool = new usm::DisjointPool();
-    pool_data->disjoint_pool->initialize(
-        provider, *(struct umf_disjoint_pool_params *)params);
-    *pool = (void *)pool_data;
-    return UMF_RESULT_SUCCESS;
-} catch (std::bad_alloc &) {
-    return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
-} catch (...) {
-    return UMF_RESULT_ERROR_UNKNOWN;
-}
-
-void disjoint_pool_finalize(void *pool) {
-    struct disjoint_memory_pool *pool_data =
-        (struct disjoint_memory_pool *)pool;
-    delete pool_data->disjoint_pool;
-    delete pool_data;
-    pool = NULL;
-}
-
-void *disjoint_malloc(void *pool, size_t size) {
-    struct disjoint_memory_pool *pool_data =
-        (struct disjoint_memory_pool *)pool;
-    return pool_data->disjoint_pool->malloc(size);
-}
-
-void *disjoint_calloc(void *pool, size_t num, size_t size) {
-    struct disjoint_memory_pool *pool_data =
-        (struct disjoint_memory_pool *)pool;
-    return pool_data->disjoint_pool->calloc(num, size);
-}
-
-void *disjoint_realloc(void *pool, void *ptr, size_t size) {
-    struct disjoint_memory_pool *pool_data =
-        (struct disjoint_memory_pool *)pool;
-    return pool_data->disjoint_pool->realloc(ptr, size);
-}
-
-void *disjoint_aligned_malloc(void *pool, size_t size, size_t alignment) {
-    struct disjoint_memory_pool *pool_data =
-        (struct disjoint_memory_pool *)pool;
-    return pool_data->disjoint_pool->aligned_malloc(size, alignment);
-}
-
-enum umf_result_t disjoint_free(void *pool, void *ptr) {
-    struct disjoint_memory_pool *pool_data =
-        (struct disjoint_memory_pool *)pool;
-    return pool_data->disjoint_pool->free(ptr);
-}
-
-enum umf_result_t disjoint_get_last_allocation_error(void *pool) {
-    struct disjoint_memory_pool *pool_data =
-        (struct disjoint_memory_pool *)pool;
-    return pool_data->disjoint_pool->get_last_allocation_error();
-}
-
-/*
- * Do not use C++ designated initializers,
- * because they are available starting from C++20,
- * when [-Wpedantic] is set and they are treated
- * as an error on Windows.
- */
-struct umf_memory_pool_ops_t UMF_DISJOINT_POOL_OPS = {
-    /* .version = */ UMF_VERSION_CURRENT,
-    /* .initialize = */ disjoint_pool_initialize,
-    /* .finalize = */ disjoint_pool_finalize,
-    /* .malloc = */ disjoint_malloc,
-    /* .calloc = */ disjoint_calloc,
-    /* .realloc = */ disjoint_realloc,
-    /* .aligned_malloc = */ disjoint_aligned_malloc,
-    /* .malloc_usable_size = */ NULL,
-    /* .free = */ disjoint_free,
-    /* .get_last_allocation_error = */ disjoint_get_last_allocation_error,
-};
+struct umf_memory_pool_ops_t UMF_DISJOINT_POOL_OPS =
+    umf::poolMakeCOps<usm::DisjointPool, umf_disjoint_pool_params>();

--- a/src/pool/disjoint/pool_disjoint_impl.cpp
+++ b/src/pool/disjoint/pool_disjoint_impl.cpp
@@ -275,7 +275,7 @@ class DisjointPool::AllocImpl {
     std::vector<std::unique_ptr<Bucket>> Buckets;
 
     // Configuration for this instance
-    DisjointPool::Config params;
+    umf_disjoint_pool_params params;
 
     umf_disjoint_pool_shared_limits DefaultSharedLimits = {
         (std::numeric_limits<size_t>::max)(), 0};
@@ -285,12 +285,12 @@ class DisjointPool::AllocImpl {
 
   public:
     AllocImpl(umf_memory_provider_handle_t hProvider,
-              DisjointPool::Config params)
-        : MemHandle{hProvider}, params(params) {
+              umf_disjoint_pool_params *params)
+        : MemHandle{hProvider}, params(*params) {
 
         // Generate buckets sized such as: 64, 96, 128, 192, ..., CutOff.
         // Powers of 2 and the value halfway between the powers of 2.
-        auto Size1 = params.MinBucketSize;
+        auto Size1 = this->params.MinBucketSize;
         // Buckets sized smaller than the bucket default size- 8 aren't needed.
         Size1 = std::max(Size1, UMF_DISJOINT_POOL_MIN_BUCKET_DEFAULT_SIZE);
         auto Size2 = Size1 + Size1 / 2;
@@ -322,7 +322,7 @@ class DisjointPool::AllocImpl {
 
     size_t SlabMinSize() { return params.SlabMinSize; };
 
-    DisjointPool::Config &getParams() { return params; }
+    umf_disjoint_pool_params &getParams() { return params; }
 
     struct umf_disjoint_pool_shared_limits *getLimits() {
         if (params.SharedLimits) {
@@ -896,14 +896,14 @@ void DisjointPool::AllocImpl::printStats(bool &TitlePrinted,
 }
 
 umf_result_t DisjointPool::initialize(umf_memory_provider_handle_t provider,
-                                      DisjointPool::Config parameters) {
+                                      umf_disjoint_pool_params *parameters) {
     if (!provider) {
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
     // MinBucketSize parameter must be a power of 2 for bucket sizes
     // to generate correctly.
-    if (!parameters.MinBucketSize ||
-        !((parameters.MinBucketSize & (parameters.MinBucketSize - 1)) == 0)) {
+    if (!parameters->MinBucketSize ||
+        !((parameters->MinBucketSize & (parameters->MinBucketSize - 1)) == 0)) {
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
 

--- a/src/pool/disjoint/pool_disjoint_impl.hpp
+++ b/src/pool/disjoint/pool_disjoint_impl.hpp
@@ -25,7 +25,7 @@ class DisjointPool {
     using Config = umf_disjoint_pool_params;
 
     umf_result_t initialize(umf_memory_provider_handle_t provider,
-                            Config parameters);
+                            umf_disjoint_pool_params *parameters);
     void *malloc(size_t size);
     void *calloc(size_t, size_t);
     void *realloc(void *, size_t);


### PR DESCRIPTION
Relies on: https://github.com/oneapi-src/unified-memory-framework/pull/29