### PR TITLE
Fix skipping memspace_numa tests

### DIFF
--- a/test/memspace_numa.cpp
+++ b/test/memspace_numa.cpp
@@ -37,17 +37,19 @@ struct numa_nodes_test : ::umf_test::test {
 struct numa_memspace_test : ::numa_nodes_test {
     void SetUp() override {
         ::numa_nodes_test::SetUp();
-
-        enum umf_result_t ret = umfMemspaceCreateFromNumaArray(
-            nodeIds.data(), nodeIds.size(), &memspace);
-        ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
-        ASSERT_NE(memspace, nullptr);
+        if (nodeIds.size()) {
+            enum umf_result_t ret = umfMemspaceCreateFromNumaArray(
+                nodeIds.data(), nodeIds.size(), &memspace);
+            ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+            ASSERT_NE(memspace, nullptr);
+        }
     }
 
     void TearDown() override {
         ::numa_nodes_test::TearDown();
-
-        umfMemspaceDestroy(memspace);
+        if (memspace) {
+            umfMemspaceDestroy(memspace);
+        }
     }
 
     umf_memspace_handle_t memspace = nullptr;
@@ -56,17 +58,19 @@ struct numa_memspace_test : ::numa_nodes_test {
 struct numa_memspace_provider_test : ::numa_memspace_test {
     void SetUp() override {
         ::numa_memspace_test::SetUp();
-
-        umf_result_t ret =
-            umfMemoryProviderCreateFromMemspace(memspace, nullptr, &provider);
-        ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
-        ASSERT_NE(provider, nullptr);
+        if (nodeIds.size()) {
+            umf_result_t ret = umfMemoryProviderCreateFromMemspace(
+                memspace, nullptr, &provider);
+            ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+            ASSERT_NE(provider, nullptr);
+        }
     }
 
     void TearDown() override {
         ::numa_memspace_test::TearDown();
-
-        umfMemoryProviderDestroy(provider);
+        if (provider) {
+            umfMemoryProviderDestroy(provider);
+        }
     }
 
     umf_memory_provider_handle_t provider = nullptr;


### PR DESCRIPTION
Fix skipping memspace_numa tests.
`GTEST_SKIP()` called in `numa_nodes_test` does not skip `numa_memspace_test` and `numa_memspace_provider_test` tests.

It fixes the following test failure:
```
[----------] 1 test from numa_memspace_test
[ RUN      ] numa_memspace_test.provider_from_numa_memspace
/home/ldorau/work/unified-memory-framework/test/memspace_numa.cpp:21: Skipped
Failed to initialize libnuma
/home/ldorau/work/unified-memory-framework/test/memspace_numa.cpp:43: Failure
Expected equality of these values:
  ret
    Which is: 3
  UMF_RESULT_SUCCESS
    Which is: 0
umf_test-memspace_numa: /home/ldorau/work/unified-memory-framework/src/memspace.c:101: umfMemspaceDestroy: Assertion `memspace' failed.


90% tests passed, 1 tests failed out of 10

Label Time Summary:
umf    =   2.71 sec*proc (10 tests)

Total Test time (real) =   2.72 sec

The following tests FAILED:
         10 - umf-memspace_numa (Subprocess aborted)
Errors while running CTest
```