### PR TITLE
Unify global umf_ba_pool_t initialization

### DIFF
--- a/src/base_alloc/base_alloc_global.c
+++ b/src/base_alloc/base_alloc_global.c
@@ -6,34 +6,39 @@
 */
 
 #include <assert.h>
+#include <stdlib.h>
 
 #include "base_alloc.h"
+#include "utils_concurrency.h"
 
 #define SIZE_BA_POOL_CHUNK 128
 
 // global base allocator used by all providers and pools
 static umf_ba_pool_t *BA_pool = NULL;
+static UTIL_ONCE_FLAG ba_is_initialized = UTIL_ONCE_FLAG_INIT;
 
-int umf_ba_create_global(void) {
-    assert(BA_pool == NULL);
-
-    BA_pool = umf_ba_create(SIZE_BA_POOL_CHUNK);
-    if (!BA_pool) {
-        return -1;
-    }
-
-    return 0;
-}
-
-void umf_ba_destroy_global(void) {
+static void umf_ba_destroy_global(void) {
     assert(BA_pool);
     umf_ba_destroy(BA_pool);
     BA_pool = NULL;
 }
 
+static void umf_ba_create_global(void) {
+    assert(BA_pool == NULL);
+    BA_pool = umf_ba_create(SIZE_BA_POOL_CHUNK);
+    if (BA_pool) {
+        atexit(umf_ba_destroy_global);
+    }
+}
+
 umf_ba_pool_t *umf_ba_get_pool(size_t size) {
+    util_init_once(&ba_is_initialized, umf_ba_create_global);
+
+    if (!BA_pool) {
+        return NULL;
+    }
+
     // TODO: a specific class-size base allocator can be returned here
-    assert(BA_pool);
     assert(size <= SIZE_BA_POOL_CHUNK);
 
     if (size > SIZE_BA_POOL_CHUNK) {

--- a/src/base_alloc/base_alloc_global.h
+++ b/src/base_alloc/base_alloc_global.h
@@ -14,8 +14,6 @@
 extern "C" {
 #endif
 
-int umf_ba_create_global(void);
-void umf_ba_destroy_global(void);
 umf_ba_pool_t *umf_ba_get_pool(size_t size);
 
 #ifdef __cplusplus

--- a/src/libumf_linux.c
+++ b/src/libumf_linux.c
@@ -16,11 +16,9 @@ umf_memory_tracker_handle_t TRACKER = NULL;
 
 void __attribute__((constructor)) umfCreate(void) {
     TRACKER = umfMemoryTrackerCreate();
-    umf_ba_create_global();
 }
 
 void __attribute__((destructor)) umfDestroy(void) {
-    umf_ba_destroy_global();
     umfMemoryTrackerDestroy(TRACKER);
 }
 

--- a/src/libumf_windows.c
+++ b/src/libumf_windows.c
@@ -15,15 +15,9 @@
 
 umf_memory_tracker_handle_t TRACKER = NULL;
 
-static void umfCreate(void) {
-    TRACKER = umfMemoryTrackerCreate();
-    umf_ba_create_global();
-}
+static void umfCreate(void) { TRACKER = umfMemoryTrackerCreate(); }
 
-static void umfDestroy(void) {
-    umf_ba_destroy_global();
-    umfMemoryTrackerDestroy(TRACKER);
-}
+static void umfDestroy(void) { umfMemoryTrackerDestroy(TRACKER); }
 
 #if defined(UMF_SHARED_LIBRARY)
 BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {

--- a/src/pool/pool_jemalloc.c
+++ b/src/pool/pool_jemalloc.c
@@ -22,14 +22,6 @@
 
 #define MALLOCX_ARENA_MAX (MALLCTL_ARENAS_ALL - 1)
 
-#ifdef UMF_SHARED_LIBRARY
-static UTIL_ONCE_FLAG jemalloc_is_initialized = UTIL_ONCE_FLAG_INIT;
-static void jemalloc_global_init(void) {
-    umf_ba_create_global();
-    atexit(umf_ba_destroy_global);
-}
-#endif
-
 typedef struct jemalloc_memory_pool_t {
     umf_memory_provider_handle_t provider;
     unsigned int arena_index; // index of jemalloc arena
@@ -362,10 +354,6 @@ static void *je_aligned_alloc(void *pool, size_t size, size_t alignment) {
 
 static umf_result_t je_initialize(umf_memory_provider_handle_t provider,
                                   void *params, void **out_pool) {
-#ifdef UMF_SHARED_LIBRARY
-    util_init_once(&jemalloc_is_initialized, jemalloc_global_init);
-#endif
-
     assert(provider);
     assert(out_pool);
     (void)params; // unused

--- a/src/pool/pool_scalable.c
+++ b/src/pool/pool_scalable.c
@@ -104,11 +104,6 @@ static void init_tbb_global_state(void) {
         return;
     }
 
-#ifdef UMF_SHARED_LIBRARY
-    umf_ba_create_global();
-    atexit(umf_ba_destroy_global);
-#endif
-
     g_tbb_ops = tbb_ops;
 }
 

--- a/src/utils/utils_windows_concurrency.c
+++ b/src/utils/utils_windows_concurrency.c
@@ -48,5 +48,5 @@ static BOOL CALLBACK initOnceCb(PINIT_ONCE InitOnce, PVOID Parameter,
 }
 
 void util_init_once(UTIL_ONCE_FLAG *flag, void (*onceCb)(void)) {
-    InitOnceExecuteOnce(flag, initOnceCb, (void *)&onceCb, NULL);
+    InitOnceExecuteOnce(flag, initOnceCb, (void *)onceCb, NULL);
 }


### PR DESCRIPTION
Initializing the global pool in libumf and in each pool separately led to problems with double initialization when multiple pools were used in a single application (and static libumf).

To avoid this problem, use util_init_once inside umf_ba_get_pool instead of having explicit constructor/destructor.

This fixes an issue exposed by:  0c55d8f55d583e87af4f08157c0ad1c828a02ac6