### PR TITLE
Fix critnib on windows

### DIFF
--- a/src/critnib/critnib.c
+++ b/src/critnib/critnib.c
@@ -81,7 +81,7 @@
 #define DELETED_LIFE 16
 
 #define SLICE 4
-#define NIB ((1UL << SLICE) - 1)
+#define NIB ((1ULL << SLICE) - 1)
 #define SLNODES (1 << SLICE)
 
 typedef uintptr_t word;
@@ -156,7 +156,7 @@ static inline bool is_leaf(struct critnib_node *n) { return (word)n & 1; }
  * internal: to_leaf -- untag a leaf pointer
  */
 static inline struct critnib_leaf *to_leaf(struct critnib_node *n) {
-    return (void *)((word)n & ~1UL);
+    return (void *)((word)n & ~1ULL);
 }
 
 /*

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -42,7 +42,7 @@ static __inline unsigned char util_mssb_index(long long value) {
 // There is no good way to do atomic_load on windows...
 #define util_atomic_load_acquire(object, dest)                                 \
     do {                                                                       \
-        *dest = InterlockedOr64Acquire((LONG64 volatile *)dest, 0);            \
+        *dest = InterlockedOr64Acquire((LONG64 volatile *)object, 0);          \
     } while (0)
 
 #define util_atomic_store_release(object, desired)                             \


### PR DESCRIPTION
I have no idea how it worked on windows (or did it?) in UR.

Here's a branch rebased on top of Rafal's branch with windows CI where all the tests are passing: https://github.com/igchor/unified-memory-framework/tree/fix_windows_ci