### PR TITLE
Upgrade version of CodeQL CI action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@b7bf0a3ed3ecfa44160715d7c442788f65f0f923 # v3.23.2
       with:
         languages: cpp
 
@@ -53,4 +53,4 @@ jobs:
         cmake --build ${{github.workspace}}/build --config Release -j ${{matrix.nproc}}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@b7bf0a3ed3ecfa44160715d7c442788f65f0f923 # v3.23.2


### PR DESCRIPTION
The version v2 of the CodeQL GitHub Action uses deprecated Node 16 Node.js resulting in CI warnings.

```
CodeQL / Analyze (ubuntu-latest)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: github/codeql-action/init@v2, github/codeql-action/analyze@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

CodeQL / Analyze (ubuntu-latest)
CodeQL Action v2 will be deprecated on December 5th, 2024. Please update all occurrences of the CodeQL Action in your workflow files to v3. For more information, see https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/
```