### PR TITLE
Implement umfMemoryProviderAllocation[Split/Merge]

### DIFF
--- a/include/umf/memory_provider.h
+++ b/include/umf/memory_provider.h
@@ -156,6 +156,34 @@ umfMemoryProviderGetName(umf_memory_provider_handle_t hProvider);
 ///
 UMF_EXPORT umf_memory_provider_handle_t umfGetLastFailedMemoryProvider(void);
 
+///
+/// @brief Splits a coarse grain allocation into 2 adjacent allocations that
+///        can be managed (freed) separately.
+/// @param hProvider handle to the memory provider
+/// @param ptr pointer to the beginning of the allocation
+/// @param totalSize total size of the allocation to be split
+/// @param firstSize size of the first new allocation, second allocation
+//         has a size equal to totalSize - firstSize
+/// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure
+///
+UMF_EXPORT umf_result_t
+umfMemoryProviderAllocationSplit(umf_memory_provider_handle_t hProvider,
+                                 void *ptr, size_t totalSize, size_t firstSize);
+
+///
+/// @brief Merges two coarse grain allocations into a single allocation that
+///        can be managed (freed) as a whole.
+/// @param hProvider handle to the memory provider
+/// @param lowPtr pointer to the first allocation
+/// @param highPtr pointer to the second allocation (should be > lowPtr)
+/// @param totalSize size of a new merged allocation. Should be equal
+///        to the sum of sizes of allocations beginning at lowPtr and highPtr
+/// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure
+///
+UMF_EXPORT umf_result_t
+umfMemoryProviderAllocationMerge(umf_memory_provider_handle_t hProvider,
+                                 void *lowPtr, void *highPtr, size_t totalSize);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/umf/memory_provider_ops.h
+++ b/include/umf/memory_provider_ops.h
@@ -139,6 +139,32 @@ typedef struct umf_memory_provider_ops_t {
     /// @return pointer to a string containing the name of the \p provider
     ///
     const char *(*get_name)(void *provider);
+
+    ///
+    /// @brief Splits a coarse grain allocation into 2 adjacent allocations that
+    ///        can be managed (freed) separately.
+    /// @param hProvider handle to the memory provider
+    /// @param ptr pointer to the beginning of the allocation
+    /// @param totalSize total size of the allocation to be split
+    /// @param firstSize size of the first new allocation, second allocation
+    //         has a size equal to totalSize - firstSize
+    /// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure
+    ///
+    umf_result_t (*allocation_split)(void *hProvider, void *ptr,
+                                     size_t totalSize, size_t firstSize);
+
+    ///
+    /// @brief Merges two coarse grain allocations into a single allocation that
+    ///        can be managed (freed) as a whole.
+    /// @param hProvider handle to the memory provider
+    /// @param lowPtr pointer to the first allocation
+    /// @param highPtr pointer to the second allocation (should be > lowPtr)
+    /// @param totalSize size of a new merged allocation. Should be equal
+    ///        to the sum of sizes of allocations beginning at lowPtr and highPtr
+    /// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure
+    ///
+    umf_result_t (*allocation_merge)(void *hProvider, void *lowPtr,
+                                     void *highPtr, size_t totalSize);
 } umf_memory_provider_ops_t;
 
 #ifdef __cplusplus

--- a/src/pool/pool_jemalloc.c
+++ b/src/pool/pool_jemalloc.c
@@ -210,15 +210,15 @@ static bool arena_extent_split(extent_hooks_t *extent_hooks, void *addr,
                                size_t size, size_t size_a, size_t size_b,
                                bool committed, unsigned arena_ind) {
     (void)extent_hooks; // unused
-    (void)addr;         // unused
-    (void)size;         // unused
-    (void)size_a;       // unused
-    (void)size_b;       // unused
     (void)committed;    // unused
-    (void)arena_ind;    // unused
+    (void)size_b;
 
-    // TODO: add this function to the provider API to support Windows and USM
-    return true; // true means failure (unsupported)
+    assert(size_a + size_b == size);
+
+    jemalloc_memory_pool_t *pool = get_pool_by_arena_index(arena_ind);
+    assert(pool);
+    return umfMemoryProviderAllocationSplit(pool->provider, addr, size,
+                                            size_a) != UMF_RESULT_SUCCESS;
 }
 
 // arena_extent_merge - an extent merge function conforms to the extent_merge_t type and optionally
