### PR TITLE
Add linear base allocator

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(UMF_LIBS umf_utils)
 
 set(UMF_SOURCES
     base_alloc/base_alloc.c
+    base_alloc/base_alloc_linear.c
     memory_pool.c
     memory_provider.c
     memory_provider_get_last_failed.c

--- a/src/base_alloc/base_alloc_linear.c
+++ b/src/base_alloc/base_alloc_linear.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+*/
+
+#include <assert.h>
+#include <stdint.h>
+
+#include "base_alloc_internal.h"
+#include "base_alloc_linear.h"
+#include "utils_common.h"
+#include "utils_concurrency.h"
+
+// minimum size of a single pool of the linear base allocator
+#define MINIMUM_LINEAR_POOL_SIZE (ba_os_get_page_size())
+
+// alignment of the linear base allocator
+#define MEMORY_ALIGNMENT (sizeof(uintptr_t))
+
+// metadata of the linear base allocator
+typedef struct {
+    size_t pool_size;
+    os_mutex_t lock;
+    char *data_ptr;
+    size_t size_left;
+} umf_ba_main_linear_pool_meta_t;
+
+// pool of the linear base allocator
+struct umf_ba_linear_pool {
+    umf_ba_main_linear_pool_meta_t metadata;
+    char data[]; // data area starts here
+};
+
+umf_ba_linear_pool_t *umf_ba_linear_create(size_t pool_size) {
+    size_t mutex_size = align_size(util_mutex_get_size(), MEMORY_ALIGNMENT);
+    size_t metadata_size = sizeof(umf_ba_main_linear_pool_meta_t);
+    pool_size = pool_size + metadata_size + mutex_size;
+    if (pool_size < MINIMUM_LINEAR_POOL_SIZE) {
+        pool_size = MINIMUM_LINEAR_POOL_SIZE;
+    }
+
+    pool_size = align_size(pool_size, ba_os_get_page_size());
+
+    umf_ba_linear_pool_t *pool = (umf_ba_linear_pool_t *)ba_os_alloc(pool_size);
+    if (!pool) {
+        return NULL;
+    }
+
+    void *data_ptr = &pool->data;
+    size_t size_left = pool_size - offsetof(umf_ba_linear_pool_t, data);
+
+    align_ptr_size(&data_ptr, &size_left, MEMORY_ALIGNMENT);
+
+    pool->metadata.pool_size = pool_size;
+    pool->metadata.data_ptr = data_ptr;
+    pool->metadata.size_left = size_left;
+
+    // init lock
+    os_mutex_t *lock = util_mutex_init(&pool->metadata.lock);
+    if (!lock) {
+        ba_os_free(pool, pool_size);
+        return NULL;
+    }
+
+    return pool;
+}
+
+void *umf_ba_linear_alloc(umf_ba_linear_pool_t *pool, size_t size) {
+    size_t aligned_size = align_size(size, MEMORY_ALIGNMENT);
+
+    util_mutex_lock(&pool->metadata.lock);
+    if (pool->metadata.size_left < aligned_size) {
+        util_mutex_unlock(&pool->metadata.lock);
+        return NULL; // out of memory
+    }
+
+    void *ptr = pool->metadata.data_ptr;
+    pool->metadata.data_ptr += aligned_size;
+    pool->metadata.size_left -= aligned_size;
+    util_mutex_unlock(&pool->metadata.lock);
+
+    return ptr;
+}
+
+void umf_ba_linear_destroy(umf_ba_linear_pool_t *pool) {
+    util_mutex_destroy_not_free(&pool->metadata.lock);
+    ba_os_free(pool, pool->metadata.pool_size);
+}

--- a/src/base_alloc/base_alloc_linear.h
+++ b/src/base_alloc/base_alloc_linear.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+*/
+
+/*
+ * A MT-safe linear base allocator.
+ * Useful for a few, small and different size allocations
+ * for a most/whole life-time of an application
+ * (since free() is not available).
+ */
+
+#ifndef UMF_BASE_ALLOC_LINEAR_H
+#define UMF_BASE_ALLOC_LINEAR_H 1
+
+#include <stddef.h>
+
+typedef struct umf_ba_linear_pool umf_ba_linear_pool_t;
+
+umf_ba_linear_pool_t *umf_ba_linear_create(size_t pool_size);
+void *umf_ba_linear_alloc(umf_ba_linear_pool_t *pool, size_t size);
+void umf_ba_linear_destroy(umf_ba_linear_pool_t *pool);
+
+#endif /* UMF_BASE_ALLOC_LINEAR_H */

--- a/src/utils/utils_common.h
+++ b/src/utils/utils_common.h
@@ -10,6 +10,7 @@
 #ifndef UMF_COMMON_H
 #define UMF_COMMON_H 1
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -76,6 +77,25 @@ static inline void *Zalloc(size_t s) {
             return errorStatus;                                                \
         }                                                                      \
     } while (0)
