### PR TITLE
Update C++17 requirement cases

### DIFF
--- a/.github/workflows/pr_push.yml
+++ b/.github/workflows/pr_push.yml
@@ -11,15 +11,16 @@ jobs:
         name: Fast build
         strategy:
             matrix:
-                os: [ubuntu-latest, windows-latest]
+                os: [ubuntu-latest]
+                nproc: ['$(nproc)']
+                pool_scalable: ['ON']
+                disjoint: ['ON', 'OFF']
+                jemalloc: ['ON']
                 include:
-                    - os: ubuntu-latest
-                      nproc: $(nproc)
-                      pool_scalable: 'ON'
-                      jemalloc: 'ON'
                     - os: windows-latest
                       nproc: $Env:NUMBER_OF_PROCESSORS
                       pool_scalable: 'OFF'
+                      disjoint: 'OFF'
                       jemalloc: 'OFF'
         runs-on: ${{matrix.os}}
 
@@ -42,8 +43,9 @@ jobs:
             -DUMF_DEVELOPER_MODE=ON
             -DUMF_ENABLE_POOL_TRACKING=ON
             -DUMF_BUILD_LIBUMF_POOL_SCALABLE=${{matrix.pool_scalable}}
-            -DUMF_BUILD_LIBUMF_POOL_DISJOINT=ON
+            -DUMF_BUILD_LIBUMF_POOL_DISJOINT=${{matrix.disjoint}}
             -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=${{matrix.jemalloc}}
+            -DUMF_BUILD_TESTS=OFF
 
         - name: Build
           run: >

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,17 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 cmake_minimum_required(VERSION 3.14.0 FATAL_ERROR)
-project(unified-memory-framework VERSION 0.1.0)
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED YES)
-
-include(CTest)
-include(CMakePackageConfigHelpers)
-include(GNUInstallDirs)
-
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-include(helpers)
+project(unified-memory-framework VERSION 0.1.0 LANGUAGES C)
 
 # Build Options
 option(UMF_BUILD_SHARED_LIBRARY "Build UMF as shared library" OFF)
@@ -30,6 +20,28 @@ option(USE_ASAN "Enable AddressSanitizer checks" OFF)
 option(USE_UBSAN "Enable UndefinedBehaviorSanitizer checks" OFF)
 option(USE_TSAN "Enable ThreadSanitizer checks" OFF)
 option(USE_MSAN "Enable MemorySanitizer checks" OFF)
+
+# For using the options listed in the OPTIONS_REQUIRING_CXX variable
+# a C++17 compiler is required. Moreover, if these options are not set,
+# CMake will set up a strict C build, without C++ support.
+set(OPTIONS_REQUIRING_CXX
+    "UMF_BUILD_TESTS"
+    "UMF_BUILD_LIBUMF_POOL_DISJOINT")
+foreach(option_name ${OPTIONS_REQUIRING_CXX})
+    if(${option_name})
+        enable_language(CXX)
+        set(CMAKE_CXX_STANDARD 17)
+        set(CMAKE_CXX_STANDARD_REQUIRED YES)
+        break()
+    endif()
+endforeach()
+
+include(CTest)
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(helpers)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     set(LINUX TRUE)

--- a/README.md
+++ b/README.md
@@ -72,11 +72,14 @@ The `UMF_BUILD_LIBUMF_POOL_SCALABLE` option has to be turned `ON` to build this 
 ### Requirements
 
 Required packages:
-- C++ compiler with C++17 support
+- C compiler
 - [CMake](https://cmake.org/) >= 3.14.0
 
 For development and contributions:
 - clang-format-15.0 (can be installed with `python -m pip install clang-format==15.0.7`)
+
+For building tests and Disjoint Pool:
+- C++ compiler with C++17 support
 
 ### Benchmark
 

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -135,7 +135,9 @@ macro(add_sanitizer_flag flag)
 
     # Check C and CXX compilers for given sanitizer flag.
     check_c_compiler_flag("${SANITIZER_FLAG}" "C_${check_name}")
-    check_cxx_compiler_flag("${SANITIZER_FLAG}" "CXX_${check_name}")
+    if (CMAKE_CXX_COMPILE_FEATURES)
+        check_cxx_compiler_flag("${SANITIZER_FLAG}" "CXX_${check_name}")
+    endif()
     if (NOT ${C_${check_name}} OR NOT ${CXX_${check_name}})
         message(FATAL_ERROR "${flag} sanitizer is not supported (either by C or CXX compiler)")
     endif()
@@ -143,8 +145,9 @@ macro(add_sanitizer_flag flag)
     # Check C and CXX compilers for sanitizer arguments.
     if (${SANITIZER_ARGS})
         check_c_compiler_flag("${SANITIZER_ARGS}" "C_HAS_SAN_ARGS")
-        check_cxx_compiler_flag("${SANITIZER_ARGS}" "CXX_HAS_SAN_ARGS")
-
+        if (CMAKE_CXX_COMPILE_FEATURES)
+            check_cxx_compiler_flag("${SANITIZER_ARGS}" "CXX_HAS_SAN_ARGS")
+        endif()
         if (NOT ${C_HAS_SAN_ARGS} OR NOT ${CXX_HAS_SAN_ARGS})
             message(FATAL_ERROR "sanitizer argument ${SANITIZER_ARGS} is not supported (either by C or CXX compiler)")
         endif()

--- a/test/test_base_alloc_linear.c
+++ b/test/test_base_alloc_linear.c
@@ -29,7 +29,8 @@ static void *start_routine(void *arg) {
     long TID = syscall(SYS_gettid);
 
     for (int i = 0; i < ITERATIONS; i++) {
-        buffer[i].size = (rand() * MAX_ALLOCATION_SIZE) / RAND_MAX;
+        buffer[i].size =
+            (size_t)((rand() / (double)RAND_MAX) * MAX_ALLOCATION_SIZE);
         buffer[i].ptr = umf_ba_linear_alloc(pool, buffer[i].size);
         UT_ASSERTne(buffer[i].ptr, NULL);
         memset(buffer[i].ptr, (i + TID) & 0xFF, buffer[i].size);


### PR DESCRIPTION
C++17 is required to build UMF only when two flags are enabled:
- UMF_BUILD_LIBUMF_POOL_DISJOINT,
- UMF_BUILD_TESTS.

In other cases, all is needed is a C compiler.