### PR TITLE
Fix the test_valgrind.sh script running tests under valgrind

### DIFF
--- a/.github/workflows/.spellcheck-conf.toml
+++ b/.github/workflows/.spellcheck-conf.toml
@@ -1,3 +1,7 @@
 [default]
 # Don't correct the following words:
 extend-ignore-words-re = ["ASSER", "Tne", "ba", "BA"]
+
+[files]
+# completely exclude those files from consideration:
+extend-exclude = ["test/supp/*.supp"]

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,5 +41,4 @@ jobs:
             cmake --build ${{github.workspace}}/build --config Debug -j$(nproc)
 
         - name: Run tests under valgrind
-          working-directory: ${{github.workspace}}/build
-          run: ../test/test_valgrind.sh ${{matrix.tool}}
+          run: ${{github.workspace}}/test/test_valgrind.sh ${{github.workspace}} ${{github.workspace}}/build ${{matrix.tool}}

--- a/test/supp/umf_test-provider_os_memory_config.supp
+++ b/test/supp/umf_test-provider_os_memory_config.supp
@@ -1,0 +1,117 @@
+{
+   Invalid read of size 8
+   Memcheck:Addr8
+   fun:memmove
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_mutateEmmPKcm
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
+   fun:_ZN18providerConfigTest11read_memoryEv
+   fun:_ZN44providerConfigTest_protection_flag_none_Test8TestBodyEv
+   fun:_ZN7testing8internal38HandleSehExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
+   fun:_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
+   fun:_ZN7testing4Test3RunEv
+   fun:_ZN7testing8TestInfo3RunEv
+   fun:_ZN7testing9TestSuite3RunEv
+   fun:_ZN7testing8internal12UnitTestImpl11RunAllTestsEv
+   fun:_ZN7testing8internal38HandleSehExceptionsInMethodIfSupportedINS0_12UnitTestImplEbEET0_PT_MS4_FS3_vEPKc
+}
+
+{
+   Bad permissions for mapped region
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:_Znwm
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_mutateEmmPKcm
+   fun:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm
+   fun:_ZN18providerConfigTest11read_memoryEv
+   fun:_ZN44providerConfigTest_protection_flag_none_Test8TestBodyEv
+   fun:_ZN7testing8internal38HandleSehExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
+   fun:_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
+   fun:_ZN7testing4Test3RunEv
+   fun:_ZN7testing8TestInfo3RunEv
+   fun:_ZN7testing9TestSuite3RunEv
+   fun:_ZN7testing8internal12UnitTestImpl11RunAllTestsEv
+   fun:_ZN7testing8internal38HandleSehExceptionsInMethodIfSupportedINS0_12UnitTestImplEbEET0_PT_MS4_FS3_vEPKc
+}
+
+{
+   4,608 bytes in 2 blocks are possibly lost in loss record 342 of 346
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:malloc
+   fun:_dlfo_mappings_segment_allocate
+   fun:_dl_find_object_update_1
+   fun:_dl_find_object_update
+   fun:dl_open_worker_begin
+   fun:_dl_catch_exception
+   fun:dl_open_worker
+   fun:_dl_catch_exception
+   fun:_dl_open
+   fun:dlopen_doit
+   fun:_dl_catch_exception
+   fun:_dl_catch_error
+   fun:_dlerror_run
+   fun:dlopen_implementation
+   fun:dlopen@@GLIBC_*
+}
+
+{
+   Invalid write of size 8
+   Memcheck:Addr8
+   fun:memset
+   fun:_ZN18providerConfigTest12write_memoryESt17basic_string_viewIcSt11char_traitsIcEE
+   fun:_ZN44providerConfigTest_protection_flag_none_Test8TestBodyEv
+   fun:_ZN7testing8internal38HandleSehExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
+   fun:_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
+   fun:_ZN7testing4Test3RunEv
+   fun:_ZN7testing8TestInfo3RunEv
+   fun:_ZN7testing9TestSuite3RunEv
+   fun:_ZN7testing8internal12UnitTestImpl11RunAllTestsEv
+   fun:_ZN7testing8internal38HandleSehExceptionsInMethodIfSupportedINS0_12UnitTestImplEbEET0_PT_MS4_FS3_vEPKc
+   fun:_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS0_12UnitTestImplEbEET0_PT_MS4_FS3_vEPKc
+   fun:_ZN7testing8UnitTest3RunEv
+}
+
+{
+   4,608 bytes in 2 blocks are possibly lost in loss record 342 of 346
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:malloc
+   fun:_dlfo_mappings_segment_allocate
+   fun:_dl_find_object_update_1
+   fun:_dl_find_object_update
+   fun:dl_open_worker_begin
+   fun:_dl_catch_exception
+   fun:dl_open_worker
+   fun:_dl_catch_exception
+   fun:_dl_open
+   fun:dlopen_doit
+   fun:_dl_catch_exception
+   fun:_dl_catch_error
+   fun:_dlerror_run
+   fun:dlopen_implementation
+   fun:dlopen@@GLIBC_*
+}
+
+{
+   4,608 bytes in 2 blocks are possibly lost in loss record 343 of 347
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:malloc
+   fun:_dlfo_mappings_segment_allocate
+   fun:_dl_find_object_update_1
+   fun:_dl_find_object_update
+   fun:dl_open_worker_begin
+   fun:_dl_catch_exception
+   fun:dl_open_worker
+   fun:_dl_catch_exception
+   fun:_dl_open
+   fun:dlopen_doit
+   fun:_dl_catch_exception
+   fun:_dl_catch_error
+   fun:_dlerror_run
+   fun:dlopen_implementation
+   fun:dlopen@@GLIBC_*
+}


### PR DESCRIPTION
The current script just checks if there is the
"ERROR SUMMARY: 0 errors from 0 contexts"
line in the output of a test.

It turned out that there can be many lines starting with
"ERROR SUMMARY:" in the output of one test - some with
errors and some without, so the current approach is wrong.
We have to check if there are no other lines starting with
"ERROR SUMMARY:" than this:
"ERROR SUMMARY: 0 errors from 0 contexts" instead.
