### PR TITLE
[RFC] Add umfPoolFreeSized

### DIFF
--- a/include/umf/memory_pool.h
+++ b/include/umf/memory_pool.h
@@ -112,6 +112,19 @@ size_t umfPoolMallocUsableSize(umf_memory_pool_handle_t hPool, void *ptr);
 
 ///
 /// @brief Frees the memory space of the specified \p hPool pointed by \p ptr
+///        This version of umfPoolFree requires allocation size to be specified.
+/// @param hPool specified memory hPool
+/// @param ptr pointer to the allocated memory to free
+/// @param size size of the allocation, has to match size passed to alloc function.
+/// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
+///         Whether any status other than UMF_RESULT_SUCCESS can be returned
+///         depends on the memory provider used by the \p hPool.
+///
+umf_result_t umfPoolFreeSized(umf_memory_pool_handle_t hPool, void *ptr,
+                              size_t size);
+
+///
+/// @brief Frees the memory space of the specified \p hPool pointed by \p ptr
 /// @param hPool specified memory hPool
 /// @param ptr pointer to the allocated memory to free
 /// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure.

--- a/include/umf/memory_pool_ops.h
+++ b/include/umf/memory_pool_ops.h
@@ -95,11 +95,12 @@ typedef struct umf_memory_pool_ops_t {
     /// @brief Frees the memory space of the specified \p pool pointed by \p ptr
     /// @param pool pointer to the memory pool
     /// @param ptr pointer to the allocated memory to free
+    /// @param size size of the allocation
     /// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
     ///         Whether any status other than UMF_RESULT_SUCCESS can be returned
     ///         depends on the memory provider used by the \p pool.
     ///
-    umf_result_t (*free)(void *pool, void *);
+    umf_result_t (*free)(void *pool, void *ptr, size_t size);
 
     ///
     /// @brief Retrieve \p umf_result_t representing the error of the last failed allocation

--- a/src/memory_pool.c
+++ b/src/memory_pool.c
@@ -58,9 +58,15 @@ size_t umfPoolMallocUsableSize(umf_memory_pool_handle_t hPool, void *ptr) {
     return hPool->ops.malloc_usable_size(hPool->pool_priv, ptr);
 }
 
+umf_result_t umfPoolFreeSized(umf_memory_pool_handle_t hPool, void *ptr,
+                              size_t size) {
+    UMF_CHECK((hPool != NULL), UMF_RESULT_ERROR_INVALID_ARGUMENT);
+    return hPool->ops.free(hPool->pool_priv, ptr, size);
+}
+
 umf_result_t umfPoolFree(umf_memory_pool_handle_t hPool, void *ptr) {
     UMF_CHECK((hPool != NULL), UMF_RESULT_ERROR_INVALID_ARGUMENT);
-    return hPool->ops.free(hPool->pool_priv, ptr);
+    return hPool->ops.free(hPool->pool_priv, ptr, 0);
 }
 
 umf_result_t umfPoolGetLastAllocationError(umf_memory_pool_handle_t hPool) {

--- a/src/pool/pool_disjoint.cpp
+++ b/src/pool/pool_disjoint.cpp
@@ -44,7 +44,7 @@ class DisjointPool {
     void *realloc(void *, size_t);
     void *aligned_malloc(size_t size, size_t alignment);
     size_t malloc_usable_size(void *);
-    umf_result_t free(void *ptr);
+    umf_result_t free(void *ptr, size_t);
     umf_result_t get_last_allocation_error();
 
     DisjointPool();
@@ -1022,7 +1022,9 @@ size_t DisjointPool::malloc_usable_size(void *) {
     return 0;
 }
 
-umf_result_t DisjointPool::free(void *ptr) try {
+umf_result_t DisjointPool::free(void *ptr, size_t size) try {
+    (void)size;
+
     bool ToPool;
     impl->deallocate(ptr, ToPool);
 

--- a/src/pool/pool_jemalloc.c
+++ b/src/pool/pool_jemalloc.c
@@ -296,8 +296,10 @@ static void *je_malloc(void *pool, size_t size) {
     return ptr;
 }
 
-static umf_result_t je_free(void *pool, void *ptr) {
+static umf_result_t je_free(void *pool, void *ptr, size_t size) {
     (void)pool; // unused
+    (void)size; // unused
+
     assert(pool);
 
     if (ptr != NULL) {

--- a/src/pool/pool_proxy.c
+++ b/src/pool/pool_proxy.c
@@ -89,7 +89,9 @@ static void *proxy_realloc(void *pool, void *ptr, size_t size) {
     return NULL;
 }
 
-static umf_result_t proxy_free(void *pool, void *ptr) {
+static umf_result_t proxy_free(void *pool, void *ptr, size_t size) {
+    (void)size;
+
     assert(pool);
 
     struct proxy_memory_pool *hPool = (struct proxy_memory_pool *)pool;

--- a/src/pool/pool_scalable.c
+++ b/src/pool/pool_scalable.c
@@ -244,7 +244,9 @@ static void *tbb_aligned_malloc(void *pool, size_t size, size_t alignment) {
     return ptr;
 }
 
-static umf_result_t tbb_free(void *pool, void *ptr) {
+static umf_result_t tbb_free(void *pool, void *ptr, size_t size) {
+    (void)size;
+
     if (ptr == NULL) {
         return UMF_RESULT_SUCCESS;
     }

--- a/test/common/pool.hpp
+++ b/test/common/pool.hpp
@@ -91,7 +91,7 @@ typedef struct pool_base_t {
     void *realloc(void *, size_t) noexcept { return nullptr; }
     void *aligned_malloc(size_t, size_t) noexcept { return nullptr; }
     size_t malloc_usable_size(void *) noexcept { return 0; }
-    umf_result_t free(void *) noexcept { return UMF_RESULT_SUCCESS; }
+    umf_result_t free(void *, size_t) noexcept { return UMF_RESULT_SUCCESS; }
     umf_result_t get_last_allocation_error() noexcept {
         return UMF_RESULT_SUCCESS;
     }
@@ -122,7 +122,7 @@ struct malloc_pool : public pool_base_t {
         return ::malloc_usable_size(ptr);
 #endif
     }
-    umf_result_t free(void *ptr) noexcept {
+    umf_result_t free(void *ptr, size_t) noexcept {
         ::free(ptr);
         return UMF_RESULT_SUCCESS;
     }

--- a/test/common/pool_null.c
+++ b/test/common/pool_null.c
@@ -52,9 +52,10 @@ static size_t nullMallocUsableSize(void *pool, void *ptr) {
     return 0;
 }
 
-static umf_result_t nullFree(void *pool, void *ptr) {
+static umf_result_t nullFree(void *pool, void *ptr, size_t size) {
     (void)pool;
     (void)ptr;
+    (void)size;
     return UMF_RESULT_SUCCESS;
 }
 

--- a/test/common/pool_trace.c
+++ b/test/common/pool_trace.c
@@ -73,11 +73,11 @@ static size_t traceMallocUsableSize(void *pool, void *ptr) {
     return umfPoolMallocUsableSize(trace_pool->params.hUpstreamPool, ptr);
 }
 
-static umf_result_t traceFree(void *pool, void *ptr) {
+static umf_result_t traceFree(void *pool, void *ptr, size_t size) {
     trace_pool_t *trace_pool = (trace_pool_t *)pool;
 
     trace_pool->params.trace("free");
-    return umfPoolFree(trace_pool->params.hUpstreamPool, ptr);
+    return umfPoolFreeSized(trace_pool->params.hUpstreamPool, ptr, size);
 }
 
 static umf_result_t traceGetLastStatus(void *pool) {


### PR DESCRIPTION
a version of umfPoolFree that accepts allocation size as arg.

Rationale:
It's often possible to greatly optimize free implementation when size is known. To support such optimizations we should expose umfPoolFreeSized an the let each pool decide whether it needs size argument or not.

Very often size of the allocation is known: e.g. especially when allocating metadata or fixed-sized structs.