### PR TITLE
Upgrade versions of actions in GitHub Pages CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
         run: python3 generate_docs.py
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@0252fc4ba7626f0298f0cf00902a25c6afc77fa8 # v3.0.0
         with:
           path: docs/html
 
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy the documentation to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@87c3283f01cd6fe19a0ab93a23b2f6fcba5a8e42 # v4.0.3


### PR DESCRIPTION
[Preview](https://github.com/PatKamin/unified-memory-framework/actions/runs/7727031302) of a successful Pages build.

The old version of the upload-artifact action uses old Node.js 16 version resulting in CI warnings below. The other action had to be bumped to be compliant.

[build with warning](https://github.com/PatKamin/unified-memory-framework/actions/runs/7726381566)
```Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.```