@@ -231,15 +231,13 @@ static bool arena_extent_merge(extent_hooks_t *extent_hooks, void *addr_a,
                                size_t size_a, void *addr_b, size_t size_b,
                                bool committed, unsigned arena_ind) {
     (void)extent_hooks; // unused
-    (void)addr_a;       // unused
-    (void)addr_b;       // unused
-    (void)size_a;       // unused
-    (void)size_b;       // unused
     (void)committed;    // unused
-    (void)arena_ind;    // unused
 
-    // TODO: add this function to the provider API to support Windows and USM
-    return true; // true means failure (unsupported)
+    jemalloc_memory_pool_t *pool = get_pool_by_arena_index(arena_ind);
+    assert(pool);
+    return umfMemoryProviderAllocationMerge(pool->provider, addr_a, addr_b,
+                                            size_a + size_b) !=
+           UMF_RESULT_SUCCESS;
 }
 
 // The extent_hooks_t structure comprises function pointers which are described individually below.

--- a/src/pool/pool_scalable.c
+++ b/src/pool/pool_scalable.c
@@ -121,7 +121,7 @@ static void tbb_raw_free_wrapper(intptr_t pool_id, void *ptr, size_t bytes) {
         TLS_last_free_error = ret;
         fprintf(
             stderr,
-            "Memory provider failed to free memory, addr = %p, size = %lu\n",
+            "Memory provider failed to free memory, addr = %p, size = %zu\n",
             ptr, bytes);
     }
 }

--- a/src/provider/provider_os_memory.c
+++ b/src/provider/provider_os_memory.c
@@ -449,6 +449,26 @@ static const char *os_get_name(void *provider) {
     return "OS";
 }
 
+static umf_result_t os_allocation_split(void *provider, void *ptr,
+                                        size_t totalSize, size_t firstSize) {
+    (void)provider;
+    (void)ptr;
+    (void)totalSize;
+    (void)firstSize;
+    // nop
+    return UMF_RESULT_SUCCESS;
+}
+
+static umf_result_t os_allocation_merge(void *provider, void *lowPtr,
+                                        void *highPtr, size_t totalSize) {
+    (void)provider;
+    (void)lowPtr;
+    (void)highPtr;
+    (void)totalSize;
+    // nop
+    return UMF_RESULT_SUCCESS;
+}
+
 umf_memory_provider_ops_t UMF_OS_MEMORY_PROVIDER_OPS = {
     .version = UMF_VERSION_CURRENT,
     .initialize = os_initialize,
@@ -461,4 +481,5 @@ umf_memory_provider_ops_t UMF_OS_MEMORY_PROVIDER_OPS = {
     .purge_lazy = os_purge_lazy,
     .purge_force = os_purge_force,
     .get_name = os_get_name,
-};
+    .allocation_split = os_allocation_split,
+    .allocation_merge = os_allocation_merge};

--- a/src/provider/provider_tracking.c
+++ b/src/provider/provider_tracking.c
@@ -9,6 +9,7 @@
 
 #include "provider_tracking.h"
 #include "critnib.h"
+#include "utils_concurrency.h"
 
 #include <umf/memory_pool.h>
 #include <umf/memory_provider.h>
