### PR TITLE
ASan workflow fix

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -17,7 +17,7 @@ jobs:
         pool_tracking: ['ON', 'OFF']
         shared_library: ['OFF']
         os_provider: ['ON']
-        sanitizers: [{asan: 'OFF', ubsan: 'OFF', tsan: 'OFF'}]
+        sanitizers: [{asan: OFF, ubsan: OFF, tsan: OFF}]
         include:
           - os: 'ubuntu-20.04'
             build_type: Release
@@ -53,13 +53,25 @@ jobs:
             pool_tracking: 'OFF'
             shared_library: 'OFF'
           # TSAN is mutually exclusive with other sanitizers
-            sanitizers: [{asan: 'ON', ubsan: 'ON', tsan: 'OFF'}, {asan: 'OFF', ubsan: 'OFF', tsan: 'ON'}]
+            sanitizers: {asan: ON, ubsan: ON, tsan: OFF}
+          - os: 'ubuntu-22.04'
+            build_type: Debug
+            compiler: {c: clang, cxx: clang++}
+            pool_tracking: 'OFF'
+            shared_library: 'OFF'
+            sanitizers: {asan: OFF, ubsan: OFF, tsan: ON}
           - os: 'ubuntu-22.04'
             build_type: Debug
             compiler: {c: gcc, cxx: g++}
             pool_tracking: 'OFF'
             shared_library: 'OFF'
-            sanitizers: [{asan: 'ON', ubsan: 'ON', tsan: 'OFF'}, {asan: 'OFF', ubsan: 'OFF', tsan: 'ON'}]
+            sanitizers: {asan: ON, ubsan: ON, tsan: OFF}
+          - os: 'ubuntu-22.04'
+            build_type: Debug
+            compiler: {c: gcc, cxx: g++}
+            pool_tracking: 'OFF'
+            shared_library: 'OFF'
+            sanitizers: {asan: OFF, ubsan: OFF, tsan: ON}
     runs-on: ${{matrix.os}}
 
     steps:
@@ -123,8 +135,6 @@ jobs:
         compiler: [{c: cl, cxx: cl}]
         pool_tracking: ['ON', 'OFF']
         shared_library: ['OFF']
-        # ASAN is the only available sanitizer on Windows
-        sanitizers: [{asan: 'OFF'}]
         include:
           - os: 'windows-2022'
             build_type: Release
@@ -136,18 +146,6 @@ jobs:
             compiler: {c: cl, cxx: cl}
             pool_tracking: 'ON'
             shared_library: 'ON'
-          - os: 'windows-2022'
-            build_type: Debug
-            compiler: {c: clang-cl, cxx: clang-cl}
-            pool_tracking: 'OFF'
-            shared_library: 'OFF'
-            sanitizers: [{asan: 'ON'}]
-          - os: 'windows-2022'
-            build_type: Debug
-            compiler: {c: cl, cxx: cl}
-            pool_tracking: 'OFF'
-            shared_library: 'OFF'
-            sanitizers: [{asan: 'ON'}]
 
     runs-on: ${{matrix.os}}
 
@@ -166,7 +164,6 @@ jobs:
           -DUMF_FORMAT_CODE_STYLE=OFF
           -DUMF_DEVELOPER_MODE=ON
           -DUMF_BUILD_LIBUMF_POOL_DISJOINT=ON
-          -DUSE_ASAN=${{matrix.sanitizers.asan}}
 
       - name: Build UMF
         run: cmake --build ${{env.BUILD_DIR}} --config ${{matrix.build_type}} -j $Env:NUMBER_OF_PROCESSORS


### PR DESCRIPTION
Enabling ASan for MSVC is more complicated than other compilers and wasn't working correctly. The changes made in https://github.com/oneapi-src/unified-memory-framework/pull/121 were not properly tested by the GHA jobs. To test the changes in `basic.yml` workflow file on this PR, I've temporarily changed the `.github/workflows/pr_push.yml` to retrieve workflow file from my fork.

For the time being, enabling ASan workflows on MSVC requires further investigation. Currently, even though CMake positively tests MSVC for ASan support and compiles the UMF project without errors, the UMF tests return `0xc0000135` error code which is `STATUS_DLL_NOT_FOUND`. Appending the `PATH` env var with the directory containing ASan lib (eg. `C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.32.31326\bin\Hostx64\x64`) changes the error code to `0xc0000142` which is `STATUS_DLL_INIT_FAILED`. I've confirmed that the compiler used to build UMF comes from the same directory as ASan lib.