### PR TITLE
Don't use CodeQL in reusable workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,10 @@
 name: CodeQL
 
-on: workflow_call
+# Due to lower score on Scorecard we're running this separately from
+# "PR/push" workflow. For some reason permissions weren't properly set
+# or recognized (by Scorecard). If Scorecard changes its behavior we can
+# go back to use 'workflow_call' trigger.
+on: [push, pull_request]
 
 permissions:
   contents: read

--- a/.github/workflows/pr_push.yml
+++ b/.github/workflows/pr_push.yml
@@ -85,9 +85,3 @@ jobs:
     Benchmark:
         needs: [Build]
         uses: ./.github/workflows/benchmarks.yml
-    CodeQL:
-        permissions:
-          contents: read
-          security-events: write
-        needs: [Build]
-        uses: ./.github/workflows/codeql.yml


### PR DESCRIPTION
Due to lower score on Scorecard we'll be running this separately from "PR/push" workflow. For some reason permissions weren't properly set or recognized (by Scorecard). If Scorecard changes its behavior we can go back to use 'workflow_call' trigger.