@@ -16,6 +17,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <stdio.h>
 #include <stdlib.h>
 
 typedef struct tracker_value_t {
@@ -32,7 +34,7 @@ static umf_result_t umfMemoryTrackerAdd(umf_memory_tracker_handle_t hTracker,
     value->pool = pool;
     value->size = size;
 
-    int ret = critnib_insert((critnib *)hTracker, (uintptr_t)ptr, value, 0);
+    int ret = critnib_insert(hTracker->map, (uintptr_t)ptr, value, 0);
 
     if (ret == 0) {
         return UMF_RESULT_SUCCESS;
@@ -59,7 +61,7 @@ static umf_result_t umfMemoryTrackerRemove(umf_memory_tracker_handle_t hTracker,
     // umfMemoryTrackerRemove call with the same ptr value.
     (void)size;
 
-    void *value = critnib_remove((critnib *)hTracker, (uintptr_t)ptr);
+    void *value = critnib_remove(hTracker->map, (uintptr_t)ptr);
     if (!value) {
         // This should not happen
         // TODO: add logging here
@@ -77,7 +79,7 @@ umfMemoryTrackerGetPool(umf_memory_tracker_handle_t hTracker, const void *ptr) {
 
     uintptr_t rkey;
     tracker_value_t *rvalue;
-    int found = critnib_find((critnib *)hTracker, (uintptr_t)ptr, FIND_LE,
+    int found = critnib_find(hTracker->map, (uintptr_t)ptr, FIND_LE,
                              (void *)&rkey, (void **)&rvalue);
     if (!found) {
         return NULL;
@@ -116,6 +118,164 @@ static umf_result_t trackingAlloc(void *hProvider, size_t size,
         }
     }
 
+    return ret;
+}
+
+static umf_result_t trackingAllocationSplit(void *hProvider, void *ptr,
+                                            size_t totalSize,
+                                            size_t firstSize) {
+    umf_result_t ret = UMF_RESULT_ERROR_UNKNOWN;
+    umf_tracking_memory_provider_t *provider =
+        (umf_tracking_memory_provider_t *)hProvider;
+
+    tracker_value_t *splitValue =
+        (tracker_value_t *)malloc(sizeof(tracker_value_t));
+    if (!splitValue) {
+        return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    splitValue->pool = provider->pool;
+    splitValue->size = firstSize;
+
+    int r = util_mutex_lock(provider->hTracker->splitMergeMutex);
+    if (r) {
+        goto err_lock;
+    }
+
+    tracker_value_t *value =
+        (tracker_value_t *)critnib_get(provider->hTracker->map, (uintptr_t)ptr);
+    if (!value) {
+        fprintf(stderr, "tracking split: no such value\n");
+        ret = UMF_RESULT_ERROR_INVALID_ARGUMENT;
+        goto err;
+    }
+    if (value->size != totalSize) {
+        fprintf(stderr, "tracking split: %zu != %zu\n", value->size, totalSize);
+        ret = UMF_RESULT_ERROR_INVALID_ARGUMENT;
+        goto err;
+    }
+
+    ret = umfMemoryProviderAllocationSplit(provider->hUpstream, ptr, totalSize,
+                                           firstSize);
+    if (ret != UMF_RESULT_SUCCESS) {
+        fprintf(stderr,
+                "tracking split: umfMemoryProviderAllocationSplit failed\n");
+        goto err;
+    }
+
+    void *highPtr = (void *)(((uintptr_t)ptr) + firstSize);
+    size_t secondSize = totalSize - firstSize;
+
+    // We'll have a duplicate entry for the range [highPtr, highValue->size] but this is fine,
+    // the value is the same anyway and we forbid removing that range concurrently
+    ret = umfMemoryTrackerAdd(provider->hTracker, provider->pool, highPtr,
+                              secondSize);
+    if (ret != UMF_RESULT_SUCCESS) {
+        fprintf(stderr, "tracking split: umfMemoryTrackerAdd failed\n");
+        // TODO: what now? should we rollback the split? This can only happen due to ENOMEM
+        // so it's unlikely but probably the best solution would be to try to preallocate everything
+        // (value and critnib nodes) before calling umfMemoryProviderAllocationSplit.
+        goto err;
+    }
+
+    int cret = critnib_insert(provider->hTracker->map, (uintptr_t)ptr,
+                              (void *)splitValue, 1 /* update */);
+    // this cannot fail since we know the element exists (nothing to allocate)
+    assert(cret == 0);
+    (void)cret;
+
+    // free the original value
+    free(value);
+    util_mutex_unlock(provider->hTracker->splitMergeMutex);
+
+    return UMF_RESULT_SUCCESS;
+
+err:
+    util_mutex_unlock(provider->hTracker->splitMergeMutex);
+err_lock:
+    free(splitValue);
+    return ret;
+}
+
+static umf_result_t trackingAllocationMerge(void *hProvider, void *lowPtr,
+                                            void *highPtr, size_t totalSize) {
+    umf_result_t ret = UMF_RESULT_ERROR_UNKNOWN;
+    umf_tracking_memory_provider_t *provider =
+        (umf_tracking_memory_provider_t *)hProvider;
+
+    tracker_value_t *mergedValue =
+        (tracker_value_t *)malloc(sizeof(tracker_value_t));
+    if (!mergedValue) {
+        return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    mergedValue->pool = provider->pool;
+    mergedValue->size = totalSize;
+
+    int r = util_mutex_lock(provider->hTracker->splitMergeMutex);
+    if (r) {
+        goto err_lock;
+    }
+
+    tracker_value_t *lowValue = (tracker_value_t *)critnib_get(
+        provider->hTracker->map, (uintptr_t)lowPtr);
+    if (!lowValue) {
+        fprintf(stderr, "tracking merge: no left value\n");
+        ret = UMF_RESULT_ERROR_INVALID_ARGUMENT;
+        goto err;
+    }
+    tracker_value_t *highValue = (tracker_value_t *)critnib_get(
+        provider->hTracker->map, (uintptr_t)highPtr);
+    if (!highValue) {
+        fprintf(stderr, "tracking merge: no right value\n");
+        ret = UMF_RESULT_ERROR_INVALID_ARGUMENT;
+        goto err;
+    }
+    if (lowValue->pool != highValue->pool) {
+        fprintf(stderr, "tracking merge: pool mismatch\n");
+        ret = UMF_RESULT_ERROR_INVALID_ARGUMENT;
+        goto err;
+    }
+    if (lowValue->size + highValue->size != totalSize) {
+        fprintf(stderr, "tracking merge: lowValue->size + highValue->size != "
+                        "totalSize\n");
+        ret = UMF_RESULT_ERROR_INVALID_ARGUMENT;
+        goto err;
+    }
+
+    ret = umfMemoryProviderAllocationMerge(provider->hUpstream, lowPtr, highPtr,
+                                           totalSize);
+    if (ret != UMF_RESULT_SUCCESS) {
+        fprintf(stderr,
+                "tracking merge: umfMemoryProviderAllocationMerge failed\n");
+        goto err;
+    }
+
+    // We'll have a duplicate entry for the range [highPtr, highValue->size] but this is fine,
+    // the value is the same anyway and we forbid removing that range concurrently
+    int cret = critnib_insert(provider->hTracker->map, (uintptr_t)lowPtr,
+                              (void *)mergedValue, 1 /* update */);
+    // this cannot fail since we know the element exists (nothing to allocate)
+    assert(cret == 0);
+    (void)cret;
+
+    // free old value that we just replaced with mergedValue
+    free(lowValue);
+
+    void *erasedhighValue =
+        critnib_remove(provider->hTracker->map, (uintptr_t)highPtr);
+    assert(erasedhighValue == highValue);
+
+    free(erasedhighValue);
+
+    util_mutex_unlock(provider->hTracker->splitMergeMutex);
+
+    return UMF_RESULT_SUCCESS;
+
+err:
+    util_mutex_unlock(provider->hTracker->splitMergeMutex);
+err_lock:
+    free(mergedValue);
     return ret;
 }
 
@@ -214,7 +374,8 @@ umf_memory_provider_ops_t UMF_TRACKING_MEMORY_PROVIDER_OPS = {
     .purge_force = trackingPurgeForce,
     .purge_lazy = trackingPurgeLazy,
     .get_name = trackingName,
-};
+    .allocation_split = trackingAllocationSplit,
+    .allocation_merge = trackingAllocationMerge};
 
 umf_result_t umfTrackingMemoryProviderCreate(
     umf_memory_provider_handle_t hUpstream, umf_memory_pool_handle_t hPool,

--- a/src/provider/provider_tracking.h
+++ b/src/provider/provider_tracking.h
@@ -10,9 +10,14 @@
 #ifndef UMF_MEMORY_TRACKER_INTERNAL_H
 #define UMF_MEMORY_TRACKER_INTERNAL_H 1
 
+#include <assert.h>
+
 #include <umf/base.h>
 #include <umf/memory_pool.h>
 #include <umf/memory_provider.h>
+
+#include "critnib.h"
+#include "utils_concurrency.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,7 +25,45 @@ extern "C" {
 
 extern umf_memory_provider_ops_t UMF_TRACKING_MEMORY_PROVIDER_OPS;
 
+struct umf_memory_tracker_t {
+    critnib *map;
+    os_mutex_t *splitMergeMutex;
+};
+
 typedef struct umf_memory_tracker_t *umf_memory_tracker_handle_t;
+
+static inline umf_memory_tracker_handle_t umfMemoryTrackerCreate(void) {
+    umf_memory_tracker_handle_t handle = (umf_memory_tracker_handle_t)malloc(
+        sizeof(struct umf_memory_tracker_t));
+    if (!handle) {
+        return NULL;
+    }
+
+    handle->map = critnib_new();
+    if (!handle->map) {
+        free(handle);
+        return NULL;
+    }
+
+    handle->splitMergeMutex = util_mutex_create();
+    if (!handle->splitMergeMutex) {
+        critnib_delete(handle->map);
+        free(handle);
+        return NULL;
+    }
+
+    return handle;
+}
+
+static inline void umfMemoryTrackerDestroy(umf_memory_tracker_handle_t handle) {
+    if (!handle) {
+        return;
+    }
+
+    critnib_delete(handle->map);
+    util_mutex_destroy(handle->splitMergeMutex);
+    free(handle);
+}
 
 umf_memory_tracker_handle_t umfMemoryTrackerGet(void);
 umf_memory_pool_handle_t

--- a/src/provider/provider_tracking_linux.c
+++ b/src/provider/provider_tracking_linux.c
@@ -7,18 +7,17 @@
  *
  */
 
-#include "critnib.h"
 #include "provider_tracking.h"
 
 #include <stddef.h>
 
-static critnib *TRACKER = NULL;
+static umf_memory_tracker_handle_t TRACKER;
 
 void __attribute__((constructor)) createLibTracker(void) {
-    TRACKER = critnib_new();
+    TRACKER = umfMemoryTrackerCreate();
 }
 void __attribute__((destructor)) deleteLibTracker(void) {
-    critnib_delete(TRACKER);
+    umfMemoryTrackerDestroy(TRACKER);
 }
 
 void umfTrackingMemoryProviderInit(void) {

--- a/src/provider/provider_tracking_windows.c
+++ b/src/provider/provider_tracking_windows.c
@@ -7,19 +7,19 @@
  *
  */
 
-#include "critnib.h"
 #include "provider_tracking.h"
 
+#include <stdlib.h>
 #include <windows.h>
 
-static critnib *TRACKER = NULL;
+static umf_memory_tracker_handle_t TRACKER = NULL;
 
 #if defined(UMF_SHARED_LIBRARY)
 BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
     if (fdwReason == DLL_PROCESS_DETACH) {
-        critnib_delete(TRACKER);
+        umfMemoryTrackerDestroy(TRACKER);
     } else if (fdwReason == DLL_PROCESS_ATTACH) {
-        TRACKER = critnib_new();
+        TRACKER = umfMemoryTrackerCreate();
     }
     return TRUE;
 }
@@ -30,11 +30,11 @@ void umfTrackingMemoryProviderInit(void) {
 #else
 INIT_ONCE init_once_flag = INIT_ONCE_STATIC_INIT;
 
-static void providerFini(void) { critnib_delete(TRACKER); }
+static void providerFini(void) { umfMemoryTrackerDestroy(TRACKER); }
 
 BOOL CALLBACK providerInit(PINIT_ONCE InitOnce, PVOID Parameter,
                            PVOID *lpContext) {
-    TRACKER = critnib_new();
+    TRACKER = umfMemoryTrackerCreate();
     atexit(providerFini);
     return TRACKER ? TRUE : FALSE;
 }

--- a/src/utils/utils_concurrency.h
+++ b/src/utils/utils_concurrency.h
@@ -1,11 +1,14 @@
 /*
  *
- * Copyright (C) 2023 Intel Corporation
+ * Copyright (C) 2023-2024 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  *
  */
+
+#ifndef UMF_UTILS_CONCURRENCY_H
+#define UMF_UTILS_CONCURRENCY_H 1
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -109,3 +112,5 @@ static inline void *Zalloc(size_t s) {
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* UMF_UTILS_CONCURRENCY_H */


### PR DESCRIPTION
That is needed to support jemalloc (avoid leaking memory).

@kswiecicki could you verify if this solves all the memory leaks? On my machine, it seems to work fine after those changes.