### PR TITLE
Remove unnecessary print from tests

### DIFF
--- a/test/poolFixtures.hpp
+++ b/test/poolFixtures.hpp
@@ -139,7 +139,6 @@ void pow2AlignedAllocHelper(umf_memory_pool_handle_t pool) {
     static constexpr size_t maxAlignment = (1u << 22);
     static constexpr size_t numAllocs = 4;
     for (size_t alignment = 1; alignment <= maxAlignment; alignment <<= 1) {
-        std::cout << alignment << std::endl;
         std::vector<void *> allocs;
 
         for (size_t alloc = 0; alloc < numAllocs; alloc++) {


### PR DESCRIPTION
This solves some of the issues under drd and valgrind:
https://github.com/oneapi-src/unified-memory-framework/issues/156
https://github.com/oneapi-src/unified-memory-framework/issues/157