### PR TITLE
Fix warning in Scorecard action

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -52,6 +52,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5 # v2.2.4
+        uses: github/codeql-action/upload-sarif@b7bf0a3ed3ecfa44160715d7c442788f65f0f923 # v3.23.2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
The old version of codeql-action in the Scorecard CI action results in [warnings](https://github.com/oneapi-src/unified-memory-framework/actions/runs/7726973544).

[Preview](https://github.com/PatKamin/unified-memory-framework/actions/runs/7728384686) of a run without warnings with changes from this PR applied.