### PR TITLE
[CI] Fix concurrency group name for PR/push workflow

### DIFF
--- a/.github/workflows/pr_push.yml
+++ b/.github/workflows/pr_push.yml
@@ -3,7 +3,7 @@ name: PR/push
 on: [push, pull_request]
 
 concurrency:
-    group: ${{ github.head_ref }}-${{ github.workflow }}
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
     cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
head_ref is only available on PRs. Without this change all pushes ended up being in one group. On upstream it cancels all consecutive main pushes (which is a little undesired), but on forks it canceled all consecutive pushes (which is undesired if you want to test multiple different branches).

This solution is copy-pasted from the UR repo and it works there just fine.

On pushes the group name was like: `-workflow_name`.