### PR TITLE
Expose provider/pool ops through a getter function

### DIFF
--- a/benchmark/ubench.c
+++ b/benchmark/ubench.c
@@ -139,7 +139,7 @@ UBENCH_EX(simple, os_memory_provider) {
 
     enum umf_result_t umf_result;
     umf_memory_provider_handle_t os_memory_provider = NULL;
-    umf_result = umfMemoryProviderCreate(&UMF_OS_MEMORY_PROVIDER_OPS,
+    umf_result = umfMemoryProviderCreate(umfOsMemoryProviderOps(),
                                          &UMF_OS_MEMORY_PROVIDER_PARAMS,
                                          &os_memory_provider);
     if (umf_result != UMF_RESULT_SUCCESS) {
@@ -188,7 +188,7 @@ UBENCH_EX(simple, disjoint_pool_with_os_memory_provider) {
 
     enum umf_result_t umf_result;
     umf_memory_provider_handle_t os_memory_provider = NULL;
-    umf_result = umfMemoryProviderCreate(&UMF_OS_MEMORY_PROVIDER_OPS,
+    umf_result = umfMemoryProviderCreate(umfOsMemoryProviderOps(),
                                          &UMF_OS_MEMORY_PROVIDER_PARAMS,
                                          &os_memory_provider);
     if (umf_result != UMF_RESULT_SUCCESS) {
@@ -204,7 +204,7 @@ UBENCH_EX(simple, disjoint_pool_with_os_memory_provider) {
     disjoint_memory_pool_params.PoolTrace = DISJOINT_POOL_TRACE;
 
     umf_memory_pool_handle_t disjoint_pool;
-    umf_result = umfPoolCreate(&UMF_DISJOINT_POOL_OPS, os_memory_provider,
+    umf_result = umfPoolCreate(umfDisjointPoolOps(), os_memory_provider,
                                &disjoint_memory_pool_params, 0, &disjoint_pool);
     if (umf_result != UMF_RESULT_SUCCESS) {
         exit(-1);
@@ -233,7 +233,7 @@ UBENCH_EX(simple, jemalloc_pool_with_os_memory_provider) {
 
     enum umf_result_t umf_result;
     umf_memory_provider_handle_t os_memory_provider = NULL;
-    umf_result = umfMemoryProviderCreate(&UMF_OS_MEMORY_PROVIDER_OPS,
+    umf_result = umfMemoryProviderCreate(umfOsMemoryProviderOps(),
                                          &UMF_OS_MEMORY_PROVIDER_PARAMS,
                                          &os_memory_provider);
     if (umf_result != UMF_RESULT_SUCCESS) {
@@ -241,7 +241,7 @@ UBENCH_EX(simple, jemalloc_pool_with_os_memory_provider) {
     }
 
     umf_memory_pool_handle_t jemalloc_pool;
-    umf_result = umfPoolCreate(&UMF_JEMALLOC_POOL_OPS, os_memory_provider, NULL,
+    umf_result = umfPoolCreate(umfJemallocPoolOps(), os_memory_provider, NULL,
                                0, &jemalloc_pool);
     if (umf_result != UMF_RESULT_SUCCESS) {
         exit(-1);
@@ -270,7 +270,7 @@ UBENCH_EX(simple, scalable_pool_with_os_memory_provider) {
 
     enum umf_result_t umf_result;
     umf_memory_provider_handle_t os_memory_provider = NULL;
-    umf_result = umfMemoryProviderCreate(&UMF_OS_MEMORY_PROVIDER_OPS,
+    umf_result = umfMemoryProviderCreate(umfOsMemoryProviderOps(),
                                          &UMF_OS_MEMORY_PROVIDER_PARAMS,
                                          &os_memory_provider);
     if (umf_result != UMF_RESULT_SUCCESS) {
@@ -278,7 +278,7 @@ UBENCH_EX(simple, scalable_pool_with_os_memory_provider) {
     }
 
     umf_memory_pool_handle_t scalable_pool;
-    umf_result = umfPoolCreate(&UMF_SCALABLE_POOL_OPS, os_memory_provider, NULL,
+    umf_result = umfPoolCreate(umfScalablePoolOps(), os_memory_provider, NULL,
                                0, &scalable_pool);
     if (umf_result != UMF_RESULT_SUCCESS) {
         exit(-1);

--- a/include/umf/pools/pool_disjoint.h
+++ b/include/umf/pools/pool_disjoint.h
@@ -60,7 +60,7 @@ typedef struct umf_disjoint_pool_params_t {
     const char *Name;
 } umf_disjoint_pool_params_t;
 
-extern umf_memory_pool_ops_t UMF_DISJOINT_POOL_OPS;
+umf_memory_pool_ops_t *umfDisjointPoolOps(void);
 
 /// @brief Create default params struct for disjoint pool
 static inline umf_disjoint_pool_params_t umfDisjointPoolParamsDefault(void) {

--- a/include/umf/pools/pool_jemalloc.h
+++ b/include/umf/pools/pool_jemalloc.h
@@ -16,7 +16,7 @@ extern "C" {
 
 #include <umf/memory_pool_ops.h>
 
-extern umf_memory_pool_ops_t UMF_JEMALLOC_POOL_OPS;
+umf_memory_pool_ops_t *umfJemallocPoolOps(void);
 
 #ifdef __cplusplus
 }

--- a/include/umf/pools/pool_scalable.h
+++ b/include/umf/pools/pool_scalable.h
@@ -17,7 +17,7 @@ extern "C" {
 #include <umf/memory_pool.h>
 #include <umf/memory_provider.h>
 
-extern umf_memory_pool_ops_t UMF_SCALABLE_POOL_OPS;
+umf_memory_pool_ops_t *umfScalablePoolOps(void);
 
 #ifdef __cplusplus
 }

--- a/include/umf/providers/provider_os_memory.h
+++ b/include/umf/providers/provider_os_memory.h
@@ -87,7 +87,7 @@ typedef enum umf_os_memory_provider_native_error {
     UMF_OS_RESULT_ERROR_PURGE_FORCE_FAILED,
 } umf_os_memory_provider_native_error_t;
 
-extern umf_memory_provider_ops_t UMF_OS_MEMORY_PROVIDER_OPS;
+umf_memory_provider_ops_t *umfOsMemoryProviderOps(void);
 
 /// @brief Create default params for os memory provider
 static inline umf_os_memory_provider_params_t

--- a/src/memory_targets/memory_target_numa.c
+++ b/src/memory_targets/memory_target_numa.c
@@ -122,7 +122,7 @@ static enum umf_result_t numa_memory_provider_create_from_memspace(
     params.numa_flags = UMF_NUMA_FLAGS_STRICT;
 
     umf_memory_provider_handle_t numaProvider = NULL;
-    ret = umfMemoryProviderCreate(&UMF_OS_MEMORY_PROVIDER_OPS, &params,
+    ret = umfMemoryProviderCreate(umfOsMemoryProviderOps(), &params,
                                   &numaProvider);
     free(nodemask);
     if (ret) {

--- a/src/pool/pool_disjoint.cpp
+++ b/src/pool/pool_disjoint.cpp
@@ -1069,5 +1069,9 @@ DisjointPool::~DisjointPool() {
     }
 }
 
-umf_memory_pool_ops_t UMF_DISJOINT_POOL_OPS =
+static umf_memory_pool_ops_t UMF_DISJOINT_POOL_OPS =
     umf::poolMakeCOps<DisjointPool, umf_disjoint_pool_params_t>();
+
+umf_memory_pool_ops_t *umfDisjointPoolOps(void) {
+    return &UMF_DISJOINT_POOL_OPS;
+}

--- a/src/pool/pool_jemalloc.c
+++ b/src/pool/pool_jemalloc.c
@@ -416,7 +416,7 @@ static umf_result_t je_get_last_allocation_error(void *pool) {
     return TLS_last_allocation_error;
 }
 
-umf_memory_pool_ops_t UMF_JEMALLOC_POOL_OPS = {
+static umf_memory_pool_ops_t UMF_JEMALLOC_POOL_OPS = {
     .version = UMF_VERSION_CURRENT,
     .initialize = je_initialize,
     .finalize = je_finalize,
@@ -428,3 +428,7 @@ umf_memory_pool_ops_t UMF_JEMALLOC_POOL_OPS = {
     .free = je_free,
     .get_last_allocation_error = je_get_last_allocation_error,
 };
+
+umf_memory_pool_ops_t *umfJemallocPoolOps(void) {
+    return &UMF_JEMALLOC_POOL_OPS;
+}

--- a/src/pool/pool_scalable.c
+++ b/src/pool/pool_scalable.c
@@ -262,7 +262,7 @@ static umf_result_t tbb_get_last_allocation_error(void *pool) {
     return TLS_last_allocation_error;
 }
 
-umf_memory_pool_ops_t UMF_SCALABLE_POOL_OPS = {
+static umf_memory_pool_ops_t UMF_SCALABLE_POOL_OPS = {
     .version = UMF_VERSION_CURRENT,
     .initialize = tbb_pool_initialize,
     .finalize = tbb_pool_finalize,
@@ -273,3 +273,7 @@ umf_memory_pool_ops_t UMF_SCALABLE_POOL_OPS = {
     .malloc_usable_size = tbb_malloc_usable_size,
     .free = tbb_free,
     .get_last_allocation_error = tbb_get_last_allocation_error};
+
+umf_memory_pool_ops_t *umfScalablePoolOps(void) {
+    return &UMF_SCALABLE_POOL_OPS;
+}

--- a/src/provider/provider_os_memory.c
+++ b/src/provider/provider_os_memory.c
@@ -594,7 +594,7 @@ static umf_result_t os_allocation_merge(void *provider, void *lowPtr,
     return UMF_RESULT_SUCCESS;
 }
 
-umf_memory_provider_ops_t UMF_OS_MEMORY_PROVIDER_OPS = {
+static umf_memory_provider_ops_t UMF_OS_MEMORY_PROVIDER_OPS = {
     .version = UMF_VERSION_CURRENT,
     .initialize = os_initialize,
     .finalize = os_finalize,
@@ -608,3 +608,7 @@ umf_memory_provider_ops_t UMF_OS_MEMORY_PROVIDER_OPS = {
     .get_name = os_get_name,
     .allocation_split = os_allocation_split,
     .allocation_merge = os_allocation_merge};
+
+umf_memory_provider_ops_t *umfOsMemoryProviderOps(void) {
+    return &UMF_OS_MEMORY_PROVIDER_OPS;
+}

--- a/test/c_api/disjoint_pool.c
+++ b/test/c_api/disjoint_pool.c
@@ -13,7 +13,7 @@ void test_disjoint_pool_default_params(void) {
     umf_result_t retp;
     umf_memory_pool_handle_t pool = NULL;
     umf_disjoint_pool_params_t params = umfDisjointPoolParamsDefault();
-    retp = umfPoolCreate(&UMF_DISJOINT_POOL_OPS, provider, &params, 0, &pool);
+    retp = umfPoolCreate(umfDisjointPoolOps(), provider, &params, 0, &pool);
 
     UT_ASSERTeq(retp, UMF_RESULT_SUCCESS);
 
@@ -31,7 +31,7 @@ void test_disjoint_pool_shared_limits(void) {
         umfDisjointPoolSharedLimitsCreate(1024);
     params.SharedLimits = limits;
 
-    retp = umfPoolCreate(&UMF_DISJOINT_POOL_OPS, provider, &params, 0, &pool);
+    retp = umfPoolCreate(umfDisjointPoolOps(), provider, &params, 0, &pool);
 
     UT_ASSERTeq(retp, UMF_RESULT_SUCCESS);
 

--- a/test/pools/disjoint_pool.cpp
+++ b/test/pools/disjoint_pool.cpp
@@ -51,8 +51,8 @@ TEST_F(test, freeErrorPropagation) {
     params.MaxPoolableSize = 0;
 
     umf_memory_pool_handle_t pool = NULL;
-    umf_result_t retp = umfPoolCreate(&UMF_DISJOINT_POOL_OPS, provider_handle,
-                                      &params, 0, &pool);
+    umf_result_t retp =
+        umfPoolCreate(umfDisjointPoolOps(), provider_handle, &params, 0, &pool);
     EXPECT_EQ(retp, UMF_RESULT_SUCCESS);
     auto poolHandle = umf_test::wrapPoolUnique(pool);
 
@@ -112,12 +112,12 @@ TEST_F(test, sharedLimits) {
 
     umf_memory_pool_handle_t pool1 = NULL;
     umf_memory_pool_handle_t pool2 = NULL;
-    auto ret = umfPoolCreate(&UMF_DISJOINT_POOL_OPS, provider.get(),
+    auto ret = umfPoolCreate(umfDisjointPoolOps(), provider.get(),
                              (void *)&config, 0, &pool1);
     EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
     auto poolHandle1 = umf_test::wrapPoolUnique(pool1);
 
-    ret = umfPoolCreate(&UMF_DISJOINT_POOL_OPS, provider.get(), (void *)&config,
+    ret = umfPoolCreate(umfDisjointPoolOps(), provider.get(), (void *)&config,
                         0, &pool2);
     EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
     auto poolHandle2 = umf_test::wrapPoolUnique(pool2);
@@ -151,18 +151,18 @@ TEST_F(test, sharedLimits) {
 auto defaultPoolConfig = poolConfig();
 INSTANTIATE_TEST_SUITE_P(disjointPoolTests, umfPoolTest,
                          ::testing::Values(poolCreateExtParams{
-                             &UMF_DISJOINT_POOL_OPS, (void *)&defaultPoolConfig,
+                             umfDisjointPoolOps(), (void *)&defaultPoolConfig,
                              &MALLOC_PROVIDER_OPS, nullptr}));
 
 INSTANTIATE_TEST_SUITE_P(
     disjointPoolTests, umfMemTest,
     ::testing::Values(std::make_tuple(
-        poolCreateExtParams{&UMF_DISJOINT_POOL_OPS, (void *)&defaultPoolConfig,
+        poolCreateExtParams{umfDisjointPoolOps(), (void *)&defaultPoolConfig,
                             &MOCK_OUT_OF_MEM_PROVIDER_OPS,
                             (void *)&defaultPoolConfig.Capacity},
         static_cast<int>(defaultPoolConfig.Capacity) / 2)));
 
 INSTANTIATE_TEST_SUITE_P(disjointMultiPoolTests, umfMultiPoolTest,
                          ::testing::Values(poolCreateExtParams{
-                             &UMF_DISJOINT_POOL_OPS, (void *)&defaultPoolConfig,
+                             umfDisjointPoolOps(), (void *)&defaultPoolConfig,
                              &MALLOC_PROVIDER_OPS, nullptr}));

--- a/test/pools/jemalloc_pool.cpp
+++ b/test/pools/jemalloc_pool.cpp
@@ -14,8 +14,8 @@ using namespace umf_test;
 auto defaultParams = umfOsMemoryProviderParamsDefault();
 INSTANTIATE_TEST_SUITE_P(jemallocPoolTest, umfPoolTest,
                          ::testing::Values(poolCreateExtParams{
-                             &UMF_JEMALLOC_POOL_OPS, nullptr,
-                             &UMF_OS_MEMORY_PROVIDER_OPS, &defaultParams}));
+                             umfJemallocPoolOps(), nullptr,
+                             umfOsMemoryProviderOps(), &defaultParams}));
 
 // this test makes sure that jemalloc does not use
 // memory provider to allocate metadata (and hence
@@ -30,8 +30,8 @@ TEST_F(test, metadataNotAllocatedUsingProvider) {
     auto params = umfOsMemoryProviderParamsDefault();
     params.protection = UMF_PROTECTION_NONE;
 
-    auto pool = poolCreateExtUnique({&UMF_JEMALLOC_POOL_OPS, nullptr,
-                                     &UMF_OS_MEMORY_PROVIDER_OPS, &params});
+    auto pool = poolCreateExtUnique(
+        {umfJemallocPoolOps(), nullptr, umfOsMemoryProviderOps(), &params});
 
     std::vector<std::shared_ptr<void>> allocs;
     for (size_t i = 0; i < numAllocs; i++) {

--- a/test/pools/scalable_pool.cpp
+++ b/test/pools/scalable_pool.cpp
@@ -11,5 +11,5 @@
 auto defaultParams = umfOsMemoryProviderParamsDefault();
 INSTANTIATE_TEST_SUITE_P(scalablePoolTest, umfPoolTest,
                          ::testing::Values(poolCreateExtParams{
-                             &UMF_SCALABLE_POOL_OPS, nullptr,
-                             &UMF_OS_MEMORY_PROVIDER_OPS, &defaultParams}));
+                             umfScalablePoolOps(), nullptr,
+                             umfOsMemoryProviderOps(), &defaultParams}));

--- a/test/provider_os_memory.cpp
+++ b/test/provider_os_memory.cpp
@@ -136,7 +136,7 @@ TEST_F(test, create_WRONG_NUMA_MODE) {
     os_memory_provider_params.visibility = UMF_VISIBILITY_SHARED;
     os_memory_provider_params.numa_mode = UMF_NUMA_MODE_BIND;
 
-    umf_result = umfMemoryProviderCreate(&UMF_OS_MEMORY_PROVIDER_OPS,
+    umf_result = umfMemoryProviderCreate(umfOsMemoryProviderOps(),
                                          &os_memory_provider_params,
                                          &os_memory_provider);
     ASSERT_EQ(umf_result, UMF_RESULT_ERROR_INVALID_ARGUMENT);
@@ -152,7 +152,7 @@ TEST_F(test, create_WRONG_NUMA_FLAGS) {
     // wrong NUMA flags
     os_memory_provider_params.numa_flags = (unsigned int)-1;
 
-    umf_result = umfMemoryProviderCreate(&UMF_OS_MEMORY_PROVIDER_OPS,
+    umf_result = umfMemoryProviderCreate(umfOsMemoryProviderOps(),
                                          &os_memory_provider_params,
                                          &os_memory_provider);
     ASSERT_EQ(umf_result, UMF_RESULT_ERROR_INVALID_ARGUMENT);
@@ -164,7 +164,7 @@ TEST_F(test, create_WRONG_NUMA_FLAGS) {
 auto defaultParams = umfOsMemoryProviderParamsDefault();
 INSTANTIATE_TEST_SUITE_P(osProviderTest, umfProviderTest,
                          ::testing::Values(providerCreateExtParams{
-                             &UMF_OS_MEMORY_PROVIDER_OPS, &defaultParams}));
+                             umfOsMemoryProviderOps(), &defaultParams}));
 
 TEST_P(umfProviderTest, create_destroy) {}
 

--- a/test/provider_os_memory_config.cpp
+++ b/test/provider_os_memory_config.cpp
@@ -41,7 +41,7 @@ struct providerConfigTest : testing::Test {
     }
 
     void create_provider(umf_os_memory_provider_params_t *params) {
-        auto res = umfMemoryProviderCreate(&UMF_OS_MEMORY_PROVIDER_OPS, params,
+        auto res = umfMemoryProviderCreate(umfOsMemoryProviderOps(), params,
                                            &provider);
         ASSERT_EQ(res, UMF_RESULT_SUCCESS);
         ASSERT_NE(provider, nullptr);

--- a/test/provider_os_memory_multiple_numa_nodes.cpp
+++ b/test/provider_os_memory_multiple_numa_nodes.cpp
@@ -45,7 +45,7 @@ struct testNumaNodes : public testing::TestWithParam<int> {
     void
     initOsProvider(umf_os_memory_provider_params_t os_memory_provider_params) {
         umf_result_t umf_result;
-        umf_result = umfMemoryProviderCreate(&UMF_OS_MEMORY_PROVIDER_OPS,
+        umf_result = umfMemoryProviderCreate(umfOsMemoryProviderOps(),
                                              &os_memory_provider_params,
                                              &os_memory_provider);
         ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);


### PR DESCRIPTION
instead of exposing a global variable. Variables are problematic on windows where __declspec(dllimport) must be used in user code on each imported variable declaration.