### PR TITLE
[COARSE] Fix error unknown type name 'bool'

### DIFF
--- a/include/umf/providers/provider_coarse.h
+++ b/include/umf/providers/provider_coarse.h
@@ -5,6 +5,7 @@
 #ifndef UMF_COARSE_PROVIDER_H
 #define UMF_COARSE_PROVIDER_H
 
+#include <stdbool.h>
 #include <umf/memory_provider.h>
 
 #if defined(__cplusplus)


### PR DESCRIPTION
Fix error: unknown type name ‘bool’:
```
include/umf/providers/provider_coarse.h:17:5:
 error: unknown type name ‘bool’
   17 |     bool immediate_init; // pre-allocate soft limit
      |     ^~~~
include/umf/providers/provider_coarse.h:18:5:
 error: unknown type name ‘bool’
   18 |     bool trace;
      |     ^~~~

```
