### PR TITLE
Add abstraction on top of ba_alloc  which supports arbitrary size allocations

### DIFF
--- a/src/base_alloc/base_alloc_global.c
+++ b/src/base_alloc/base_alloc_global.c
@@ -5,49 +5,116 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 */
 
+/* A MT-safe base allocator */
+
 #include <assert.h>
+#include <stdio.h>
 #include <stdlib.h>
 
 #include "base_alloc.h"
 #include "base_alloc_global.h"
+#include "base_alloc_internal.h"
 #include "utils_concurrency.h"
-
-#define SIZE_BA_POOL_CHUNK 128
+#include "utils_math.h"
 
 // global base allocator used by all providers and pools
-static umf_ba_pool_t *BA_pool = NULL;
 static UTIL_ONCE_FLAG ba_is_initialized = UTIL_ONCE_FLAG_INIT;
 
+// allocation classes need to be powers of 2
+#define ALLOCATION_CLASSES                                                     \
+    { 16, 32, 64, 128 }
+#define NUM_ALLOCATION_CLASSES 4
+
+struct base_alloc_t {
+    size_t ac_sizes[NUM_ALLOCATION_CLASSES];
+    umf_ba_pool_t *ac[NUM_ALLOCATION_CLASSES];
+    size_t smallest_ac_size_log2;
+};
+
+static struct base_alloc_t BASE_ALLOC = {.ac_sizes = ALLOCATION_CLASSES};
+
+void umf_ba_destroy_global(void) {
+    for (int i = 0; i < NUM_ALLOCATION_CLASSES; i++) {
+        if (BASE_ALLOC.ac[i]) {
+            umf_ba_destroy(BASE_ALLOC.ac[i]);
+            BASE_ALLOC.ac[i] = NULL;
+        }
+    }
+}
+
 static void umf_ba_create_global(void) {
-    assert(BA_pool == NULL);
-    BA_pool = umf_ba_create(SIZE_BA_POOL_CHUNK);
-    assert(BA_pool);
+    for (int i = 0; i < NUM_ALLOCATION_CLASSES; i++) {
+        // allocation classes need to be powers of 2
+        assert(0 == (BASE_ALLOC.ac_sizes[i] & (BASE_ALLOC.ac_sizes[i] - 1)));
+        BASE_ALLOC.ac[i] = umf_ba_create(BASE_ALLOC.ac_sizes[i]);
+        if (!BASE_ALLOC.ac[i]) {
+            fprintf(stderr,
+                    "base_alloc: Error. Cannot create base alloc allocation "
+                    "class for size: %zu\n. Each allocation will fallback to "
+                    "allocating memory from the OS.",
+                    BASE_ALLOC.ac_sizes[i]);
+        }
+    }
+
+    size_t smallestSize = BASE_ALLOC.ac_sizes[0];
+    BASE_ALLOC.smallest_ac_size_log2 = log2Utils(smallestSize);
+
 #if defined(_WIN32) && !defined(UMF_SHARED_LIBRARY)
     atexit(umf_ba_destroy_global);
 #endif
 }
 
