### PR TITLE
Add arguments NAME, SRCS and LIBS to add_umf_test()

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,29 +18,35 @@ enable_testing()
 
 set(UMF_TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-if(LINUX)
-    set(LIBS_OS_SPECIFIC numa)
-else()
-    set(LIBS_OS_SPECIFIC "")
-endif()
+function(add_umf_test)
+    # NAME - a name of the test
+    # SRCS - source files
+    # LIBS - libraries to be linked with
+    set(oneValueArgs NAME)
+    set(multiValueArgs SRCS LIBS)
+    cmake_parse_arguments(ARG "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-function(add_umf_test name)
-    set(TEST_TARGET_NAME umf_test-${name})
-    add_umf_executable(${TEST_TARGET_NAME}
-        ${ARGN})
-    target_link_libraries(${TEST_TARGET_NAME}
-        PRIVATE
+    set(TEST_NAME umf-${ARG_NAME})
+    set(TEST_TARGET_NAME umf_test-${ARG_NAME})
+
+    add_umf_executable(${TEST_TARGET_NAME} ${ARG_SRCS})
+
+    target_link_libraries(${TEST_TARGET_NAME} PRIVATE
         test_common
         ${PROJECT_NAME}::unified_memory_framework
         GTest::gtest_main
-        ${LIBS_OS_SPECIFIC})
+        ${ARG_LIBS})
+
     target_include_directories(${TEST_TARGET_NAME} PRIVATE
         ${UMF_TEST_DIR}/common
         ${CMAKE_SOURCE_DIR}/src/pool/disjoint)
-    add_test(NAME  umf-${name}
+
+    add_test(NAME ${TEST_NAME}
         COMMAND ${TEST_TARGET_NAME}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-    set_tests_properties(umf-${name} PROPERTIES LABELS "umf")
+
+    set_tests_properties(${TEST_NAME} PROPERTIES LABELS "umf")
+
     if (UMF_ENABLE_POOL_TRACKING)
         target_compile_definitions(${TEST_TARGET_NAME} PRIVATE UMF_ENABLE_POOL_TRACKING_TESTS=1)
     endif()
@@ -48,13 +54,12 @@ endfunction()
 
 add_subdirectory(common)
 
-add_umf_test(c_api_disjoint_pool c_api/disjoint_pool.c)
-
-add_umf_test(base base.cpp)
-add_umf_test(memoryPool memoryPoolAPI.cpp)
-add_umf_test(memoryProvider memoryProviderAPI.cpp)
-add_umf_test(disjointPool disjoint_pool.cpp)
+add_umf_test(NAME base SRCS base.cpp)
+add_umf_test(NAME memoryPool SRCS memoryPoolAPI.cpp)
+add_umf_test(NAME memoryProvider SRCS memoryProviderAPI.cpp)
+add_umf_test(NAME disjointPool SRCS disjoint_pool.cpp)
+add_umf_test(NAME c_api_disjoint_pool SRCS c_api/disjoint_pool.c)
 
 if(LINUX) # OS-specific functions are implemented only for Linux now
-    add_umf_test(provider_os_memory provider_os_memory.cpp)
+    add_umf_test(NAME provider_os_memory SRCS provider_os_memory.cpp LIBS numa)
 endif()


### PR DESCRIPTION
Add arguments NAME, SRCS and LIBS to add_umf_test():
- NAME - a name of the test
- SRCS - source files
- LIBS - libraries to be linked with.