### PR TITLE
Add asserts for C tests

### DIFF
--- a/test/c_api/disjoint_pool.c
+++ b/test/c_api/disjoint_pool.c
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2024 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -15,10 +15,7 @@ void test_disjoint_pool_default_params(void) {
     umf_disjoint_pool_params_t params = umfDisjointPoolParamsDefault();
     retp = umfPoolCreate(&UMF_DISJOINT_POOL_OPS, provider, &params, &pool);
 
-    // TODO: use asserts
-    if (retp != UMF_RESULT_SUCCESS) {
-        abort();
-    }
+    UT_ASSERTeq(retp, UMF_RESULT_SUCCESS);
 
     umfPoolDestroy(pool);
     umfMemoryProviderDestroy(provider);
@@ -36,10 +33,7 @@ void test_disjoint_pool_shared_limits(void) {
 
     retp = umfPoolCreate(&UMF_DISJOINT_POOL_OPS, provider, &params, &pool);
 
-    // TODO: use asserts
-    if (retp != UMF_RESULT_SUCCESS) {
-        abort();
-    }
+    UT_ASSERTeq(retp, UMF_RESULT_SUCCESS);
 
     umfPoolDestroy(pool);
     umfMemoryProviderDestroy(provider);

--- a/test/common/test_helpers.h
+++ b/test/common/test_helpers.h
@@ -1,11 +1,13 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2024 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// This file contains tests for UMF pool API
+// This file contains helpers for tests for UMF pool API
 
 #ifndef UMF_TEST_HELPERS_H
 #define UMF_TEST_HELPERS_H 1
 
+#include <stdarg.h>
+#include <stdio.h>
 #include <umf/base.h>
 #include <umf/memory_pool.h>
 #include <umf/memory_provider_ops.h>
@@ -13,6 +15,59 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+static inline void UT_FATAL(const char *format, ...) {
+    va_list args_list;
+    va_start(args_list, format);
+    vfprintf(stderr, format, args_list);
+    va_end(args_list);
+
+    fprintf(stderr, "\n");
+
+    abort();
+}
+
+static inline void UT_OUT(const char *format, ...) {
+    va_list args_list;
+    va_start(args_list, format);
+    vfprintf(stdout, format, args_list);
+    va_end(args_list);
+
+    fprintf(stdout, "\n");
+}
+
+// Assert a condition is true at runtime
+#define UT_ASSERT(cnd)                                                         \
+    ((void)((cnd) || (UT_FATAL("%s:%d %s - assertion failure: %s", __FILE__,   \
+                               __LINE__, __func__, #cnd),                      \
+                      0)))
+
+// Assertion with extra info printed if assertion fails at runtime
+#define UT_ASSERTinfo(cnd, info)                                               \
+    ((void)((cnd) ||                                                           \
+            (UT_FATAL("%s:%d %s - assertion failure: %s (%s = %s)", __FILE__,  \
+                      __LINE__, __func__, #cnd, #info, info),                  \
+             0)))
+
+// Assert two integer values are equal at runtime
+#define UT_ASSERTeq(lhs, rhs)                                                  \
+    ((void)(((lhs) == (rhs)) ||                                                \
+            (UT_FATAL("%s:%d %s - assertion failure: %s (0x%llx) == %s "       \
+                      "(0x%llx)",                                              \
+                      __FILE__, __LINE__, __func__, #lhs,                      \
+                      (unsigned long long)(lhs), #rhs,                         \
+                      (unsigned long long)(rhs)),                              \
+             0)))
+
+// Assert two integer values are not equal at runtime
+#define UT_ASSERTne(lhs, rhs)                                                  \
+    ((void)(((lhs) != (rhs)) ||                                                \
+            (UT_FATAL("%s:%d %s - assertion failure: %s (0x%llx) != %s "       \
+                      "(0x%llx)",                                              \
+                      __FILE__, __LINE__, __func__, #lhs,                      \
+                      (unsigned long long)(lhs), #rhs,                         \
+                      (unsigned long long)(rhs)),                              \
+             0)))
 
 int bufferIsFilledWithChar(void *ptr, size_t size, char c);
 


### PR DESCRIPTION
This PR adds asserts for C tests (using the implementation from pmemstream: https://github.com/pmem/pmemstream/blob/master/tests/common/unittest.h) and uses them in a c test for disjoint pool.