### PR TITLE
Fix running benchmark without disjoint pool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,10 +75,12 @@ install(
     EXPORT ${PROJECT_NAME}-targets)
 
 add_subdirectory(src)
+
 if(UMF_BUILD_TESTS)
     add_subdirectory(test)
 endif()
-if(UMF_BUILD_BENCHMARKS AND UMF_BUILD_LIBUMF_POOL_DISJOINT)
+
+if(UMF_BUILD_BENCHMARKS)
     if(LINUX)
         add_subdirectory(benchmark)
     else()

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ For development and contributions:
 
 ### Benchmark
 
-Disjoint Pool is a required dependency of the micro benchmark.
-In order to build the benchmark, the `UMF_BUILD_LIBUMF_POOL_DISJOINT` CMake configuration flag has to be turned `ON`.
+A simple micro benchmark based on [ubench](https://github.com/sheredom/ubench.h).
+In order to build the benchmark, the `UMF_BUILD_BENCHMARKS` CMake configuration flag has to be turned `ON`.
 
 ### Windows
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -6,13 +6,24 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 	message(WARNING "The ubench SHOULD NOT be run in the Debug build type!")
 endif()
 
+if(UMF_BUILD_LIBUMF_POOL_DISJOINT)
+	set(LIBS_OPTIONAL ${LIBS_OPTIONAL} disjoint_pool)
+endif()
+
 add_executable(ubench ubench.c)
+
 add_dependencies(ubench
 	umf
-	disjoint_pool)
+	${LIBS_OPTIONAL})
+
 target_include_directories(ubench PRIVATE ${UMF_CMAKE_SOURCE_DIR}/include/)
+
 target_link_libraries(ubench
 	umf
-	disjoint_pool
+	${LIBS_OPTIONAL}
 	pthread
 	m)
+
+if (UMF_BUILD_LIBUMF_POOL_DISJOINT)
+	target_compile_definitions(ubench PRIVATE UMF_BUILD_LIBUMF_POOL_DISJOINT=1)
+endif()

--- a/benchmark/ubench.c
+++ b/benchmark/ubench.c
@@ -7,8 +7,11 @@
  *
  */
 
-#include <umf/pools/pool_disjoint.h>
 #include <umf/providers/provider_os_memory.h>
+
+#ifdef UMF_BUILD_LIBUMF_POOL_DISJOINT
+#include <umf/pools/pool_disjoint.h>
+#endif
 
 #include <stdbool.h>
 #include <unistd.h>
@@ -145,6 +148,7 @@ UBENCH_EX(simple, os_memory_provider) {
     free(array);
 }
 
+#ifdef UMF_BUILD_LIBUMF_POOL_DISJOINT
 ////////////////// DISJOINT POOL WITH OS MEMORY PROVIDER
 
 static void *w_umfPoolMalloc(void *provider, size_t size, size_t alignment) {
@@ -200,5 +204,6 @@ UBENCH_EX(simple, disjoint_pool_with_os_memory_provider) {
     umfMemoryProviderDestroy(os_memory_provider);
     free(array);
 }
+#endif /* UMF_BUILD_LIBUMF_POOL_DISJOINT */
 
 UBENCH_MAIN();


### PR DESCRIPTION
Turning off disjoint pool (using `UMF_BUILD_LIBUMF_POOL_DISJOINT`) should not turn off benchmark (as it is now).