### PR TITLE
[CI] Use local reusable workflows

### DIFF
--- a/.github/workflows/pr_push.yml
+++ b/.github/workflows/pr_push.yml
@@ -73,13 +73,13 @@ jobs:
           cmake --build build --target clang-format-check  
 
     Spellcheck:
-        uses: oneapi-src/unified-memory-framework/.github/workflows/spellcheck.yml@main
+        uses: ./.github/workflows/spellcheck.yml
     Build:
         needs: [Spellcheck, FastBuild, CodeStyle]
-        uses: oneapi-src/unified-memory-framework/.github/workflows/basic.yml@main
+        uses: ./.github/workflows/basic.yml
     Benchmark:
         needs: [Build]
-        uses: oneapi-src/unified-memory-framework/.github/workflows/benchmarks.yml@main
+        uses: ./.github/workflows/benchmarks.yml
     CodeQL:
         needs: [Build]
-        uses: oneapi-src/unified-memory-framework/.github/workflows/codeql.yml@main
+        uses: ./.github/workflows/codeql.yml


### PR DESCRIPTION
If not specified, workflows from the same commit will be used.

Ref:
https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow


This PR is prepared due to an issue encountered around sanitizers... (ref. #154).

// Tested when it should not work: https://github.com/lukaszstolarczuk/unified-memory-framework/actions/runs/7571300540/job/20618545502