### PR TITLE
IPC API

### DIFF
--- a/include/umf/ipc.h
+++ b/include/umf/ipc.h
@@ -1,0 +1,56 @@
+/*
+ *
+ * Copyright (C) 2023-2024 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ */
+
+#ifndef UMF_IPC_H
+#define UMF_IPC_H 1
+
+#include <umf/base.h>
+#include <umf/memory_pool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct umf_ipc_data_t *umf_ipc_handle_t;
+
+///
+/// @brief Creates an IPC handle for the specified UMF allocation.
+/// @param ptr pointer to the allocated memory.
+/// @param ipcHandle [out] returned IPC handle.
+/// @param size [out] size of IPC handle in bytes.
+/// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
+umf_result_t umfGetIPCHandle(const void *ptr, umf_ipc_handle_t *ipcHandle,
+                             size_t *size);
+
+///
+/// @brief Release IPC handle retrieved by umfGetIPCHandle.
+/// @param ipcHandle IPC handle.
+/// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
+umf_result_t umfPutIPCHandle(umf_ipc_handle_t ipcHandle);
+
+///
+/// @brief Open IPC handle retrieved by umfGetIPCHandle.
+/// @param hPool [in] Pool handle where to open the the IPC handle.
+/// @param ipcHandle [in] IPC handle.
+/// @param ptr [out] pointer to the memory in the current process.
+/// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
+umf_result_t umfOpenIPCHandle(umf_memory_pool_handle_t hPool,
+                              umf_ipc_handle_t ipcHandle, void **ptr);
+
+///
+/// @brief Close IPC handle.
+/// @param ptr [in] pointer to the memory.
+/// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
+umf_result_t umfCloseIPCHandle(void *ptr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UMF_IPC_H */

--- a/include/umf/memory_provider.h
+++ b/include/umf/memory_provider.h
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023 Intel Corporation
+ * Copyright (C) 2023-2024 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -135,6 +135,65 @@ umf_result_t umfMemoryProviderPurgeLazy(umf_memory_provider_handle_t hProvider,
 ///
 umf_result_t umfMemoryProviderPurgeForce(umf_memory_provider_handle_t hProvider,
                                          void *ptr, size_t size);
+
+///
+/// @brief Retrieve the size of opaque data structure required to store IPC data.
+/// \param hProvider [in] handle to the memory provider.
+/// \param size [out] pointer to the size.
+/// \return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
+///         UMF_RESULT_ERROR_NOT_SUPPORTED if IPC functionality is not supported by this provider.
+umf_result_t
+umfMemoryProviderGetIPCHandleSize(umf_memory_provider_handle_t hProvider,
+                                  size_t *size);
+
+///
+/// @brief Retrieve an IPC memory handle for the specified allocation.
+/// \param hProvider [in] handle to the memory provider.
+/// \param ptr [in] beginning of the virtual memory range returned by
+///                 umfMemoryProviderAlloc function.
+/// \param size [in] size of the memory address range.
+/// \param providerIpcData [out] pointer to the preallocated opaque data structure to store IPC handle.
+/// \return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
+///         UMF_RESULT_ERROR_INVALID_ARGUMENT if ptr was not allocated by this provider.
+///         UMF_RESULT_ERROR_NOT_SUPPORTED if IPC functionality is not supported by this provider.
+umf_result_t
+umfMemoryProviderGetIPCHandle(umf_memory_provider_handle_t hProvider,
+                              const void *ptr, size_t size,
+                              void *providerIpcData);
+
+///
+/// @brief Release IPC handle retrieved with get_ipc_handle function.
+/// @param hProvider [in] handle to the memory provider.
+/// @param providerIpcData [in] pointer to the IPC opaque data structure.
+/// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
+///         UMF_RESULT_ERROR_INVALID_ARGUMENT if providerIpcData was not created by this provider.
+///         UMF_RESULT_ERROR_NOT_SUPPORTED if IPC functionality is not supported by this provider.
+umf_result_t
+umfMemoryProviderPutIPCHandle(umf_memory_provider_handle_t hProvider,
+                              void *providerIpcData);
+
+///
+/// @brief Open IPC handle.
+/// @param hProvider [in] handle to the memory provider.
+/// @param providerIpcData [in] pointer to the IPC opaque data structure.
+/// @param ptr [out] pointer to the memory to be used in the current process.
+/// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
+///         UMF_RESULT_ERROR_INVALID_ARGUMENT if providerIpcData cannot be handled by the provider.
+///         UMF_RESULT_ERROR_NOT_SUPPORTED if IPC functionality is not supported by this provider.
+umf_result_t
+umfMemoryProviderOpenIPCHandle(umf_memory_provider_handle_t hProvider,
+                               void *providerIpcData, void **ptr);
+
+///
+/// @brief Close an IPC memory handle.
+/// @param hProvider [in] handle to the memory provider.
+/// @param ptr [in] pointer returned by umfMemoryProviderOpenIPCHandle function.
+/// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
+///         UMF_RESULT_ERROR_INVALID_ARGUMENT if invalid \p hProvider or \p ptr are passed.
+///         UMF_RESULT_ERROR_NOT_SUPPORTED if IPC functionality is not supported by this provider.
+umf_result_t
+umfMemoryProviderCloseIPCHandle(umf_memory_provider_handle_t hProvider,
+                                void *ptr);
 
 ///
 /// @brief Retrieve name of a given memory \p hProvider.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,7 @@ set(BA_SOURCES
 
 set(UMF_SOURCES
     ${BA_SOURCES}
+    ipc.c
     memory_pool.c
     memory_provider.c
     memory_provider_get_last_failed.c

--- a/src/cpp_helpers.hpp
+++ b/src/cpp_helpers.hpp
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023 Intel Corporation
+ * Copyright (C) 2023-2024 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -93,6 +93,11 @@ template <typename T> umf_memory_provider_ops_t providerOpsBase() {
     UMF_ASSIGN_OP(ops.ext, T, purge_force, UMF_RESULT_ERROR_UNKNOWN);
     UMF_ASSIGN_OP(ops.ext, T, allocation_merge, UMF_RESULT_ERROR_UNKNOWN);
     UMF_ASSIGN_OP(ops.ext, T, allocation_split, UMF_RESULT_ERROR_UNKNOWN);
+    UMF_ASSIGN_OP(ops.ipc, T, get_ipc_handle_size, UMF_RESULT_ERROR_UNKNOWN);
+    UMF_ASSIGN_OP(ops.ipc, T, get_ipc_handle, UMF_RESULT_ERROR_UNKNOWN);
+    UMF_ASSIGN_OP(ops.ipc, T, put_ipc_handle, UMF_RESULT_ERROR_UNKNOWN);
+    UMF_ASSIGN_OP(ops.ipc, T, open_ipc_handle, UMF_RESULT_ERROR_UNKNOWN);
+    UMF_ASSIGN_OP(ops.ipc, T, close_ipc_handle, UMF_RESULT_ERROR_UNKNOWN);
     return ops;
 }
 } // namespace detail

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -1,0 +1,117 @@
+/*
+ *
+ * Copyright (C) 2023-2024 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+
+#include <umf/ipc.h>
+
+#include "base_alloc_global.h"
+#include "ipc_internal.h"
+#include "memory_pool_internal.h"
+#include "provider/provider_tracking.h"
+#include "utils_log.h"
+
+umf_result_t umfGetIPCHandle(const void *ptr, umf_ipc_handle_t *umfIPCHandle,
+                             size_t *size) {
+    size_t ipcHandleSize = 0;
+    umf_alloc_info_t allocInfo;
+    umf_result_t ret = umfMemoryTrackerGetAllocInfo(ptr, &allocInfo);
+    if (ret != UMF_RESULT_SUCCESS) {
+        LOG_ERR("umfGetIPCHandle: cannot get alloc info for ptr = %p.", ptr);
+        return ret;
+    }
+
+    // We cannot use umfPoolGetMemoryProvider function because it returns
+    // upstream provider but we need tracking one
+    umf_memory_provider_handle_t provider = allocInfo.pool->provider;
+    assert(provider);
+
+    size_t providerIPCHandleSize;
+    ret = umfMemoryProviderGetIPCHandleSize(provider, &providerIPCHandleSize);
+    if (ret != UMF_RESULT_SUCCESS) {
+        LOG_ERR("umfGetIPCHandle: cannot get IPC handle size.");
+        return ret;
+    }
+
+    ipcHandleSize = sizeof(umf_ipc_data_t) + providerIPCHandleSize;
+    umf_ipc_data_t *ipcData = umf_ba_global_alloc(ipcHandleSize);
+    if (!ipcData) {
+        LOG_ERR("umfGetIPCHandle: failed to allocate ipcData");
+        return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    ret =
+        umfMemoryProviderGetIPCHandle(provider, allocInfo.base, allocInfo.size,
+                                      (void *)ipcData->providerIpcData);
+    if (ret != UMF_RESULT_SUCCESS) {
+        LOG_ERR("umfGetIPCHandle: failed to get IPC handle.");
+        umf_ba_global_free(ipcData);
+        return ret;
+    }
+
+    ipcData->size = allocInfo.size;
+    ipcData->offset = (uintptr_t)ptr - (uintptr_t)allocInfo.base;
+
+    *umfIPCHandle = ipcData;
+    *size = ipcHandleSize;
+
+    return ret;
+}
+
+umf_result_t umfPutIPCHandle(umf_ipc_handle_t umfIPCHandle) {
+    umf_result_t ret = UMF_RESULT_SUCCESS;
+
+    // TODO: Just return SUCCESS because current tracking memory provider
+    //       implementation does nothing in Put function. Tracking memory
+    //       provider relies on IPC cache and actually Put IPC handle back
+    //       to upstream memory provider when umfMemoryProviderFree is called.
+    //       To support incapsulation we should not take into account
+    //       implementation details of tracking memory provider and find the
+    //       approrpiate pool, get memory provider of that pool and call
+    //       umfMemoryProviderPutIPCHandle(hProvider,
+    //                                     umfIPCHandle->providerIpcData);
+    umf_ba_global_free(umfIPCHandle);
+
+    return ret;
+}
+
+umf_result_t umfOpenIPCHandle(umf_memory_pool_handle_t hPool,
+                              umf_ipc_handle_t umfIPCHandle, void **ptr) {
+
+    // We cannot use umfPoolGetMemoryProvider function because it returns
+    // upstream provider but we need tracking one
+    umf_memory_provider_handle_t hProvider = hPool->provider;
+    void *base = NULL;
+
+    umf_result_t ret = umfMemoryProviderOpenIPCHandle(
+        hProvider, (void *)umfIPCHandle->providerIpcData, &base);
+    if (ret != UMF_RESULT_SUCCESS) {
+        LOG_ERR("umfOpenIPCHandle: memory provider failed to IPC handle.");
+        return ret;
+    }
+    *ptr = (void *)((uintptr_t)base + umfIPCHandle->offset);
+
+    return UMF_RESULT_SUCCESS;
+}
+
+umf_result_t umfCloseIPCHandle(void *ptr) {
+    umf_alloc_info_t allocInfo;
+    umf_result_t ret = umfMemoryTrackerGetAllocInfo(ptr, &allocInfo);
+    if (ret != UMF_RESULT_SUCCESS) {
+        LOG_ERR("umfCloseIPCHandle: cannot get alloc info for ptr = %p.", ptr);
+        return ret;
+    }
+
+    // We cannot use umfPoolGetMemoryProvider function because it returns
+    // upstream provider but we need tracking one
+    umf_memory_provider_handle_t hProvider = allocInfo.pool->provider;
+
+    return umfMemoryProviderCloseIPCHandle(hProvider, allocInfo.base);
+}

--- a/src/ipc_internal.h
+++ b/src/ipc_internal.h
@@ -1,0 +1,33 @@
+/*
+ *
+ * Copyright (C) 2023-2024 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ */
+
+#ifndef UMF_IPC_INTERNAL_H
+#define UMF_IPC_INTERNAL_H 1
+
+#include <umf/base.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// UMF representation of IPC handle. It contains UMF-specific common data
+// and provider-specific IPC data, stored in providerIpcData.
+// providerIpcData is a Flexible Array Member because its size varies
+// depending on the provider.
+typedef struct umf_ipc_data_t {
+    size_t size; // size of base allocation
+    uint64_t offset;
+    char providerIpcData[];
+} umf_ipc_data_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UMF_IPC_INTERNAL_H */

--- a/src/libumf.def
+++ b/src/libumf.def
@@ -10,22 +10,30 @@ VERSION 1.0
 
 EXPORTS
     DllMain
+    umfCloseIPCHandle
     umfFree
+    umfGetIPCHandle
     umfGetLastFailedMemoryProvider
     umfMemoryProviderAlloc
     umfMemoryProviderAllocationMerge
     umfMemoryProviderAllocationSplit
+    umfMemoryProviderCloseIPCHandle
     umfMemoryProviderCreate
     umfMemoryProviderCreateFromMemspace
     umfMemoryProviderDestroy
     umfMemoryProviderFree
+    umfMemoryProviderGetIPCHandle
+    umfMemoryProviderGetIPCHandleSize
     umfMemoryProviderGetLastNativeError
     umfMemoryProviderGetMinPageSize
     umfMemoryProviderGetName
     umfMemoryProviderGetRecommendedPageSize
+    umfMemoryProviderOpenIPCHandle
     umfMemoryProviderPurgeForce
     umfMemoryProviderPurgeLazy
+    umfMemoryProviderPutIPCHandle
     umfMemspaceDestroy
+    umfOpenIPCHandle
     umfPoolAlignedMalloc
     umfPoolByPtr
     umfPoolCalloc
@@ -39,4 +47,5 @@ EXPORTS
     umfPoolMallocUsableSize
     umfPoolRealloc
     umfProxyPoolOps
+    umfPutIPCHandle
     umfOsMemoryProviderOps

--- a/src/libumf.map
+++ b/src/libumf.map
@@ -4,26 +4,34 @@
 
 UMF_1.0 {
     global:
+        umfCloseIPCHandle;
         umfFree;
+        umfGetIPCHandle;
         umfGetLastFailedMemoryProvider;
         umfLevelZeroMemoryProviderOps;
         umfMemoryProviderAlloc;
         umfMemoryProviderAllocationMerge;
         umfMemoryProviderAllocationSplit;
+        umfMemoryProviderCloseIPCHandle;
         umfMemoryProviderCreate;
         umfMemoryProviderCreateFromMemspace;
         umfMemoryProviderDestroy;
         umfMemoryProviderFree;
+        umfMemoryProviderGetIPCHandle;
+        umfMemoryProviderGetIPCHandleSize;
         umfMemoryProviderGetLastNativeError;
         umfMemoryProviderGetMinPageSize;
         umfMemoryProviderGetName;
         umfMemoryProviderGetRecommendedPageSize;
+        umfMemoryProviderOpenIPCHandle;
         umfMemoryProviderPurgeForce;
         umfMemoryProviderPurgeLazy;
+        umfMemoryProviderPutIPCHandle;
         umfMemspaceCreateFromNumaArray;
         umfMemspaceDestroy;
         umfMemspaceHighestCapacityGet;
         umfMemspaceHostAllGet;
+        umfOpenIPCHandle;
         umfOsMemoryProviderOps;
         umfPoolAlignedMalloc;
         umfPoolByPtr;
@@ -38,6 +46,7 @@ UMF_1.0 {
         umfPoolMallocUsableSize;
         umfPoolRealloc;
         umfProxyPoolOps;
+        umfPutIPCHandle;
     local:
         *;
 };

--- a/src/provider/provider_os_memory.c
+++ b/src/provider/provider_os_memory.c
@@ -614,7 +614,12 @@ static umf_memory_provider_ops_t UMF_OS_MEMORY_PROVIDER_OPS = {
     .ext.purge_lazy = os_purge_lazy,
     .ext.purge_force = os_purge_force,
     .ext.allocation_merge = os_allocation_merge,
-    .ext.allocation_split = os_allocation_split};
+    .ext.allocation_split = os_allocation_split,
+    .ipc.get_ipc_handle_size = NULL,
+    .ipc.get_ipc_handle = NULL,
+    .ipc.put_ipc_handle = NULL,
+    .ipc.open_ipc_handle = NULL,
+    .ipc.close_ipc_handle = NULL};
 
 umf_memory_provider_ops_t *umfOsMemoryProviderOps(void) {
     return &UMF_OS_MEMORY_PROVIDER_OPS;

--- a/src/provider/provider_tracking.h
+++ b/src/provider/provider_tracking.h
@@ -40,6 +40,15 @@ void umfMemoryTrackerDestroy(umf_memory_tracker_handle_t handle);
 
 umf_memory_pool_handle_t umfMemoryTrackerGetPool(const void *ptr);
 
+typedef struct umf_alloc_info_t {
+    void *base;
+    size_t size;
+    umf_memory_pool_handle_t pool;
+} umf_alloc_info_t;
+
+umf_result_t umfMemoryTrackerGetAllocInfo(const void *ptr,
+                                          umf_alloc_info_t *pAllocInfo);
+
 // Creates a memory provider that tracks each allocation/deallocation through umf_memory_tracker_handle_t and
 // forwards all requests to hUpstream memory Provider. hUpstream lifetime should be managed by the user of this function.
 umf_result_t umfTrackingMemoryProviderCreate(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -241,3 +241,7 @@ if(UMF_PROXY_LIB_ENABLED AND UMF_BUILD_SHARED_LIBRARY)
         LIBS umf_proxy
         CFGS ${CONFIGS})
 endif()
+
+if(UMF_ENABLE_POOL_TRACKING)
+    add_umf_test(NAME ipc SRCS ipcAPI.cpp)
+endif()

--- a/test/common/provider.hpp
+++ b/test/common/provider.hpp
@@ -73,6 +73,26 @@ typedef struct provider_base_t {
                                   [[maybe_unused]] size_t firstSize) {
         return UMF_RESULT_ERROR_UNKNOWN;
     }
+    umf_result_t get_ipc_handle_size([[maybe_unused]] size_t *size) noexcept {
+        return UMF_RESULT_ERROR_UNKNOWN;
+    }
+    umf_result_t
+    get_ipc_handle([[maybe_unused]] const void *ptr,
+                   [[maybe_unused]] size_t size,
+                   [[maybe_unused]] void *providerIpcData) noexcept {
+        return UMF_RESULT_ERROR_UNKNOWN;
+    }
+    umf_result_t
+    put_ipc_handle([[maybe_unused]] void *providerIpcData) noexcept {
+        return UMF_RESULT_ERROR_UNKNOWN;
+    }
+    umf_result_t open_ipc_handle([[maybe_unused]] void *providerIpcData,
+                                 [[maybe_unused]] void **ptr) noexcept {
+        return UMF_RESULT_ERROR_UNKNOWN;
+    }
+    umf_result_t close_ipc_handle([[maybe_unused]] void *ptr) noexcept {
+        return UMF_RESULT_ERROR_UNKNOWN;
+    }
 } provider_base_t;
 
 umf_memory_provider_ops_t BASE_PROVIDER_OPS =

--- a/test/common/provider_null.c
+++ b/test/common/provider_null.c
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2024 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -93,6 +93,41 @@ static umf_result_t nullAllocationSplit(void *provider, void *ptr,
     return UMF_RESULT_SUCCESS;
 }
 
+static umf_result_t nullGetIpcHandleSize(void *provider, size_t *size) {
+    (void)provider;
+    (void)size;
+    return UMF_RESULT_SUCCESS;
+}
+
+static umf_result_t nullGetIpcHandle(void *provider, const void *ptr,
+                                     size_t size, void *ipcHandle) {
+    (void)provider;
+    (void)ptr;
+    (void)size;
+    (void)ipcHandle;
+    return UMF_RESULT_SUCCESS;
+}
+
+static umf_result_t nullPutIpcHandle(void *provider, void *ipcHandle) {
+    (void)provider;
+    (void)ipcHandle;
+    return UMF_RESULT_SUCCESS;
+}
+
+static umf_result_t nullOpenIpcHandle(void *provider, void *ipcHandle,
+                                      void **ptr) {
+    (void)provider;
+    (void)ipcHandle;
+    (void)ptr;
+    return UMF_RESULT_SUCCESS;
+}
+
+static umf_result_t nullCloseIpcHandle(void *provider, void *ptr) {
+    (void)provider;
+    (void)ptr;
+    return UMF_RESULT_SUCCESS;
+}
+
 umf_memory_provider_ops_t UMF_NULL_PROVIDER_OPS = {
     .version = UMF_VERSION_CURRENT,
     .initialize = nullInitialize,
@@ -107,4 +142,9 @@ umf_memory_provider_ops_t UMF_NULL_PROVIDER_OPS = {
     .ext.purge_force = nullPurgeForce,
     .ext.allocation_merge = nullAllocationMerge,
     .ext.allocation_split = nullAllocationSplit,
+    .ipc.get_ipc_handle_size = nullGetIpcHandleSize,
+    .ipc.get_ipc_handle = nullGetIpcHandle,
+    .ipc.put_ipc_handle = nullPutIpcHandle,
+    .ipc.open_ipc_handle = nullOpenIpcHandle,
+    .ipc.close_ipc_handle = nullCloseIpcHandle,
 };

--- a/test/common/provider_trace.c
+++ b/test/common/provider_trace.c
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2024 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -127,6 +127,53 @@ static umf_result_t traceAllocationSplit(void *provider, void *ptr,
                                             ptr, totalSize, firstSize);
 }
 
+static umf_result_t traceGetIpcHandleSize(void *provider, size_t *pSize) {
+    umf_provider_trace_params_priv_t *traceProvider =
+        (umf_provider_trace_params_priv_t *)provider;
+
+    traceProvider->trace("get_ipc_handle_size");
+    return umfMemoryProviderGetIPCHandleSize(traceProvider->hUpstreamProvider,
+                                             pSize);
+}
+
+static umf_result_t traceGetIpcHandle(void *provider, const void *ptr,
+                                      size_t size, void *ipcHandle) {
+    umf_provider_trace_params_priv_t *traceProvider =
+        (umf_provider_trace_params_priv_t *)provider;
+
+    traceProvider->trace("get_ipc_handle");
+    return umfMemoryProviderGetIPCHandle(traceProvider->hUpstreamProvider, ptr,
+                                         size, ipcHandle);
+}
+
+static umf_result_t tracePutIpcHandle(void *provider, void *ipcHandle) {
+    umf_provider_trace_params_priv_t *traceProvider =
+        (umf_provider_trace_params_priv_t *)provider;
+
+    traceProvider->trace("put_ipc_handle");
+    return umfMemoryProviderPutIPCHandle(traceProvider->hUpstreamProvider,
+                                         ipcHandle);
+}
+
+static umf_result_t traceOpenIpcHandle(void *provider, void *ipcHandle,
+                                       void **ptr) {
+    umf_provider_trace_params_priv_t *traceProvider =
+        (umf_provider_trace_params_priv_t *)provider;
+
+    traceProvider->trace("open_ipc_handle");
+    return umfMemoryProviderOpenIPCHandle(traceProvider->hUpstreamProvider,
+                                          ipcHandle, ptr);
+}
+
+static umf_result_t traceCloseIpcHandle(void *provider, void *ptr) {
+    umf_provider_trace_params_priv_t *traceProvider =
+        (umf_provider_trace_params_priv_t *)provider;
+
+    traceProvider->trace("close_ipc_handle");
+    return umfMemoryProviderCloseIPCHandle(traceProvider->hUpstreamProvider,
+                                           ptr);
+}
+
 umf_memory_provider_ops_t UMF_TRACE_PROVIDER_OPS = {
     .version = UMF_VERSION_CURRENT,
     .initialize = traceInitialize,
@@ -141,4 +188,9 @@ umf_memory_provider_ops_t UMF_TRACE_PROVIDER_OPS = {
     .ext.purge_force = tracePurgeForce,
     .ext.allocation_merge = traceAllocationMerge,
     .ext.allocation_split = traceAllocationSplit,
+    .ipc.get_ipc_handle_size = traceGetIpcHandleSize,
+    .ipc.get_ipc_handle = traceGetIpcHandle,
+    .ipc.put_ipc_handle = tracePutIpcHandle,
+    .ipc.open_ipc_handle = traceOpenIpcHandle,
+    .ipc.close_ipc_handle = traceCloseIpcHandle,
 };

--- a/test/ipcAPI.cpp
+++ b/test/ipcAPI.cpp
@@ -1,0 +1,339 @@
+// Copyright (C) 2023-2024 Intel Corporation
+// Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// This file contains tests for UMF pool API
+
+#include "pool.hpp"
+#include "provider.hpp"
+
+#include <umf/ipc.h>
+#include <umf/memory_pool.h>
+#include <umf/pools/pool_proxy.h>
+
+#include <array>
+#include <atomic>
+#include <cstdlib>
+#include <mutex>
+#include <numeric>
+#include <shared_mutex>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+struct provider_mock_ipc : public umf_test::provider_base_t {
+    using allocations_map_type = std::unordered_map<const void *, size_t>;
+    using allocations_mutex_type = std::shared_mutex;
+    using allocations_read_lock_type = std::shared_lock<allocations_mutex_type>;
+    using allocations_write_lock_type =
+        std::unique_lock<allocations_mutex_type>;
+
+    struct provider_ipc_data_t {
+        const void *ptr;
+        size_t size;
+    };
+    struct stats {
+        std::atomic<size_t> getCount;
+        std::atomic<size_t> putCount;
+        std::atomic<size_t> openCount;
+        std::atomic<size_t> closeCount;
+
+        stats() : getCount(0), putCount(0), openCount(0), closeCount(0) {}
+    };
+
+    stats *stat = nullptr;
+    umf_test::provider_malloc helper_prov;
+    allocations_mutex_type alloc_mutex;
+    allocations_map_type allocations;
+
+    umf_result_t initialize(stats *s) noexcept {
+        stat = s;
+        return UMF_RESULT_SUCCESS;
+    }
+    enum umf_result_t alloc(size_t size, size_t align, void **ptr) noexcept {
+        auto ret = helper_prov.alloc(size, align, ptr);
+        if (ret == UMF_RESULT_SUCCESS) {
+            allocations_write_lock_type lock(alloc_mutex);
+            auto [it, res] = allocations.emplace(*ptr, size);
+            (void)it;
+            EXPECT_TRUE(res);
+        }
+        return ret;
+    }
+    enum umf_result_t free(void *ptr, size_t size) noexcept {
+        allocations_write_lock_type lock(alloc_mutex);
+        allocations.erase(ptr);
+        lock.unlock();
+        auto ret = helper_prov.free(ptr, size);
+        return ret;
+    }
+    const char *get_name() noexcept { return "mock_ipc"; }
+    enum umf_result_t get_ipc_handle_size(size_t *size) noexcept {
+        *size = sizeof(provider_ipc_data_t);
+        return UMF_RESULT_SUCCESS;
+    }
+    enum umf_result_t get_ipc_handle(const void *ptr, size_t size,
+                                     void *providerIpcData) noexcept {
+        ++stat->getCount;
+        provider_ipc_data_t *ipcData =
+            static_cast<provider_ipc_data_t *>(providerIpcData);
+        allocations_read_lock_type lock(alloc_mutex);
+        auto it = allocations.find(ptr);
+        if (it == allocations.end()) {
+            // client tries to get handle for the pointer that does not match
+            // with any of the base addresses allocated by the instance of
+            // the memory provider
+            return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+        }
+        (void)size;
+        ipcData->ptr = ptr;
+        ipcData->size = it->second; // size of the base allocation
+        return UMF_RESULT_SUCCESS;
+    }
+    enum umf_result_t put_ipc_handle(void *providerIpcData) noexcept {
+        ++stat->putCount;
+        (void)providerIpcData;
+        return UMF_RESULT_SUCCESS;
+    }
+    enum umf_result_t open_ipc_handle(void *providerIpcData,
+                                      void **ptr) noexcept {
+        ++stat->openCount;
+        provider_ipc_data_t *ipcData =
+            static_cast<provider_ipc_data_t *>(providerIpcData);
+        void *mapping = std::malloc(ipcData->size);
+        if (!mapping) {
+            return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+        }
+
+        memcpy(mapping, ipcData->ptr, ipcData->size);
+
+        *ptr = mapping;
+
+        return UMF_RESULT_SUCCESS;
+    }
+    enum umf_result_t close_ipc_handle(void *ptr) noexcept {
+        ++stat->closeCount;
+        std::free(ptr);
+        return UMF_RESULT_SUCCESS;
+    }
+};
+
+struct umfIpcTest : umf_test::test {
+    umfIpcTest() : pool(nullptr, nullptr) {}
+    void SetUp() override {
+        test::SetUp();
+        this->pool = makePool();
+    }
+
+    void TearDown() override { test::TearDown(); }
+
+    umf::pool_unique_handle_t makePool() {
+        // TODO: The function is similar to poolCreateExt function
+        //       from memoryPool.hpp
+        umf_memory_provider_handle_t hProvider;
+        umf_memory_pool_handle_t hPool;
+
+        auto ret =
+            umfMemoryProviderCreate(&IPC_MOCK_PROVIDER_OPS, &stat, &hProvider);
+        EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
+
+        ret = umfPoolCreate(umfProxyPoolOps(), hProvider, nullptr,
+                            UMF_POOL_CREATE_FLAG_OWN_PROVIDER, &hPool);
+        EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
+
+        return umf::pool_unique_handle_t(hPool, &umfPoolDestroy);
+    }
+
+    using stats_type = typename provider_mock_ipc::stats;
+    umf_memory_provider_ops_t IPC_MOCK_PROVIDER_OPS =
+        umf::providerMakeCOps<provider_mock_ipc, stats_type>();
+    umf::pool_unique_handle_t pool;
+    static constexpr int NTHREADS = 10;
+    stats_type stat;
+};
+
+TEST_F(umfIpcTest, BasicFlow) {
+    constexpr size_t SIZE = 100;
+    int *ptr = (int *)umfPoolMalloc(pool.get(), SIZE * sizeof(int));
+    EXPECT_NE(ptr, nullptr);
+
+    std::iota(ptr, ptr + SIZE, 0);
+
+    umf_ipc_handle_t ipcHandleFull = nullptr;
+    size_t handleFullSize = 0;
+    umf_result_t ret = umfGetIPCHandle(ptr, &ipcHandleFull, &handleFullSize);
+    ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+    umf_ipc_handle_t ipcHandleHalf = nullptr;
+    size_t handleHalfSize = 0;
+    ret = umfGetIPCHandle(ptr + SIZE / 2, &ipcHandleHalf, &handleHalfSize);
+    ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+    ASSERT_EQ(handleFullSize, handleHalfSize);
+
+    void *fullArray = nullptr;
+    ret = umfOpenIPCHandle(pool.get(), ipcHandleFull, &fullArray);
+    ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+
+    void *halfArray = nullptr;
+    ret = umfOpenIPCHandle(pool.get(), ipcHandleHalf, &halfArray);
+    ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+
+    for (int i = 0; i < (int)SIZE; ++i) {
+        ASSERT_EQ(reinterpret_cast<int *>(fullArray)[i], i);
+    }
+    // Close fullArray before reading halfArray
+    ret = umfCloseIPCHandle(fullArray);
+    EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
+
+    for (int i = 0; i < (int)SIZE / 2; ++i) {
+        ASSERT_EQ(reinterpret_cast<int *>(halfArray)[i], i + SIZE / 2);
+    }
+    ret = umfCloseIPCHandle(halfArray);
+    EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
+
+    ret = umfPutIPCHandle(ipcHandleFull);
+    EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
+
+    ret = umfPutIPCHandle(ipcHandleHalf);
+    EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
+
+    ret = umfPoolFree(pool.get(), ptr);
+    EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
+
+    EXPECT_EQ(stat.getCount, 1);
+    EXPECT_EQ(stat.putCount, stat.getCount);
+    // TODO: enale check below once cache for open IPC handles is implemented
+    // EXPECT_EQ(stat.openCount, 1);
+    EXPECT_EQ(stat.closeCount, stat.openCount);
+}
+
+TEST_F(umfIpcTest, ConcurrentGetPutHandles) {
+    std::vector<void *> ptrs;
+    constexpr size_t ALLOC_SIZE = 100;
+    constexpr size_t NUM_POINTERS = 100;
+    for (size_t i = 0; i < NUM_POINTERS; ++i) {
+        void *ptr = umfPoolMalloc(pool.get(), ALLOC_SIZE);
+        EXPECT_NE(ptr, nullptr);
+        ptrs.push_back(ptr);
+    }
+
+    std::array<std::vector<umf_ipc_handle_t>, NTHREADS> ipcHandles;
+
+    auto getHandlesFn = [&ipcHandles, &ptrs](size_t tid) {
+        // TODO: better to wait on the barrier here so that every thread
+        // starts at the same point. But std::barrier is available only
+        // starting from C++20
+        for (void *ptr : ptrs) {
+            umf_ipc_handle_t ipcHandle;
+            size_t handleSize;
+            umf_result_t ret = umfGetIPCHandle(ptr, &ipcHandle, &handleSize);
+            ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+            ipcHandles[tid].push_back(ipcHandle);
+        }
+    };
+
+    std::vector<std::thread> threads;
+    for (int i = 0; i < NTHREADS; i++) {
+        threads.emplace_back(getHandlesFn, i);
+    }
+
+    for (auto &thread : threads) {
+        thread.join();
+    }
+    threads.clear();
+
+    auto putHandlesFn = [&ipcHandles](size_t tid) {
+        for (umf_ipc_handle_t ipcHandle : ipcHandles[tid]) {
+            umf_result_t ret = umfPutIPCHandle(ipcHandle);
+            EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
+        }
+    };
+
+    for (int i = 0; i < NTHREADS; i++) {
+        threads.emplace_back(putHandlesFn, i);
+    }
+
+    for (auto &thread : threads) {
+        thread.join();
+    }
+    threads.clear();
+
+    for (void *ptr : ptrs) {
+        umf_result_t ret = umfPoolFree(pool.get(), ptr);
+        EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
+    }
+
+    EXPECT_GE(stat.getCount, NUM_POINTERS);
+    EXPECT_LE(stat.getCount, NUM_POINTERS * NTHREADS);
+    EXPECT_EQ(stat.putCount, stat.getCount);
+}
+
+TEST_F(umfIpcTest, ConcurrentOpenCloseHandles) {
+    std::vector<void *> ptrs;
+    constexpr size_t ALLOC_SIZE = 100;
+    constexpr size_t NUM_POINTERS = 100;
+    for (size_t i = 0; i < NUM_POINTERS; ++i) {
+        void *ptr = umfPoolMalloc(pool.get(), ALLOC_SIZE);
+        EXPECT_NE(ptr, nullptr);
+        ptrs.push_back(ptr);
+    }
+
+    std::array<umf_ipc_handle_t, NUM_POINTERS> ipcHandles;
+    for (size_t i = 0; i < NUM_POINTERS; ++i) {
+        umf_ipc_handle_t ipcHandle;
+        size_t handleSize;
+        umf_result_t ret = umfGetIPCHandle(ptrs[i], &ipcHandle, &handleSize);
+        ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+        ipcHandles[i] = ipcHandle;
+    }
+
+    std::array<std::vector<void *>, NTHREADS> openedIpcHandles;
+
+    auto openHandlesFn = [this, &ipcHandles, &openedIpcHandles](size_t tid) {
+        // TODO: better to wait on the barrier here so that every thread
+        // starts at the same point. But std::barrier is available only
+        // starting from C++20
+        for (auto ipcHandle : ipcHandles) {
+            void *ptr;
+            umf_result_t ret = umfOpenIPCHandle(pool.get(), ipcHandle, &ptr);
+            ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+            openedIpcHandles[tid].push_back(ptr);
+        }
+    };
+
+    std::vector<std::thread> threads;
+    for (int i = 0; i < NTHREADS; i++) {
+        threads.emplace_back(openHandlesFn, i);
+    }
+
+    for (auto &thread : threads) {
+        thread.join();
+    }
+    threads.clear();
+
+    auto closeHandlesFn = [&openedIpcHandles](size_t tid) {
+        for (void *ptr : openedIpcHandles[tid]) {
+            umf_result_t ret = umfCloseIPCHandle(ptr);
+            EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
+        }
+    };
+
+    for (int i = 0; i < NTHREADS; i++) {
+        threads.emplace_back(closeHandlesFn, i);
+    }
+
+    for (auto &thread : threads) {
+        thread.join();
+    }
+    threads.clear();
+
+    for (auto ipcHandle : ipcHandles) {
+        umf_result_t ret = umfPutIPCHandle(ipcHandle);
+        EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
+    }
+
+    for (void *ptr : ptrs) {
+        umf_result_t ret = umfPoolFree(pool.get(), ptr);
+        EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
+    }
+
+    EXPECT_EQ(stat.openCount, stat.closeCount);
+}

--- a/test/memoryProviderAPI.cpp
+++ b/test/memoryProviderAPI.cpp
@@ -207,6 +207,46 @@ TEST_F(test, memoryProviderOpsNullAllocationMergeField) {
     ASSERT_EQ(ret, UMF_RESULT_ERROR_INVALID_ARGUMENT);
 }
 
+TEST_F(test, memoryProviderOpsNullGetIpcHandleSize) {
+    umf_memory_provider_ops_t provider_ops = UMF_NULL_PROVIDER_OPS;
+    provider_ops.ipc.get_ipc_handle_size = nullptr;
+    umf_memory_provider_handle_t hProvider;
+    auto ret = umfMemoryProviderCreate(&provider_ops, nullptr, &hProvider);
+    ASSERT_EQ(ret, UMF_RESULT_ERROR_INVALID_ARGUMENT);
+}
+
+TEST_F(test, memoryProviderOpsNullGetIpcHandle) {
+    umf_memory_provider_ops_t provider_ops = UMF_NULL_PROVIDER_OPS;
+    provider_ops.ipc.get_ipc_handle = nullptr;
+    umf_memory_provider_handle_t hProvider;
+    auto ret = umfMemoryProviderCreate(&provider_ops, nullptr, &hProvider);
+    ASSERT_EQ(ret, UMF_RESULT_ERROR_INVALID_ARGUMENT);
+}
+
+TEST_F(test, memoryProviderOpsNullPutIpcHandle) {
+    umf_memory_provider_ops_t provider_ops = UMF_NULL_PROVIDER_OPS;
+    provider_ops.ipc.put_ipc_handle = nullptr;
+    umf_memory_provider_handle_t hProvider;
+    auto ret = umfMemoryProviderCreate(&provider_ops, nullptr, &hProvider);
+    ASSERT_EQ(ret, UMF_RESULT_ERROR_INVALID_ARGUMENT);
+}
+
+TEST_F(test, memoryProviderOpsNullOpenIpcHandle) {
+    umf_memory_provider_ops_t provider_ops = UMF_NULL_PROVIDER_OPS;
+    provider_ops.ipc.open_ipc_handle = nullptr;
+    umf_memory_provider_handle_t hProvider;
+    auto ret = umfMemoryProviderCreate(&provider_ops, nullptr, &hProvider);
+    ASSERT_EQ(ret, UMF_RESULT_ERROR_INVALID_ARGUMENT);
+}
+
+TEST_F(test, memoryProviderOpsNullCloseIpcHandle) {
+    umf_memory_provider_ops_t provider_ops = UMF_NULL_PROVIDER_OPS;
+    provider_ops.ipc.close_ipc_handle = nullptr;
+    umf_memory_provider_handle_t hProvider;
+    auto ret = umfMemoryProviderCreate(&provider_ops, nullptr, &hProvider);
+    ASSERT_EQ(ret, UMF_RESULT_ERROR_INVALID_ARGUMENT);
+}
+
 struct providerInitializeTest : umf_test::test,
                                 ::testing::WithParamInterface<umf_result_t> {};
 


### PR DESCRIPTION
This PR introduces IPC API to UMF. The main use cases so far are from the GPU domain (L0, CUDA have such capabilities). The API is pretty similar to what L0 and CUDA have, but it also could be applied for shared memory or file-backed memory.

This PR is big enough, but still it does not contain everything we need.

The remaining tasks/items are the following:
- Implement more efficient caching for IPC handles. This PR implements caching of IPC handles on the producer side (on getting IPC handles). Based on `critnib` data structure (in fact just a map, not a real cache with eviction policy).
- Need to implement proper cache with eviction policies (e.g. LRU) so that we can control the size of the cache.
- Implement cache on the consumer side (when we open IPC handles), in this PR we always call memory provider.
- Evaluate `uthash` data structure that supports arbitrary key type and is more suitable for caching on a consumer side where the key is remote PID + address
- Create documentation.
- Create more tests.
- Extend UMF IPC API to allow retrieving native IPC handle from UMF IPC handle. 