### PR TITLE
Use UMF_NUMA_MODE_BIND as the default NUMA mode in memory_target_numa.c

### DIFF
--- a/include/umf/providers/provider_os_memory.h
+++ b/include/umf/providers/provider_os_memory.h
@@ -31,7 +31,7 @@ typedef enum umf_mem_visibility_t {
 } umf_mem_visibility_t;
 
 typedef enum umf_numa_mode_t {
-    UMF_NUMA_MODE_DEFAULT,
+    UMF_NUMA_MODE_DEFAULT, // the nodemask and maxnode arguments must specify the empty set of nodes
     UMF_NUMA_MODE_BIND,
     UMF_NUMA_MODE_INTERLEAVE,
     UMF_NUMA_MODE_PREFERRED,

--- a/src/memory_targets/memory_target_numa.c
+++ b/src/memory_targets/memory_target_numa.c
@@ -50,7 +50,9 @@ static const umf_os_memory_provider_params_t
         // NUMA config
         .nodemask = NULL,
         .maxnode = 0, // TODO: numa_max_node/GetNumaHighestNodeNumber
-        .numa_mode = UMF_NUMA_MODE_DEFAULT,
+        // use UMF_NUMA_MODE_BIND instead of UMF_NUMA_MODE_DEFAULT, because for UMF_NUMA_MODE_DEFAULT
+        // the nodemask and maxnode arguments would have to specify the empty set of nodes
+        .numa_mode = UMF_NUMA_MODE_BIND,
         .numa_flags = UMF_NUMA_FLAGS_STRICT, // TODO: determine default behavior
 
         // Logging


### PR DESCRIPTION
Use UMF_NUMA_MODE_BIND instead of UMF_NUMA_MODE_DEFAULT as the default NUMA mode in memory_target_numa.c, because for UMF_NUMA_MODE_DEFAULT the nodemask and maxnode arguments would have to specify the empty set of nodes. With UMF_NUMA_MODE_DEFAULT and non-empty the nodemask and maxnode arguments the bind() function fails with EINVAL.

Fixes: #149