### PR TITLE
Fix linking

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -11,5 +11,5 @@ add_dependencies(ubench unified_memory_framework)
 target_include_directories(ubench PRIVATE ${UMF_CMAKE_SOURCE_DIR}/include/)
 target_link_libraries(ubench
 	unified_memory_framework
-	numa
-	pthread)
+	pthread
+	m)

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -72,18 +72,35 @@ function(add_umf_target_exec_options name)
     endif()
 endfunction()
 
-function(add_umf_executable name)
-    add_executable(${name} ${ARGN})
-    add_umf_target_compile_options(${name})
-    add_umf_target_exec_options(${name})
-    add_umf_target_link_options(${name})
+function(add_umf_executable)
+    # NAME - a name of the executable
+    # SRCS - source files
+    # LIBS - libraries to be linked with
+    set(oneValueArgs NAME)
+    set(multiValueArgs SRCS LIBS)
+    cmake_parse_arguments(ARG "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    add_executable(${ARG_NAME} ${ARG_SRCS})
+    target_link_libraries(${ARG_NAME} PRIVATE ${ARG_LIBS})
+    add_umf_target_compile_options(${ARG_NAME})
+    add_umf_target_exec_options(${ARG_NAME})
+    add_umf_target_link_options(${ARG_NAME})
 endfunction()
 
-function(add_umf_library name)
-    add_library(${name} ${ARGN})
-    target_include_directories(${name} PRIVATE
+function(add_umf_library)
+    # NAME - a name of the executable
+    # TYPE - type of the library (shared or static)
+    # SRCS - source files
+    # LIBS - libraries to be linked with
+    set(oneValueArgs NAME TYPE)
+    set(multiValueArgs SRCS LIBS)
+    cmake_parse_arguments(ARG "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    add_library(${ARG_NAME} ${ARG_TYPE} ${ARG_SRCS})
+    target_link_libraries(${ARG_NAME} PRIVATE ${ARG_LIBS})
+    target_include_directories(${ARG_NAME} PRIVATE
         ${UMF_CMAKE_SOURCE_DIR}/include
         ${UMF_CMAKE_SOURCE_DIR}/src/common)
-    add_umf_target_compile_options(${name})
-    add_umf_target_link_options(${name})
+    add_umf_target_compile_options(${ARG_NAME})
+    add_umf_target_link_options(${ARG_NAME})
 endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,12 @@ set(UMF_SOURCES_MACOSX
 )
 
 if(LINUX)
+    set(UMF_LIBS numa)
+else()
+    set(UMF_LIBS)
+endif()
+
+if(LINUX)
     set(UMF_SOURCES ${UMF_SOURCES} ${UMF_SOURCES_LINUX})
 elseif(WINDOWS)
     set(UMF_SOURCES ${UMF_SOURCES} ${UMF_SOURCES_WINDOWS})
@@ -40,10 +46,10 @@ elseif(MACOSX)
 endif()
 
 if(UMF_BUILD_SHARED_LIBRARY)
-    add_umf_library(unified_memory_framework SHARED ${UMF_SOURCES})
+    add_umf_library(NAME unified_memory_framework TYPE SHARED SRCS ${UMF_SOURCES} LIBS ${UMF_LIBS})
     target_compile_definitions(unified_memory_framework PUBLIC UMF_SHARED_LIBRARY)
 else()
-    add_umf_library(unified_memory_framework STATIC ${UMF_SOURCES})
+    add_umf_library(NAME unified_memory_framework TYPE STATIC SRCS ${UMF_SOURCES} LIBS ${UMF_LIBS})
 endif()
 
 if (UMF_ENABLE_POOL_TRACKING)
@@ -64,7 +70,7 @@ target_include_directories(unified_memory_framework PUBLIC
 # libumf_pool_jemalloc
 if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
     if(LINUX)
-        add_umf_library(pool_jemalloc STATIC pool/pool_jemalloc.c)
+        add_umf_library(NAME pool_jemalloc TYPE STATIC SRCS pool/pool_jemalloc.c LIBS jemalloc)
     else()
         message(FATAL_ERROR "libumf_pool_jemalloc is supported on Linux only")
     endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,13 +29,14 @@ function(add_umf_test)
     set(TEST_NAME umf-${ARG_NAME})
     set(TEST_TARGET_NAME umf_test-${ARG_NAME})
 
-    add_umf_executable(${TEST_TARGET_NAME} ${ARG_SRCS})
-
-    target_link_libraries(${TEST_TARGET_NAME} PRIVATE
-        test_common
+    set(TEST_LIBS test_common
         ${PROJECT_NAME}::unified_memory_framework
         GTest::gtest_main
         ${ARG_LIBS})
+    if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
+        set(TEST_LIBS ${TEST_LIBS} pool_jemalloc)
+    endif()
+    add_umf_executable(NAME ${TEST_TARGET_NAME} SRCS ${ARG_SRCS} LIBS ${TEST_LIBS})
 
     target_include_directories(${TEST_TARGET_NAME} PRIVATE
         ${UMF_TEST_DIR}/common
@@ -58,17 +59,13 @@ endfunction()
 
 add_subdirectory(common)
 
-if (UMF_BUILD_LIBUMF_POOL_JEMALLOC)
-    set(LIBS_JEMALLOC pool_jemalloc jemalloc numa)
-endif()
-
 add_umf_test(NAME base SRCS base.cpp)
-add_umf_test(NAME memoryPool SRCS memoryPoolAPI.cpp malloc_compliance_tests.cpp LIBS ${LIBS_JEMALLOC})
+add_umf_test(NAME memoryPool SRCS memoryPoolAPI.cpp malloc_compliance_tests.cpp)
 add_umf_test(NAME memoryProvider SRCS memoryProviderAPI.cpp)
 add_umf_test(NAME disjointPool SRCS disjoint_pool.cpp malloc_compliance_tests.cpp)
 add_umf_test(NAME c_api_disjoint_pool SRCS c_api/disjoint_pool.c)
 add_umf_test(NAME memory_pool_internal SRCS memory_pool_internal.cpp)
 
 if(LINUX) # OS-specific functions are implemented only for Linux now
-    add_umf_test(NAME provider_os_memory SRCS provider_os_memory.cpp LIBS numa)
+    add_umf_test(NAME provider_os_memory SRCS provider_os_memory.cpp)
 endif()

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -10,6 +10,6 @@ set(COMMON_SOURCES
     provider_trace.c
 )
 
-add_umf_library(test_common STATIC ${COMMON_SOURCES})
+add_umf_library(NAME test_common TYPE STATIC SRCS ${COMMON_SOURCES})
 
 target_include_directories(test_common PRIVATE ${UMF_CMAKE_SOURCE_DIR}/include)


### PR DESCRIPTION
Some libraries that were dependencies of UMF were not link to UMF but rather directly to tests and benchmark. Fix this by extending add_umf_library and passing required libs there.