### PR TITLE
Fixes required to use UMF as an external project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,9 @@ else()
     message(FATAL_ERROR "Unknown OS type")
 endif()
 
+# needed when UMF is used as an external project
+set(UMF_CMAKE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_UMF_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 add_executable(ubench ubench.c)
 add_dependencies(ubench unified_memory_framework)
-target_include_directories(ubench PRIVATE ../include/)
+target_include_directories(ubench PRIVATE ${UMF_CMAKE_SOURCE_DIR}/include/)
 target_link_libraries(ubench
 	unified_memory_framework
 	numa

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -82,8 +82,8 @@ endfunction()
 function(add_umf_library name)
     add_library(${name} ${ARGN})
     target_include_directories(${name} PRIVATE
-        ${CMAKE_SOURCE_DIR}/include
-        ${CMAKE_SOURCE_DIR}/src/common)
+        ${UMF_CMAKE_SOURCE_DIR}/include
+        ${UMF_CMAKE_SOURCE_DIR}/src/common)
     add_umf_target_compile_options(${name})
     add_umf_target_link_options(${name})
 endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-include(../cmake/helpers.cmake)
+include(${UMF_CMAKE_SOURCE_DIR}/cmake/helpers.cmake)
 
 set(UMF_SOURCES
     memory_pool.c
@@ -54,7 +54,12 @@ endif()
 
 add_library(${PROJECT_NAME}::unified_memory_framework ALIAS unified_memory_framework)
 
-target_include_directories(unified_memory_framework PUBLIC ../include ./common ./provider ./critnib)
+target_include_directories(unified_memory_framework PUBLIC
+    ${UMF_CMAKE_SOURCE_DIR}/include
+    ./common
+    ./critnib
+    ./provider
+    ./utils)
 
 # libumf_pool_jemalloc
 if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)

--- a/src/critnib/critnib.c
+++ b/src/critnib/critnib.c
@@ -57,8 +57,8 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#include "../utils/utils_concurrency.h"
 #include "critnib.h"
+#include "utils_concurrency.h"
 
 /*
  * A node that has been deleted is left untouched for this many delete

--- a/src/pool/pool_disjoint.cpp
+++ b/src/pool/pool_disjoint.cpp
@@ -22,10 +22,10 @@
 // TODO: replace with logger?
 #include <iostream>
 
-#include "../utils/utils_math.h"
 #include "umf.h"
 #include "umf/pools/pool_disjoint.h"
 #include "umf_helpers.hpp"
+#include "utils_math.h"
 
 typedef struct umf_disjoint_pool_shared_limits_t {
     size_t MaxSize;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,7 +39,8 @@ function(add_umf_test)
 
     target_include_directories(${TEST_TARGET_NAME} PRIVATE
         ${UMF_TEST_DIR}/common
-        ${CMAKE_SOURCE_DIR}/src/pool/disjoint)
+        ${UMF_CMAKE_SOURCE_DIR}/src
+        ${UMF_CMAKE_SOURCE_DIR}/src/pool/disjoint)
 
     add_test(NAME ${TEST_NAME}
         COMMAND ${TEST_TARGET_NAME}

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -12,4 +12,4 @@ set(COMMON_SOURCES
 
 add_umf_library(test_common STATIC ${COMMON_SOURCES})
 
-target_include_directories(test_common PRIVATE ../../include)
+target_include_directories(test_common PRIVATE ${UMF_CMAKE_SOURCE_DIR}/include)

--- a/test/memory_pool_internal.cpp
+++ b/test/memory_pool_internal.cpp
@@ -2,7 +2,7 @@
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "../src/memory_pool_internal.h"
+#include "memory_pool_internal.h"
 #include "base.hpp"
 #include "common/provider_null.h"
 #include "pool.hpp"


### PR DESCRIPTION
Fixes required to use UMF as an external project (with `FetchContent`):
- add `UMF_CMAKE_SOURCE_DIR`
- add include directories