### PR TITLE
Link jemalloc pool and test with libc explicitly to avoid recursive calls to jemalloc (tmp fix)

### DIFF
--- a/src/pool/CMakeLists.txt
+++ b/src/pool/CMakeLists.txt
@@ -30,10 +30,12 @@ endif()
 # libumf_pool_jemalloc
 if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
     if(LINUX)
+        # TODO: we link directly with libc to force using malloc from glibc
+        # This is a temporary fix for https://github.com/oneapi-src/unified-memory-framework/issues/161
         add_umf_library(NAME jemalloc_pool
                         TYPE STATIC
                         SRCS pool_jemalloc.c
-                        LIBS jemalloc umf_utils)
+                        LIBS c jemalloc umf_utils)
         add_library(${PROJECT_NAME}::jemalloc_pool ALIAS jemalloc_pool)
         install(TARGETS jemalloc_pool
             EXPORT ${PROJECT_NAME}-targets

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -80,9 +80,11 @@ endif()
 
 if(UMF_BUILD_OS_MEMORY_PROVIDER)
     if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
+        # TODO: we link directly with libc to force using malloc from glibc
+        # This is a temporary fix for https://github.com/oneapi-src/unified-memory-framework/issues/161
         add_umf_test(NAME jemalloc_pool
                     SRCS pools/jemalloc_pool.cpp malloc_compliance_tests.cpp
-                    LIBS jemalloc_pool)
+                    LIBS c jemalloc_pool)
     endif()
 else()
     message(STATUS "The jemalloc_pool test is DISABLED, because it uses OS_MEMORY_PROVIDER, while the UMF_BUILD_OS_MEMORY_PROVIDER option is set to OFF")


### PR DESCRIPTION
This forces the linker to link with libc before linking with jemalloc. Because of that, jemalloc will not override symbols for malloc/free.

Without this patch, we would call `malloc` from within the `arena_extent_alloc`  (jemalloc hook) that would be intercepted by jemalloc.

This fixes the issue with debug jemalloc when running tests with tracking enabled:
```
<jemalloc>: Should own 0 locks of rank >= 14: extent_grow(17)
Aborted (core dumped)
```