### PR TITLE
Fix arena_extent_split() and arena_extent_merge()

### DIFF
--- a/src/pool/pool_jemalloc.c
+++ b/src/pool/pool_jemalloc.c
@@ -218,7 +218,7 @@ static bool arena_extent_split(extent_hooks_t *extent_hooks, void *addr,
     (void)arena_ind;    // unused
 
     // TODO: add this function to the provider API to support Windows and USM
-    return false; // false means success (split is a nop)
+    return true; // true means failure (unsupported)
 }
 
 // arena_extent_merge - an extent merge function conforms to the extent_merge_t type and optionally
@@ -239,7 +239,7 @@ static bool arena_extent_merge(extent_hooks_t *extent_hooks, void *addr_a,
     (void)arena_ind;    // unused
 
     // TODO: add this function to the provider API to support Windows and USM
-    return false; // false means success (merge is a nop)
+    return true; // true means failure (unsupported)
 }
 
 // The extent_hooks_t structure comprises function pointers which are described individually below.


### PR DESCRIPTION
Fix a regression introduced by commit 459a492de41a647d6dab2364d2f15c9603bf7a71
With this commit the jemalloc_pool test fails very often, see:
https://github.com/ldorau/unified-memory-framework/actions/workflows/basic.yml?query=branch%3ATest_real_make_install
This patch fixes this issue.

Ref: 459a492de41a647d6dab2364d2f15c9603bf7a71