### PR TITLE
Add malloc compliance tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,9 +55,9 @@ endfunction()
 add_subdirectory(common)
 
 add_umf_test(NAME base SRCS base.cpp)
-add_umf_test(NAME memoryPool SRCS memoryPoolAPI.cpp)
+add_umf_test(NAME memoryPool SRCS memoryPoolAPI.cpp malloc_compliance_tests.cpp)
 add_umf_test(NAME memoryProvider SRCS memoryProviderAPI.cpp)
-add_umf_test(NAME disjointPool SRCS disjoint_pool.cpp)
+add_umf_test(NAME disjointPool SRCS disjoint_pool.cpp malloc_compliance_tests.cpp)
 add_umf_test(NAME c_api_disjoint_pool SRCS c_api/disjoint_pool.c)
 
 if(LINUX) # OS-specific functions are implemented only for Linux now

--- a/test/common/test_helpers.c
+++ b/test/common/test_helpers.c
@@ -4,6 +4,9 @@
 // This file contains tests for UMF pool API
 
 #include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "pool_null.h"
 #include "pool_trace.h"
@@ -11,6 +14,23 @@
 #include "provider_trace.h"
 #include "umf/memory_pool.h"
 #include "umf/memory_provider.h"
+
+#include "test_helpers.h"
+
+// Check if the memory is filled with the given character
+int is_filled_with_char(void *ptr, size_t size, char c) {
+    char *mem = (char *)ptr;
+    return (*mem == c) && memcmp(mem, mem + 1, size - 1) == 0;
+}
+
+// Check if two memory regions has the same content
+int is_same_content(void *first, void *second, size_t size) {
+    return memcmp(first, second, size) == 0;
+}
+
+int is_aligned(void *ptr, size_t alignment) {
+    return ((uintptr_t)ptr & (alignment - 1)) == 0;
+}
 
 umf_memory_provider_handle_t nullProviderCreate(void) {
     umf_memory_provider_handle_t hProvider;

--- a/test/common/test_helpers.h
+++ b/test/common/test_helpers.h
@@ -14,6 +14,12 @@
 extern "C" {
 #endif
 
+int is_filled_with_char(void *ptr, size_t size, char c);
+
+int is_same_content(void *first, void *second, size_t size);
+
+int is_aligned(void *ptr, size_t alignment);
+
 umf_memory_provider_handle_t nullProviderCreate(void);
 umf_memory_provider_handle_t
 traceProviderCreate(umf_memory_provider_handle_t hUpstreamProvider,

--- a/test/disjoint_pool.cpp
+++ b/test/disjoint_pool.cpp
@@ -155,7 +155,6 @@ INSTANTIATE_TEST_SUITE_P(
                             (void *)&defaultPoolConfig.Capacity},
         static_cast<int>(defaultPoolConfig.Capacity) / 2)));
 
-GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(umfMultiPoolTest);
 INSTANTIATE_TEST_SUITE_P(disjointMultiPoolTests, umfMultiPoolTest,
                          ::testing::Values(poolCreateExtParams{
                              &UMF_DISJOINT_POOL_OPS, (void *)&defaultPoolConfig,

--- a/test/malloc_compliance_tests.cpp
+++ b/test/malloc_compliance_tests.cpp
@@ -1,0 +1,151 @@
+// Copyright (C) 2023 Intel Corporation
+// Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Basic tests
+// ISO/IEC 9899:201x 7.22.3 compliance
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "malloc_compliance_tests.hpp"
+#include "test_helpers.h"
+#include "umf/memory_pool.h"
+
+#include "base.hpp"
+using umf_test::test;
+
+//------------------------------------------------------------------------
+// Configurable defs
+//------------------------------------------------------------------------
+
+#define MAX_ALLOC_SIZE (1024 * 1024) // 1 MB
+#define ITERATIONS 100
+#define SRAND_INIT_VALUE 0
+
+//------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------
+
+static inline size_t rand_alloc_size(int max) {
+    srand(SRAND_INIT_VALUE);
+    return rand() % max;
+}
+
+static inline void free_memory(umf_memory_pool_handle_t hPool,
+                               void *ptr[ITERATIONS]) {
+    for (int i = 0; i < ITERATIONS; i++) {
+        umfPoolFree(hPool, ptr[i]);
+    }
+}
+
+//------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------
+
+// ISO/IEC 9899:TC3 7.20.3.3
+void malloc_compliance_test(umf_memory_pool_handle_t hPool) {
+    void *alloc_ptr[ITERATIONS];
+    size_t alloc_ptr_size[ITERATIONS];
+
+    // Each allocation shall yield a pointer to an object disjoint from
+    // any other object.
+    for (int i = 0; i < ITERATIONS; i++) {
+        alloc_ptr_size[i] = rand_alloc_size(MAX_ALLOC_SIZE);
+        alloc_ptr[i] = umfPoolMalloc(hPool, alloc_ptr_size[i]);
+
+#ifndef _WIN32 // TODO: explain why it fails on some Windows systems
+        // Supported under USE_WEAK_ALIGNMENT_RULES macro
+        // For compatibility, on 64-bit systems malloc should align to 16 bytes
+        size_t alignment =
+            (sizeof(intptr_t) > 4 && alloc_ptr_size[i] > 8) ? 16 : 8;
+        ASSERT_NE(is_aligned(alloc_ptr[i], alignment), 0)
+            << "Malloc should return pointer that is suitably aligned so that "
+               "it may be assigned to a pointer to any type of object";
+#endif
+
+        // Fill memory with a pattern ((id of the allocation) % 256)
+        ASSERT_NE(alloc_ptr[i], nullptr)
+            << "malloc returned NULL, couldn't allocate much memory";
+        memset(alloc_ptr[i], i % 0xFF, alloc_ptr_size[i]);
+    }
+    for (int i = 0; i < ITERATIONS; i++) {
+        ASSERT_NE(
+            is_filled_with_char(alloc_ptr[i], alloc_ptr_size[i], i % 0xFF), 0)
+            << "Object returned by malloc is not disjoined from others";
+        memset(alloc_ptr[i], 1, alloc_ptr_size[i]);
+    }
+    free_memory(hPool, alloc_ptr);
+}
+
+// ISO/IEC 9899:TC3 7.20.3.1
+void calloc_compliance_test(umf_memory_pool_handle_t hPool) {
+    void *alloc_ptr[ITERATIONS];
+    size_t alloc_size;
+
+    // Checking that the memory returned by calloc is zero filled
+    for (int i = 0; i < ITERATIONS; i++) {
+        alloc_size = rand_alloc_size(MAX_ALLOC_SIZE);
+        alloc_ptr[i] = umfPoolCalloc(hPool, i + 1, alloc_size);
+
+        ASSERT_NE(alloc_ptr[i], nullptr)
+            << "calloc returned NULL, couldn't allocate much memory";
+        ASSERT_NE(is_filled_with_char(alloc_ptr[i], alloc_size, 0), 0)
+            << "Memory returned by calloc was not zeroed";
+    }
+    free_memory(hPool, alloc_ptr);
+}
+
+// ISO/IEC 9899:TC3 7.20.3.4
+void realloc_compliance_test(umf_memory_pool_handle_t hPool) {
+    // If ptr is a null pointer, the realloc function behaves
+    // like the malloc function for the specified size
+    void *ret = umfPoolRealloc(hPool, NULL, 10);
+    ASSERT_NE(ret, nullptr)
+        << "If ptr is a NULL, realloc should behave like malloc";
+    // SIGSEGV if memory was allocated wrong
+    memset(ret, 1, 10);
+    umfPoolFree(hPool, ret);
+
+    // The contents of the new object shall be the same
+    // as that of the old object prior to deallocation
+    void *realloc_ptr[ITERATIONS];
+    size_t alloc_size;
+    for (int i = 0; i < ITERATIONS; i++) {
+        // Generate allocation size
+        alloc_size = rand_alloc_size(MAX_ALLOC_SIZE);
+        void *malloc_obj = umfPoolMalloc(hPool, alloc_size);
+        ASSERT_NE(malloc_obj, nullptr)
+            << "malloc returned NULL, couldn't allocate much memory";
+
+        // Fit memory region with data and store
+        // it's content somehere before realloc
+        void *saved_obj = umfPoolMalloc(hPool, alloc_size);
+        ASSERT_NE(saved_obj, nullptr)
+            << "malloc returned NULL, couldn't allocate much memory";
+        memset(malloc_obj, 1, alloc_size);
+        memcpy(saved_obj, malloc_obj, alloc_size);
+
+        // Reallocate with 100 byte size increasing
+        realloc_ptr[i] = umfPoolRealloc(hPool, malloc_obj, alloc_size + 100);
+        ASSERT_NE(is_same_content(realloc_ptr[i], saved_obj, alloc_size), 0)
+            << "Content after realloc should remain the same";
+
+        // Delete saved memory
+        umfPoolFree(hPool, saved_obj);
+    }
+    free_memory(hPool, realloc_ptr);
+}
+
+// ISO/IEC 9899:TC3 7.20.3.2
+void free_compliance_test(umf_memory_pool_handle_t hPool) {
+    // If ptr is a null pointer, no action occurs
+    errno = 0;
+    for (int i = 0; i < ITERATIONS; i++) {
+        umfPoolFree(hPool, NULL);
+    }
+    ASSERT_EQ(errno, 0) << "Error was found by a free call with NULL parameter";
+}

--- a/test/malloc_compliance_tests.hpp
+++ b/test/malloc_compliance_tests.hpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2023 Intel Corporation
+// Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef UMF_TEST_MALLOC_COMPLIANCE_TESTS_H
+#define UMF_TEST_MALLOC_COMPLIANCE_TESTS_H
+
+#include "umf/memory_pool.h"
+
+void malloc_compliance_test(umf_memory_pool_handle_t hPool);
+void calloc_compliance_test(umf_memory_pool_handle_t hPool);
+void realloc_compliance_test(umf_memory_pool_handle_t hPool);
+void free_compliance_test(umf_memory_pool_handle_t hPool);
+
+#endif /* UMF_TEST_MALLOC_COMPLIANCE_TESTS_H */

--- a/test/memoryPool.hpp
+++ b/test/memoryPool.hpp
@@ -2,6 +2,9 @@
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#ifndef UMF_TEST_MEMORY_POOL_OPS_HPP
+#define UMF_TEST_MEMORY_POOL_OPS_HPP
+
 #include "pool.hpp"
 #include "provider.hpp"
 
@@ -12,8 +15,7 @@
 #include <string>
 #include <thread>
 
-#ifndef UMF_TEST_MEMORY_POOL_OPS_HPP
-#define UMF_TEST_MEMORY_POOL_OPS_HPP
+#include "malloc_compliance_tests.hpp"
 
 using poolCreateExtParams = std::tuple<umf_memory_pool_ops_t *, void *,
                                        umf_memory_provider_ops_t *, void *>;
@@ -90,6 +92,8 @@ struct umfMemTest
 };
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(umfMemTest);
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(umfPoolTest);
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(umfMultiPoolTest);
 
 TEST_P(umfPoolTest, allocFree) {
     static constexpr size_t allocSize = 64;
@@ -376,5 +380,27 @@ TEST_P(umfMultiPoolTest, memoryTracking) {
     }
 }
 #endif /* UMF_ENABLE_POOL_TRACKING_TESTS */
+
+/* malloc compliance tests */
+
+TEST_P(umfPoolTest, malloc_compliance) { malloc_compliance_test(pool.get()); }
+
+TEST_P(umfPoolTest, calloc_compliance) {
+    if (!umf_test::isCallocSupported(pool.get())) {
+        GTEST_SKIP();
+    }
+
+    calloc_compliance_test(pool.get());
+}
+
+TEST_P(umfPoolTest, realloc_compliance) {
+    if (!umf_test::isReallocSupported(pool.get())) {
+        GTEST_SKIP();
+    }
+
+    realloc_compliance_test(pool.get());
+}
+
+TEST_P(umfPoolTest, free_compliance) { free_compliance_test(pool.get()); }
 
 #endif /* UMF_TEST_MEMORY_POOL_OPS_HPP */

--- a/test/memoryPoolAPI.cpp
+++ b/test/memoryPoolAPI.cpp
@@ -127,7 +127,6 @@ INSTANTIATE_TEST_SUITE_P(
                       poolCreateExtParams{&PROXY_POOL_OPS, nullptr,
                                           &MALLOC_PROVIDER_OPS, nullptr}));
 
-GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(umfMultiPoolTest);
 INSTANTIATE_TEST_SUITE_P(mallocMultiPoolTest, umfMultiPoolTest,
                          ::testing::Values(poolCreateExtParams{
                              &PROXY_POOL_OPS, nullptr, &MALLOC_PROVIDER_OPS,


### PR DESCRIPTION
They will be useful to test pool managers.

See https://github.com/oneapi-src/unified-memory-framework/pull/65 for an example.