### PR TITLE
Simplify test fixtures

### DIFF
--- a/test/common/provider.hpp
+++ b/test/common/provider.hpp
@@ -20,6 +20,14 @@
 
 namespace umf_test {
 
+umf_memory_provider_handle_t
+createProviderChecked(umf_memory_provider_ops_t *ops, void *params) {
+    umf_memory_provider_handle_t hProvider;
+    auto ret = umfMemoryProviderCreate(ops, params, &hProvider);
+    EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
+    return hProvider;
+}
+
 auto wrapProviderUnique(umf_memory_provider_handle_t hProvider) {
     return umf::provider_unique_handle_t(hProvider, &umfMemoryProviderDestroy);
 }
@@ -80,11 +88,14 @@ struct provider_malloc : public provider_base_t {
     const char *get_name() noexcept { return "malloc"; }
 };
 
+umf_memory_provider_ops_t MALLOC_PROVIDER_OPS =
+    umf::providerMakeCOps<provider_malloc, void>();
+
 struct provider_mock_out_of_mem : public provider_base_t {
     provider_malloc helper_prov;
     int allocNum = 0;
-    umf_result_t initialize(int allocNum) noexcept {
-        this->allocNum = allocNum;
+    umf_result_t initialize(int *allocNum) noexcept {
+        this->allocNum = *allocNum;
         return UMF_RESULT_SUCCESS;
     }
     umf_result_t alloc(size_t size, size_t align, void **ptr) noexcept {
@@ -101,6 +112,9 @@ struct provider_mock_out_of_mem : public provider_base_t {
     }
     const char *get_name() noexcept { return "mock_out_of_mem"; }
 };
+
+umf_memory_provider_ops_t MOCK_OUT_OF_MEM_PROVIDER_OPS =
+    umf::providerMakeCOps<provider_mock_out_of_mem, int>();
 
 } // namespace umf_test
 

--- a/test/memoryProviderAPI.cpp
+++ b/test/memoryProviderAPI.cpp
@@ -80,11 +80,15 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(providerInitializeTest, errorPropagation) {
     struct provider : public umf_test::provider_base_t {
-        umf_result_t initialize(umf_result_t errorToReturn) noexcept {
-            return errorToReturn;
+        umf_result_t initialize(umf_result_t *errorToReturn) noexcept {
+            return *errorToReturn;
         }
     };
-    auto ret = umf::memoryProviderMakeUnique<provider>(this->GetParam());
-    ASSERT_EQ(ret.first, this->GetParam());
-    ASSERT_EQ(ret.second, nullptr);
+    umf_memory_provider_ops_t provider_ops =
+        umf::providerMakeCOps<provider, umf_result_t>();
+
+    umf_memory_provider_handle_t hProvider;
+    auto ret = umfMemoryProviderCreate(&provider_ops, (void *)&this->GetParam(),
+                                       &hProvider);
+    ASSERT_EQ(ret, this->GetParam());
 }


### PR DESCRIPTION
Expose ops for all pools/providers implemented in tests and change fixtures to accepts ops and params, instead of factory functions.

Also, remove no longer needed pool/providerMakeUnique functions from umf_helpers.hpp.