### PR TITLE
Do not call srand before each rand

### DIFF
--- a/test/malloc_compliance_tests.cpp
+++ b/test/malloc_compliance_tests.cpp
@@ -32,10 +32,7 @@ using umf_test::test;
 // Helpers
 //------------------------------------------------------------------------
 
-static inline size_t rand_alloc_size(int max) {
-    srand(SRAND_INIT_VALUE);
-    return rand() % max;
-}
+static inline size_t rand_alloc_size(int max) { return rand() % max; }
 
 static inline void free_memory(umf_memory_pool_handle_t hPool,
                                void *ptr[ITERATIONS]) {
@@ -50,6 +47,7 @@ static inline void free_memory(umf_memory_pool_handle_t hPool,
 
 // ISO/IEC 9899:TC3 7.20.3.3
 void malloc_compliance_test(umf_memory_pool_handle_t hPool) {
+    srand(SRAND_INIT_VALUE);
     void *alloc_ptr[ITERATIONS];
     size_t alloc_ptr_size[ITERATIONS];
 
@@ -80,6 +78,7 @@ void malloc_compliance_test(umf_memory_pool_handle_t hPool) {
 
 // ISO/IEC 9899:TC3 7.20.3.1
 void calloc_compliance_test(umf_memory_pool_handle_t hPool) {
+    srand(SRAND_INIT_VALUE);
     void *alloc_ptr[ITERATIONS];
     size_t alloc_size;
 
@@ -98,6 +97,7 @@ void calloc_compliance_test(umf_memory_pool_handle_t hPool) {
 
 // ISO/IEC 9899:TC3 7.20.3.4
 void realloc_compliance_test(umf_memory_pool_handle_t hPool) {
+    srand(SRAND_INIT_VALUE);
     // If ptr is a null pointer, the realloc function behaves
     // like the malloc function for the specified size
     void *ret = umfPoolRealloc(hPool, NULL, 10);


### PR DESCRIPTION
It should only be called once, to initialize the seed.
Otherwise, all values returned by rand() will be the same.