-void umf_ba_destroy_global(void) {
-    if (BA_pool) {
-        umf_ba_pool_t *pool = BA_pool;
-        BA_pool = NULL;
-        umf_ba_destroy(pool);
+// returns index of the allocation class for a given size
+static int size_to_idx(size_t size) {
+    assert(size <= BASE_ALLOC.ac_sizes[NUM_ALLOCATION_CLASSES - 1]);
+
+    if (size <= BASE_ALLOC.ac_sizes[0]) {
+        return 0;
     }
+
+    int isPowerOf2 = (0 == (size & (size - 1)));
+    int index =
+        (int)(log2Utils(size) + !isPowerOf2 - BASE_ALLOC.smallest_ac_size_log2);
+
+    assert(index >= 0);
+    assert(index < NUM_ALLOCATION_CLASSES);
+
+    return index;
 }
 
-umf_ba_pool_t *umf_ba_get_pool(size_t size) {
+void *umf_ba_global_alloc(size_t size) {
     util_init_once(&ba_is_initialized, umf_ba_create_global);
 
-    if (!BA_pool) {
-        return NULL;
+    if (size > BASE_ALLOC.ac_sizes[NUM_ALLOCATION_CLASSES - 1]) {
+        fprintf(stderr,
+                "base_alloc: allocation size larger than the biggest "
+                "allocation class. Falling back to OS memory allocation.\n");
+        return ba_os_alloc(size);
     }
 
-    // TODO: a specific class-size base allocator can be returned here
-    assert(size <= SIZE_BA_POOL_CHUNK);
-
-    if (size > SIZE_BA_POOL_CHUNK) {
-        return NULL;
+    int ac_index = size_to_idx(size);
+    if (!BASE_ALLOC.ac[ac_index]) {
+        // if creating ac failed, fall back to os allocation
+        fprintf(stderr, "base_alloc: allocation class not created. Falling "
+                        "back to OS memory allocation.\n");
+        return ba_os_alloc(size);
     }
 
-    return BA_pool;
+    return umf_ba_alloc(BASE_ALLOC.ac[ac_index]);
+}
+
+void umf_ba_global_free(void *ptr, size_t size) {
+    if (size > BASE_ALLOC.ac_sizes[NUM_ALLOCATION_CLASSES - 1]) {
+        ba_os_free(ptr, size);
+        return;
+    }
+
+    int ac_index = size_to_idx(size);
+    if (!BASE_ALLOC.ac[ac_index]) {
+        // if creating ac failed, memory must have been allocated by os
+        ba_os_free(ptr, size);
+        return;
+    }
+
+    umf_ba_free(BASE_ALLOC.ac[ac_index], ptr);
 }

--- a/src/base_alloc/base_alloc_global.h
+++ b/src/base_alloc/base_alloc_global.h
@@ -14,7 +14,8 @@
 extern "C" {
 #endif
 
-umf_ba_pool_t *umf_ba_get_pool(size_t size);
+void *umf_ba_global_alloc(size_t size);
+void umf_ba_global_free(void *ptr, size_t size);
 void umf_ba_destroy_global(void);
 
 #ifdef __cplusplus

--- a/src/memory_pool_internal.h
+++ b/src/memory_pool_internal.h
@@ -31,9 +31,6 @@ typedef struct umf_memory_pool_t {
     umf_memory_provider_handle_t provider;
     // Tells whether memory provider is owned by the pool.
     bool own_provider;
-
-    // saved pointer to the global base allocator
-    umf_ba_pool_t *base_allocator;
 } umf_memory_pool_t;
 
 umf_result_t umfPoolCreateInternal(const umf_memory_pool_ops_t *ops,

--- a/src/memory_target.c
+++ b/src/memory_target.c
@@ -24,27 +24,20 @@ umf_result_t umfMemoryTargetCreate(const umf_memory_target_ops_t *ops,
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
 
-    umf_ba_pool_t *base_allocator =
-        umf_ba_get_pool(sizeof(umf_memory_target_t));
-    if (!base_allocator) {
-        return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
-    }
-
     umf_memory_target_handle_t target =
-        (umf_memory_target_t *)umf_ba_alloc(base_allocator);
+        (umf_memory_target_t *)umf_ba_global_alloc(sizeof(umf_memory_target_t));
     if (!target) {
         return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
 
     assert(ops->version == UMF_VERSION_CURRENT);
 
-    target->base_allocator = base_allocator;
     target->ops = ops;
 
     void *target_priv;
     umf_result_t ret = ops->initialize(params, &target_priv);
     if (ret != UMF_RESULT_SUCCESS) {
-        umf_ba_free(base_allocator, target);
+        umf_ba_global_free(target, sizeof(umf_memory_target_t));
         return ret;
     }
 
@@ -58,5 +51,5 @@ umf_result_t umfMemoryTargetCreate(const umf_memory_target_ops_t *ops,
 void umfMemoryTargetDestroy(umf_memory_target_handle_t memoryTarget) {
     assert(memoryTarget);
     memoryTarget->ops->finalize(memoryTarget->priv);
-    umf_ba_free(memoryTarget->base_allocator, memoryTarget);
+    umf_ba_global_free(memoryTarget, sizeof(umf_memory_target_t));
 }

--- a/src/memory_target.h
+++ b/src/memory_target.h
@@ -24,9 +24,6 @@ typedef struct umf_memory_target_ops_t umf_memory_target_ops_t;
 typedef struct umf_memory_target_t {
     const umf_memory_target_ops_t *ops;
     void *priv;
-
-    // saved pointer to the global base allocator
-    umf_ba_pool_t *base_allocator;
 } umf_memory_target_t;
 
 typedef umf_memory_target_t *umf_memory_target_handle_t;

--- a/src/memspace.c
+++ b/src/memspace.c
@@ -12,6 +12,7 @@
 
 #include <umf/memspace.h>
 
+#include "base_alloc_global.h"
 #include "memory_target.h"
 #include "memory_target_ops.h"
 #include "memspace_internal.h"
@@ -105,5 +106,5 @@ void umfMemspaceDestroy(umf_memspace_handle_t memspace) {
     }
 
     umf_ba_linear_destroy(memspace->linear_allocator);
-    umf_ba_free(memspace->base_allocator, memspace);
+    umf_ba_global_free(memspace, sizeof(struct umf_memspace_t));
 }

--- a/src/memspace_internal.h
+++ b/src/memspace_internal.h
@@ -24,9 +24,6 @@ struct umf_memspace_t {
     size_t size;
     umf_memory_target_handle_t *nodes;
 
-    // saved pointer to the global base allocator
-    umf_ba_pool_t *base_allocator;
-
     // own local linear base allocator
     umf_ba_linear_pool_t *linear_allocator;
 };

--- a/src/memspaces/memspace_numa.c
+++ b/src/memspaces/memspace_numa.c
@@ -23,15 +23,9 @@ umfMemspaceCreateFromNumaArray(size_t *nodeIds, size_t numIds,
     }
 
     enum umf_result_t ret = UMF_RESULT_SUCCESS;
-
-    umf_ba_pool_t *base_allocator =
-        umf_ba_get_pool(sizeof(struct umf_memspace_t));
-    if (!base_allocator) {
-        return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
-    }
-
     umf_memspace_handle_t memspace =
-        (struct umf_memspace_t *)umf_ba_alloc(base_allocator);
+        (struct umf_memspace_t *)umf_ba_global_alloc(
+            sizeof(struct umf_memspace_t));
     if (!memspace) {
         return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
@@ -43,7 +37,6 @@ umfMemspaceCreateFromNumaArray(size_t *nodeIds, size_t numIds,
         goto err_umf_ba_linear_create;
     }
 
-    memspace->base_allocator = base_allocator;
     memspace->linear_allocator = linear_allocator;
 
     memspace->size = numIds;
@@ -75,6 +68,6 @@ err_target_create:
 err_nodes_alloc:
     umf_ba_linear_destroy(linear_allocator);
 err_umf_ba_linear_create:
-    umf_ba_free(base_allocator, memspace);
+    umf_ba_global_free(memspace, sizeof(struct umf_memspace_t));
     return ret;
 }

--- a/src/provider/provider_os_memory.c
+++ b/src/provider/provider_os_memory.c
@@ -44,9 +44,6 @@ typedef struct os_memory_provider_t {
     int traces; // log level of debug traces
 
     hwloc_topology_t topo;
-
-    // saved pointer to the global base allocator
-    umf_ba_pool_t *base_allocator;
 } os_memory_provider_t;
 
 #define TLS_MSG_BUF_LEN 1024
@@ -229,20 +226,14 @@ static umf_result_t os_initialize(void *params, void **provider) {
     umf_os_memory_provider_params_t *in_params =
         (umf_os_memory_provider_params_t *)params;
 
-    umf_ba_pool_t *base_allocator =
-        umf_ba_get_pool(sizeof(os_memory_provider_t));
-    if (!base_allocator) {
-        return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
-    }
-
     os_memory_provider_t *os_provider =
-        (os_memory_provider_t *)umf_ba_alloc(base_allocator);
+        (os_memory_provider_t *)umf_ba_global_alloc(
+            sizeof(os_memory_provider_t));
     if (!os_provider) {
         return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
 
     memset(os_provider, 0, sizeof(*os_provider));
-    os_provider->base_allocator = base_allocator;
 
     int r = hwloc_topology_init(&os_provider->topo);
     if (r) {
@@ -287,7 +278,7 @@ static umf_result_t os_initialize(void *params, void **provider) {
 err_destroy_hwloc_topology:
     hwloc_topology_destroy(os_provider->topo);
 err_free_os_provider:
-    umf_ba_free(base_allocator, os_provider);
+    umf_ba_global_free(os_provider, sizeof(os_memory_provider_t));
     return ret;
 }
 
@@ -300,7 +291,7 @@ static void os_finalize(void *provider) {
     os_memory_provider_t *os_provider = provider;
     hwloc_bitmap_free(os_provider->nodeset);
     hwloc_topology_destroy(os_provider->topo);
-    umf_ba_free(os_provider->base_allocator, os_provider);
+    umf_ba_global_free(os_provider, sizeof(os_memory_provider_t));
 }
 
 static umf_result_t os_get_min_page_size(void *provider, void *ptr,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -135,3 +135,9 @@ add_umf_test(NAME base_alloc
 add_umf_test(NAME base_alloc_linear
             SRCS ${BA_SOURCES_FOR_TEST} test_base_alloc_linear.cpp
             LIBS umf_utils)
+if(LINUX)
+    # TODO: fix this on windows
+    add_umf_test(NAME base_alloc_global
+                SRCS ${BA_SOURCES_FOR_TEST} pools/pool_base_alloc.cpp malloc_compliance_tests.cpp
+                LIBS umf_utils)
+endif()

--- a/test/common/pool.hpp
+++ b/test/common/pool.hpp
@@ -82,6 +82,22 @@ bool isCallocSupported(umf_memory_pool_handle_t hPool) {
     return supported;
 }
 
+bool isAlignedAllocSupported(umf_memory_pool_handle_t hPool) {
+    static constexpr size_t allocSize = 8;
+    static constexpr size_t alignment = 8;
+    auto *ptr = umfPoolAlignedMalloc(hPool, allocSize, alignment);
+
+    if (ptr) {
+        umfPoolFree(hPool, ptr);
+        return true;
+    } else if (umfPoolGetLastAllocationError(hPool) ==
+               UMF_RESULT_ERROR_NOT_SUPPORTED) {
+        return false;
+    } else {
+        throw std::runtime_error("AlignedMalloc failed with unexpected error");
+    }
+}
+
 typedef struct pool_base_t {
     umf_result_t initialize(umf_memory_provider_handle_t) noexcept {
         return UMF_RESULT_SUCCESS;

--- a/test/common/provider.hpp
+++ b/test/common/provider.hpp
@@ -63,6 +63,9 @@ typedef struct provider_base_t {
     const char *get_name() noexcept { return "base"; }
 } provider_base_t;
 
+umf_memory_provider_ops_t BASE_PROVIDER_OPS =
+    umf::providerMakeCOps<provider_base_t, void>();
+
 struct provider_malloc : public provider_base_t {
     umf_result_t alloc(size_t size, size_t align, void **ptr) noexcept {
         if (!align) {

--- a/test/poolFixtures.hpp
+++ b/test/poolFixtures.hpp
@@ -136,6 +136,9 @@ TEST_P(umfPoolTest, callocFree) {
 }
 
 void pow2AlignedAllocHelper(umf_memory_pool_handle_t pool) {
+    if (!umf_test::isAlignedAllocSupported(pool)) {
+        GTEST_SKIP();
+    }
     static constexpr size_t maxAlignment = (1u << 22);
     static constexpr size_t numAllocs = 4;
     for (size_t alignment = 1; alignment <= maxAlignment; alignment <<= 1) {

--- a/test/pools/pool_base_alloc.cpp
+++ b/test/pools/pool_base_alloc.cpp
@@ -1,0 +1,65 @@
+// Copyright (C) 2023 Intel Corporation
+// Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <unordered_map>
+
+#include "umf/pools/pool_scalable.h"
+#include "umf/providers/provider_os_memory.h"
+
+#include "pool.hpp"
+#include "poolFixtures.hpp"
+#include "provider.hpp"
+
+#include "base_alloc_global.h"
+
+struct base_alloc_pool : public umf_test::pool_base_t {
+    std::unordered_map<void *, size_t> sizes;
+    std::mutex m;
+
+    void *malloc(size_t size) noexcept {
+        auto *ptr = umf_ba_global_alloc(size);
+        std::unique_lock<std::mutex> l(m);
+        sizes[ptr] = size;
+        return ptr;
+    }
+    void *calloc(size_t, size_t) noexcept {
+        umf::getPoolLastStatusRef<base_alloc_pool>() =
+            UMF_RESULT_ERROR_NOT_SUPPORTED;
+        return NULL;
+    }
+    void *realloc(void *, size_t) noexcept {
+        umf::getPoolLastStatusRef<base_alloc_pool>() =
+            UMF_RESULT_ERROR_NOT_SUPPORTED;
+        return NULL;
+    }
+    void *aligned_malloc(size_t, size_t) noexcept {
+        umf::getPoolLastStatusRef<base_alloc_pool>() =
+            UMF_RESULT_ERROR_NOT_SUPPORTED;
+        return NULL;
+    }
+    size_t malloc_usable_size(void *ptr) noexcept {
+        std::unique_lock<std::mutex> l(m);
+        return sizes[ptr];
+    }
+    umf_result_t free(void *ptr) noexcept {
+        size_t size;
+        {
+            std::unique_lock<std::mutex> l(m);
+            size = sizes[ptr];
+        }
+
+        umf_ba_global_free(ptr, size);
+        return UMF_RESULT_SUCCESS;
+    }
+    umf_result_t get_last_allocation_error() {
+        return umf::getPoolLastStatusRef<base_alloc_pool>();
+    }
+};
+
+umf_memory_pool_ops_t BA_POOL_OPS = umf::poolMakeCOps<base_alloc_pool, void>();
+
+INSTANTIATE_TEST_SUITE_P(baPool, umfPoolTest,
+                         ::testing::Values(poolCreateExtParams{
+                             &BA_POOL_OPS, nullptr,
+                             &umf_test::BASE_PROVIDER_OPS, nullptr}));


### PR DESCRIPTION
The `umf_ba_global_free` requires size but this should not be a problem - I believe we know size of each allocation in our codebase currently.