### PR TITLE
Fix os_alloc() of OS memory provider to return aligned address

### DIFF
--- a/src/provider/provider_os_memory.c
+++ b/src/provider/provider_os_memory.c
@@ -262,7 +262,8 @@ static umf_result_t os_alloc(void *provider, size_t size, size_t alignment,
 
     void *addr = NULL;
     errno = 0;
-    ret = os_mmap(NULL, size, protection, flags, -1, 0, &addr);
+    ret =
+        os_mmap_aligned(NULL, size, alignment, protection, flags, -1, 0, &addr);
     if (ret) {
         os_store_last_native_error(UMF_OS_RESULT_ERROR_ALLOC_FAILED, errno);
         if (os_config->traces) {
@@ -271,6 +272,7 @@ static umf_result_t os_alloc(void *provider, size_t size, size_t alignment,
         return UMF_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC;
     }
 
+    // sanity check - the address should be aligned here
     if ((alignment > 0) && ((uintptr_t)addr & (alignment - 1))) {
         if (os_config->traces) {
             os_store_last_native_error(UMF_OS_RESULT_ERROR_ADDRESS_NOT_ALIGNED,

--- a/src/provider/provider_os_memory_internal.h
+++ b/src/provider/provider_os_memory_internal.h
@@ -32,8 +32,8 @@ long os_mbind(void *addr, size_t len, int mode, const unsigned long *nodemask,
 long os_get_mempolicy(int *mode, unsigned long *nodemask, unsigned long maxnode,
                       void *addr);
 
-int os_mmap(void *addr, size_t length, int prot, int flags, int fd, long offset,
-            void **out_addr);
+int os_mmap_aligned(void *hint_addr, size_t length, size_t alignment, int prot,
+                    int flags, int fd, long offset, void **out_addr);
 
 int os_munmap(void *addr, size_t length);
 

--- a/test/provider_os_memory.cpp
+++ b/test/provider_os_memory.cpp
@@ -91,7 +91,7 @@ TEST_F(test, provider_os_memory_create_MBIND_FAILED) {
     ASSERT_EQ(os_memory_provider, nullptr);
 }
 
-TEST_F(test, provider_os_memory_alloc_free) {
+TEST_F(test, provider_os_memory_alloc_free_4k_alignment_0) {
     umf_result_t umf_result;
     umf_memory_provider_handle_t os_memory_provider = nullptr;
     umf_os_memory_provider_params_t os_memory_provider_params =
@@ -106,6 +106,62 @@ TEST_F(test, provider_os_memory_alloc_free) {
     void *ptr = nullptr;
     size_t size = SIZE_4K;
     size_t alignment = 0;
+    umf_result =
+        umfMemoryProviderAlloc(os_memory_provider, size, alignment, &ptr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(ptr, nullptr);
+
+    memset(ptr, 0xFF, size);
+
+    umf_result = umfMemoryProviderFree(os_memory_provider, ptr, size);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umfMemoryProviderDestroy(os_memory_provider);
+}
+
+TEST_F(test, provider_os_memory_alloc_free_2k_alignment_2k) {
+    umf_result_t umf_result;
+    umf_memory_provider_handle_t os_memory_provider = nullptr;
+    umf_os_memory_provider_params_t os_memory_provider_params =
+        UMF_OS_MEMORY_PROVIDER_PARAMS_TEST;
+
+    umf_result = umfMemoryProviderCreate(&UMF_OS_MEMORY_PROVIDER_OPS,
+                                         &os_memory_provider_params,
+                                         &os_memory_provider);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(os_memory_provider, nullptr);
+
+    void *ptr = nullptr;
+    size_t size = SIZE_4K / 2;
+    size_t alignment = SIZE_4K / 2;
+    umf_result =
+        umfMemoryProviderAlloc(os_memory_provider, size, alignment, &ptr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(ptr, nullptr);
+
+    memset(ptr, 0xFF, size);
+
+    umf_result = umfMemoryProviderFree(os_memory_provider, ptr, size);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umfMemoryProviderDestroy(os_memory_provider);
+}
+
+TEST_F(test, provider_os_memory_alloc_free_8k_alignment_8k) {
+    umf_result_t umf_result;
+    umf_memory_provider_handle_t os_memory_provider = nullptr;
+    umf_os_memory_provider_params_t os_memory_provider_params =
+        UMF_OS_MEMORY_PROVIDER_PARAMS_TEST;
+
+    umf_result = umfMemoryProviderCreate(&UMF_OS_MEMORY_PROVIDER_OPS,
+                                         &os_memory_provider_params,
+                                         &os_memory_provider);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(os_memory_provider, nullptr);
+
+    void *ptr = nullptr;
+    size_t size = 2 * SIZE_4K;
+    size_t alignment = 2 * SIZE_4K;
     umf_result =
         umfMemoryProviderAlloc(os_memory_provider, size, alignment, &ptr);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
@@ -172,35 +228,6 @@ TEST_F(test, provider_os_memory_alloc_MMAP_FAILED) {
     int32_t error;
     umfMemoryProviderGetLastNativeError(os_memory_provider, &message, &error);
     ASSERT_EQ(error, UMF_OS_RESULT_ERROR_ALLOC_FAILED);
-    ASSERT_EQ(compare_native_error_str(message, error), 0);
-
-    umfMemoryProviderDestroy(os_memory_provider);
-}
-
-TEST_F(test, provider_os_memory_alloc_MMAP_ADDR_NOT_ALIGNED) {
-    umf_result_t umf_result;
-    umf_memory_provider_handle_t os_memory_provider = nullptr;
-    umf_os_memory_provider_params_t os_memory_provider_params =
-        UMF_OS_MEMORY_PROVIDER_PARAMS_TEST;
-
-    umf_result = umfMemoryProviderCreate(&UMF_OS_MEMORY_PROVIDER_OPS,
-                                         &os_memory_provider_params,
-                                         &os_memory_provider);
-    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
-    ASSERT_NE(os_memory_provider, nullptr);
-
-    void *ptr = nullptr;
-    size_t size = SIZE_4K;
-    size_t alignment = 1 << 30; // wrong alignment
-    umf_result =
-        umfMemoryProviderAlloc(os_memory_provider, size, alignment, &ptr);
-    ASSERT_EQ(umf_result, UMF_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC);
-    ASSERT_EQ(ptr, nullptr);
-
-    const char *message;
-    int32_t error;
-    umfMemoryProviderGetLastNativeError(os_memory_provider, &message, &error);
-    ASSERT_EQ(error, UMF_OS_RESULT_ERROR_ADDRESS_NOT_ALIGNED);
     ASSERT_EQ(compare_native_error_str(message, error), 0);
 
     umfMemoryProviderDestroy(os_memory_provider);


### PR DESCRIPTION
Fix `os_alloc()` of OS memory provider. Make it return aligned address. Replace `os_mmap()` with `os_mmap_aligned()` that returns aligned address.