### PR TITLE
Fix small memory leak in the memoryPoolWithCustomProvider test

### DIFF
--- a/test/memoryPoolAPI.cpp
+++ b/test/memoryPoolAPI.cpp
@@ -105,6 +105,7 @@ TEST_F(test, memoryPoolWithCustomProvider) {
     ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
     ASSERT_NE(hPool, nullptr);
 
+    umfPoolDestroy(hPool);
     umfMemoryProviderDestroy(hProvider);
 }
 


### PR DESCRIPTION
The pool has not been destroyed.