+
+// align a pointer and a size
+static inline void align_ptr_size(void **ptr, size_t *size, size_t alignment) {
+    uintptr_t p = (uintptr_t)*ptr;
+    size_t s = *size;
+
+    // align pointer to 'alignment' bytes and adjust the size
+    size_t rest = p & (alignment - 1);
+    if (rest) {
+        p += alignment - rest;
+        s -= alignment - rest;
+    }
+
+    ASSERT((p & (alignment - 1)) == 0);
+    ASSERT((s & (alignment - 1)) == 0);
+
+    *ptr = (void *)p;
+    *size = s;
+}
 
 static inline size_t align_size(size_t size, size_t alignment) {
     // align size to 'alignment' bytes

--- a/src/utils/utils_concurrency.h
+++ b/src/utils/utils_concurrency.h
@@ -14,6 +14,7 @@
 #if defined(_WIN32)
 #include <windows.h>
 #else
+#include <pthread.h>
 #include <stdatomic.h>
 #endif
 
@@ -21,9 +22,13 @@
 extern "C" {
 #endif
 
-struct os_mutex_t;
-
-typedef struct os_mutex_t os_mutex_t;
+typedef struct os_mutex_t {
+#ifdef _WIN32
+    CRITICAL_SECTION lock;
+#else
+    pthread_mutex_t lock;
+#endif
+} os_mutex_t;
 
 size_t util_mutex_get_size(void);
 os_mutex_t *util_mutex_init(void *ptr);

--- a/src/utils/utils_windows_concurrency.c
+++ b/src/utils/utils_windows_concurrency.c
@@ -9,14 +9,10 @@
 
 #include "utils_concurrency.h"
 
-typedef struct {
-    CRITICAL_SECTION lock;
-} internal_os_mutex_t;
-
-size_t util_mutex_get_size(void) { return sizeof(internal_os_mutex_t); }
+size_t util_mutex_get_size(void) { return sizeof(os_mutex_t); }
 
 os_mutex_t *util_mutex_init(void *ptr) {
-    internal_os_mutex_t *mutex_internal = (internal_os_mutex_t *)ptr;
+    os_mutex_t *mutex_internal = (os_mutex_t *)ptr;
     InitializeCriticalSection(&mutex_internal->lock);
     return (os_mutex_t *)mutex_internal;
 }
@@ -26,7 +22,7 @@ os_mutex_t *util_mutex_create(void) {
 }
 
 void util_mutex_destroy_not_free(os_mutex_t *mutex) {
-    internal_os_mutex_t *mutex_internal = (internal_os_mutex_t *)mutex;
+    os_mutex_t *mutex_internal = (os_mutex_t *)mutex;
     DeleteCriticalSection(&mutex_internal->lock);
 }
 
@@ -35,7 +31,7 @@ void util_mutex_destroy(os_mutex_t *mutex) {
 }
 
 int util_mutex_lock(os_mutex_t *mutex) {
-    internal_os_mutex_t *mutex_internal = (internal_os_mutex_t *)mutex;
+    os_mutex_t *mutex_internal = (os_mutex_t *)mutex;
     EnterCriticalSection(&mutex_internal->lock);
 
     if (mutex_internal->lock.RecursionCount > 1) {
@@ -47,7 +43,7 @@ int util_mutex_lock(os_mutex_t *mutex) {
 }
 
 int util_mutex_unlock(os_mutex_t *mutex) {
-    internal_os_mutex_t *mutex_internal = (internal_os_mutex_t *)mutex;
+    os_mutex_t *mutex_internal = (os_mutex_t *)mutex;
     LeaveCriticalSection(&mutex_internal->lock);
     return 0;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -117,4 +117,7 @@ if(LINUX)
     add_umf_test(NAME base_alloc
                 SRCS test_base_alloc.c
                 LIBS umf_utils)
+    add_umf_test(NAME base_alloc_linear
+                SRCS test_base_alloc_linear.c
+                LIBS umf_utils)
 endif()

--- a/test/test_base_alloc_linear.c
+++ b/test/test_base_alloc_linear.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+*/
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "base_alloc_linear.h"
+#include "test_helpers.h"
+
+#define NTHREADS 10
+#define ITERATIONS 1000
+#define MAX_ALLOCATION_SIZE 1024
+
+static void *start_routine(void *arg) {
+    struct buffer_t {
+        unsigned char *ptr;
+        size_t size;
+    } buffer[ITERATIONS];
+    umf_ba_linear_pool_t *pool = (umf_ba_linear_pool_t *)arg;
+
+    long TID = syscall(SYS_gettid);
+
+    for (int i = 0; i < ITERATIONS; i++) {
+        buffer[i].size = (rand() * MAX_ALLOCATION_SIZE) / RAND_MAX;
+        buffer[i].ptr = umf_ba_linear_alloc(pool, buffer[i].size);
+        memset(buffer[i].ptr, (i + TID) & 0xFF, buffer[i].size);
+    }
+
+    for (int i = 0; i < ITERATIONS; i++) {
+        for (int k = 0; k < buffer[i].size; k++) {
+            if (*(buffer[i].ptr + k) != ((i + TID) & 0xFF)) {
+                fprintf(
+                    stderr,
+                    "i = %i k = %i, *(buffer[i].ptr + k) = %i != ((i + TID) & "
+                    "0xFF) = %li\n",
+                    i, k, *(buffer[i].ptr + k), ((i + TID) & 0xFF));
+            }
+            UT_ASSERTeq(*(buffer[i].ptr + k), ((i + TID) & 0xFF));
+        }
+    }
+
+    return NULL;
+}
+
+int main() {
+    pthread_t thread[NTHREADS];
+    umf_ba_linear_pool_t *pool = umf_ba_linear_create(MAX_ALLOCATION_SIZE);
+
+    for (int i = 0; i < NTHREADS; i++) {
+        int ret = pthread_create(&thread[i], NULL, start_routine, pool);
+        if (ret) {
+            fprintf(stderr, "pthread_create() failed!\n");
+            UT_ASSERTeq(ret, 0);
+        }
+    }
+
+    for (int i = 0; i < NTHREADS; i++) {
+        void *retval;
+        int ret = pthread_join(thread[i], &retval);
+        if (ret) {
+            fprintf(stderr, "pthread_join() failed!\n");
+            UT_ASSERTeq(ret, 0);
+        }
+    }
+
+    umf_ba_linear_destroy(pool);
+
+    return 0;
+}


### PR DESCRIPTION
Add a MT-safe linear base allocator. It is useful for a few, small and different size allocations for a most/whole life-time of an application (free() is not available).

It is needed by https://github.com/oneapi-src/unified-memory-framework/pull/178 and https://github.com/oneapi-src/unified-memory-framework/pull/170.