### PR TITLE
Cleanup install dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ target_include_directories(umf_headers INTERFACE
 # Add the include directory and the headers target to the install.
 install(
     DIRECTORY "${PROJECT_SOURCE_DIR}/include/"
-    DESTINATION include COMPONENT umf_headers)
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 install(
     TARGETS umf_headers
@@ -136,6 +136,10 @@ if(UMF_FORMAT_CODE_STYLE)
         COMMENT "Format files using clang-format")        
 endif()
 
+# Add license to the installation path
+install(FILES ${CMAKE_SOURCE_DIR}/LICENSE.TXT
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME}/")
+
 # Add the list of installed targets to the install. This includes the namespace
 # which all installed targets will be prefixed with, e.g. for the headers
 # target users will depend on ${PROJECT_NAME}::headers.
@@ -143,7 +147,7 @@ install(
     EXPORT ${PROJECT_NAME}-targets
     FILE ${PROJECT_NAME}-targets.cmake
     NAMESPACE ${PROJECT_NAME}::
-    DESTINATION lib/cmake/${PROJECT_NAME})
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 
 # Configure the package versions file for use in find_package when installed.
 write_basic_package_version_file(
@@ -155,11 +159,11 @@ write_basic_package_version_file(
 configure_package_config_file(
     ${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}-config.cmake.in
     ${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}-config.cmake
-    INSTALL_DESTINATION lib/cmake/${PROJECT_NAME})
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 
 # Add the package files to the install.
 install(
     FILES
         ${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}-config.cmake
         ${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}-config-version.cmake
-    DESTINATION lib/cmake/${PROJECT_NAME})
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -8,11 +8,11 @@ endif()
 
 add_executable(ubench ubench.c)
 add_dependencies(ubench
-	unified_memory_framework
+	umf
 	disjoint_pool)
 target_include_directories(ubench PRIVATE ${UMF_CMAKE_SOURCE_DIR}/include/)
 target_link_libraries(ubench
-	unified_memory_framework
+	umf
 	disjoint_pool
 	pthread
 	m)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,21 +45,27 @@ elseif(MACOSX)
 endif()
 
 if(UMF_BUILD_SHARED_LIBRARY)
-    add_umf_library(NAME unified_memory_framework TYPE SHARED SRCS ${UMF_SOURCES} LIBS ${UMF_LIBS})
-    target_compile_definitions(unified_memory_framework PUBLIC UMF_SHARED_LIBRARY)
+    add_umf_library(NAME umf
+                    TYPE SHARED
+                    SRCS ${UMF_SOURCES}
+                    LIBS ${UMF_LIBS})
+    target_compile_definitions(umf PUBLIC UMF_SHARED_LIBRARY)
 else()
-    add_umf_library(NAME unified_memory_framework TYPE STATIC SRCS ${UMF_SOURCES} LIBS ${UMF_LIBS})
+    add_umf_library(NAME umf
+                    TYPE STATIC 
+                    SRCS ${UMF_SOURCES} 
+                    LIBS ${UMF_LIBS})
 endif()
 
 if (UMF_ENABLE_POOL_TRACKING)
-    target_sources(unified_memory_framework PRIVATE memory_pool_tracking.c)
+    target_sources(umf PRIVATE memory_pool_tracking.c)
 else()
-    target_sources(unified_memory_framework PRIVATE memory_pool_default.c)
+    target_sources(umf PRIVATE memory_pool_default.c)
 endif()
 
-add_library(${PROJECT_NAME}::unified_memory_framework ALIAS unified_memory_framework)
+add_library(${PROJECT_NAME}::umf ALIAS umf)
 
-target_include_directories(unified_memory_framework PUBLIC 
+target_include_directories(umf PUBLIC 
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/common>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/critnib>
@@ -68,11 +74,8 @@ target_include_directories(unified_memory_framework PUBLIC
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-install(TARGETS unified_memory_framework
+install(TARGETS umf
     EXPORT ${PROJECT_NAME}-targets
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
 add_subdirectory(pool)

--- a/src/pool/CMakeLists.txt
+++ b/src/pool/CMakeLists.txt
@@ -11,10 +11,10 @@ if(UMF_BUILD_LIBUMF_POOL_DISJOINT)
     add_library(${PROJECT_NAME}::disjoint_pool ALIAS disjoint_pool)
 
     add_dependencies(disjoint_pool
-        unified_memory_framework)
+        umf)
 
     target_link_libraries(disjoint_pool PRIVATE
-        unified_memory_framework)
+        umf)
 
     target_include_directories(disjoint_pool PUBLIC
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/umf/pools>
@@ -23,14 +23,20 @@ if(UMF_BUILD_LIBUMF_POOL_DISJOINT)
 
     install(TARGETS disjoint_pool
         EXPORT ${PROJECT_NAME}-targets
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
 endif()
-    
+
 # libumf_pool_jemalloc
 if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
     if(LINUX)
-        add_umf_library(NAME pool_jemalloc TYPE STATIC SRCS pool_jemalloc.c LIBS jemalloc)
+        add_umf_library(NAME jemalloc_pool
+                        TYPE STATIC
+                        SRCS pool_jemalloc.c
+                        LIBS jemalloc)
+        add_library(${PROJECT_NAME}::jemalloc_pool ALIAS jemalloc_pool)
+        install(TARGETS jemalloc_pool
+            EXPORT ${PROJECT_NAME}-targets
+        )
     else()
         message(FATAL_ERROR "libumf_pool_jemalloc is supported on Linux only")
     endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ FetchContent_Declare(
 )
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 enable_testing()
 
@@ -30,11 +31,11 @@ function(add_umf_test)
     set(TEST_TARGET_NAME umf_test-${ARG_NAME})
 
     set(TEST_LIBS test_common
-        ${PROJECT_NAME}::unified_memory_framework
+        umf
         GTest::gtest_main
         ${ARG_LIBS})
     if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
-        set(TEST_LIBS ${TEST_LIBS} pool_jemalloc)
+        set(TEST_LIBS ${TEST_LIBS} jemalloc_pool)
     endif()
     add_umf_executable(NAME ${TEST_TARGET_NAME} SRCS ${ARG_SRCS} LIBS ${TEST_LIBS})
 
@@ -69,11 +70,11 @@ add_umf_test(NAME memory_pool_internal
 
 if(UMF_BUILD_LIBUMF_POOL_DISJOINT)
     add_umf_test(NAME disjointPool
-                SRCS disjoint_pool.cpp malloc_compliance_tests.cpp
-                LIBS ${PROJECT_NAME}::disjoint_pool)
+                 SRCS disjoint_pool.cpp malloc_compliance_tests.cpp
+                 LIBS disjoint_pool)
     add_umf_test(NAME c_api_disjoint_pool
-                SRCS c_api/disjoint_pool.c
-                LIBS ${PROJECT_NAME}::disjoint_pool)
+                 SRCS c_api/disjoint_pool.c
+                 LIBS disjoint_pool)
 endif()
 
 if(LINUX) # OS-specific functions are implemented only for Linux now


### PR DESCRIPTION
Please, review only the last commit. This PR is based on #73 .
 
Refactor UMF installation
    
    - remove tests from the installation
    - rename libunified-memory-framework.a
    - install license file
    - change hardcoded installation paths to prefixed with CMake vars
    - remove installation paths that are equal to default ones
    - remove alias targets usages where not needed