### PR TITLE
Expose 'metadata_use_provider' for jemalloc pool

### DIFF
--- a/include/umf/pools/pool_jemalloc.h
+++ b/include/umf/pools/pool_jemalloc.h
@@ -10,11 +10,19 @@
 #ifndef UMF_JEMALLOC_MEMORY_POOL_H
 #define UMF_JEMALLOC_MEMORY_POOL_H 1
 
+#include <stdbool.h>
+
+#include <umf/memory_pool_ops.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include <umf/memory_pool_ops.h>
+/// Configuration of Jemalloc pool
+typedef struct umf_jemalloc_pool_params_t {
+    /// Use memory provider for metadata allocations when true
+    bool metadata_use_provider;
+} umf_jemalloc_pool_params_t;
 
 extern umf_memory_pool_ops_t UMF_JEMALLOC_POOL_OPS;
 

--- a/test/pools/jemalloc_pool.cpp
+++ b/test/pools/jemalloc_pool.cpp
@@ -22,6 +22,65 @@ static umf_os_memory_provider_params_t UMF_OS_MEMORY_PROVIDER_PARAMS = {
     /* .traces = */ 0,
 };
 
+using umf_test::test;
+using namespace umf_test;
+
+TEST_F(test, metadataUseProvider) {
+    size_t allocSize = 1024;
+    umf_jemalloc_pool_params_t metadataByMallocParams;
+    metadataByMallocParams.metadata_use_provider = false;
+
+    umf_jemalloc_pool_params_t metadataByProviderParams;
+    metadataByProviderParams.metadata_use_provider = true;
+
+    static size_t numAllocs = 0;
+    struct memory_provider : public umf_test::provider_base_t {
+        umf_result_t alloc(size_t size, size_t, void **ptr) noexcept {
+            *ptr = malloc(size);
+            numAllocs++;
+            return UMF_RESULT_SUCCESS;
+        }
+        umf_result_t free(void *ptr, [[maybe_unused]] size_t size) noexcept {
+            ::free(ptr);
+            return UMF_RESULT_SUCCESS;
+        }
+    };
+    umf_memory_provider_ops_t provider_ops =
+        umf::providerMakeCOps<memory_provider, void>();
+
+    umf_result_t res = UMF_RESULT_ERROR_UNKNOWN;
+    umf::pool_unique_handle_t poolMetadataByMalloc;
+    try {
+        poolMetadataByMalloc =
+            poolCreateExt<ErrorReportingStrategyType::Exception>(
+                {&UMF_JEMALLOC_POOL_OPS, (void *)&metadataByMallocParams,
+                 &provider_ops, nullptr});
+        res = UMF_RESULT_SUCCESS;
+    } catch (umf_result_t &status) {
+        res = status;
+    }
+
+    if (res == UMF_RESULT_ERROR_NOT_SUPPORTED) {
+        GTEST_SKIP() << "Wrong version of jemalloc";
+    }
+    ASSERT_EQ(res, UMF_RESULT_SUCCESS);
+
+    auto *ptr1 = umfPoolMalloc(poolMetadataByMalloc.get(), allocSize);
+    auto numAllocsPoolMetadataByMalloc = numAllocs;
+
+    numAllocs = 0;
+
+    auto poolMetadataByProvider = poolCreateExt(
+        {&UMF_JEMALLOC_POOL_OPS, (void *)&metadataByProviderParams,
+         &provider_ops, nullptr});
+    auto *ptr2 = umfPoolMalloc(poolMetadataByProvider.get(), allocSize);
+
+    ASSERT_GT(numAllocs, numAllocsPoolMetadataByMalloc);
+
+    umfFree(ptr1);
+    umfFree(ptr2);
+}
+
 INSTANTIATE_TEST_SUITE_P(jemallocPoolTest, umfPoolTest,
                          ::testing::Values(poolCreateExtParams{
                              &UMF_JEMALLOC_POOL_OPS, nullptr,


### PR DESCRIPTION
TODO: the test doesn't seem to work... That is, even if I don't set `metadat_use_provider=false` jemalloc doesn't seem to allocate metadata using hooks.