### PR TITLE
Add tests with multiple pools

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -77,6 +77,15 @@ if(UMF_BUILD_LIBUMF_POOL_DISJOINT)
                  LIBS disjoint_pool)
 endif()
 
+if(UMF_BUILD_LIBUMF_POOL_DISJOINT
+   AND UMF_BUILD_LIBUMF_POOL_JEMALLOC
+   AND UMF_BUILD_OS_MEMORY_PROVIDER
+   AND UMF_ENABLE_POOL_TRACKING)
+    add_umf_test(NAME c_api_multi_pool
+                 SRCS c_api/multi_pool.c
+                 LIBS disjoint_pool jemalloc_pool)
+endif()
+
 if(UMF_BUILD_OS_MEMORY_PROVIDER)
     if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
         # TODO: we link directly with libc to force using malloc from glibc

--- a/test/c_api/multi_pool.c
+++ b/test/c_api/multi_pool.c
@@ -1,0 +1,82 @@
+// Copyright (C) 2023-2024 Intel Corporation
+// Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <stdlib.h>
+
+#include <umf/memory_pool.h>
+#include <umf/pools/pool_disjoint.h>
+#include <umf/pools/pool_jemalloc.h>
+#include <umf/pools/pool_proxy.h>
+#include <umf/providers/provider_os_memory.h>
+
+#include "test_helpers.h"
+
+umf_memory_pool_handle_t
+createDisjointPool(umf_memory_provider_handle_t provider) {
+    umf_memory_pool_handle_t pool = NULL;
+    umf_disjoint_pool_params_t params = umfDisjointPoolParamsDefault();
+    umf_result_t ret =
+        umfPoolCreate(umfDisjointPoolOps(), provider, &params, 0, &pool);
+    UT_ASSERTeq(ret, UMF_RESULT_SUCCESS);
+    return pool;
+}
+
+umf_memory_pool_handle_t
+createProxyPool(umf_memory_provider_handle_t provider) {
+    umf_memory_pool_handle_t pool = NULL;
+    umf_result_t ret =
+        umfPoolCreate(umfProxyPoolOps(), provider, NULL, 0, &pool);
+    UT_ASSERTeq(ret, UMF_RESULT_SUCCESS);
+    return pool;
+}
+
+umf_memory_pool_handle_t
+createJemallocPool(umf_memory_provider_handle_t provider) {
+    umf_memory_pool_handle_t pool = NULL;
+    umf_result_t ret =
+        umfPoolCreate(umfJemallocPoolOps(), provider, NULL, 0, &pool);
+    UT_ASSERTeq(ret, UMF_RESULT_SUCCESS);
+    return pool;
+}
+
+#define ALLOC_SIZE 64
+
+int main(void) {
+    umf_os_memory_provider_params_t params = umfOsMemoryProviderParamsDefault();
+
+    umf_memory_provider_handle_t hProvider;
+    umf_result_t ret =
+        umfMemoryProviderCreate(umfOsMemoryProviderOps(), &params, &hProvider);
+    UT_ASSERTeq(ret, UMF_RESULT_SUCCESS);
+
+    umf_memory_pool_handle_t pools[3];
+
+    pools[0] = createDisjointPool(hProvider);
+    pools[1] = createProxyPool(hProvider);
+    pools[2] = createJemallocPool(hProvider);
+
+    void *ptrs[3];
+
+    for (int i = 0; i < 3; i++) {
+        UT_ASSERTne(pools[i], NULL);
+        ptrs[i] = umfPoolMalloc(pools[i], ALLOC_SIZE);
+        UT_ASSERTne(ptrs[i], NULL);
+    }
+
+    for (int i = 0; i < 3; i++) {
+        UT_ASSERTeq(umfPoolByPtr(ptrs[i]), pools[i]);
+    }
+
+    for (int i = 0; i < 3; i++) {
+        umfFree(ptrs[i]);
+    }
+
+    for (int i = 0; i < 3; i++) {
+        umfPoolDestroy(pools[i]);
+    }
+
+    umfMemoryProviderDestroy(hProvider);
+
+    return 0;
+}


### PR DESCRIPTION
To verify that:
- tracking works across different type of pools
- we can succesfully link multiple pool libs to a single app