### PR TITLE
Add missing lib dependency to the test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -103,5 +103,6 @@ if(UMF_BUILD_OS_MEMORY_PROVIDER AND LINUX) # OS-specific functions are implement
                  SRCS provider_os_memory.cpp
                  LIBS umf_utils)
     add_umf_test(NAME memspace_numa
-                 SRCS memspace_numa.cpp)
+                 SRCS memspace_numa.cpp
+                 LIBS numa)
 endif()


### PR DESCRIPTION
The test calls `numa_available` and `numa_max_node` from libnuma