### PR TITLE
Add ALIGN_UP and ALIGN_DOWN macros and remove align_size()

### DIFF
--- a/src/base_alloc/base_alloc.c
+++ b/src/base_alloc/base_alloc.c
@@ -115,8 +115,8 @@ static void ba_divide_memory_into_chunks(umf_ba_pool_t *pool, void *ptr,
 }
 
 umf_ba_pool_t *umf_ba_create(size_t size) {
-    size_t chunk_size = align_size(size, MEMORY_ALIGNMENT);
-    size_t mutex_size = align_size(util_mutex_get_size(), MEMORY_ALIGNMENT);
+    size_t chunk_size = ALIGN_UP(size, MEMORY_ALIGNMENT);
+    size_t mutex_size = ALIGN_UP(util_mutex_get_size(), MEMORY_ALIGNMENT);
 
     size_t metadata_size = sizeof(struct umf_ba_main_pool_meta_t);
     size_t pool_size = sizeof(void *) + metadata_size + mutex_size +
@@ -125,7 +125,7 @@ umf_ba_pool_t *umf_ba_create(size_t size) {
         pool_size = MINIMUM_POOL_SIZE;
     }
 
-    pool_size = align_size(pool_size, ba_os_get_page_size());
+    pool_size = ALIGN_UP(pool_size, ba_os_get_page_size());
 
     umf_ba_pool_t *pool = (umf_ba_pool_t *)ba_os_alloc(pool_size);
     if (!pool) {

--- a/src/base_alloc/base_alloc_linear.c
+++ b/src/base_alloc/base_alloc_linear.c
@@ -78,7 +78,7 @@ umf_ba_linear_pool_t *umf_ba_linear_create(size_t pool_size) {
         pool_size = MINIMUM_LINEAR_POOL_SIZE;
     }
 
-    pool_size = align_size(pool_size, ba_os_get_page_size());
+    pool_size = ALIGN_UP(pool_size, ba_os_get_page_size());
 
     umf_ba_linear_pool_t *pool = (umf_ba_linear_pool_t *)ba_os_alloc(pool_size);
     if (!pool) {
@@ -109,7 +109,7 @@ umf_ba_linear_pool_t *umf_ba_linear_create(size_t pool_size) {
 }
 
 void *umf_ba_linear_alloc(umf_ba_linear_pool_t *pool, size_t size) {
-    size_t aligned_size = align_size(size, MEMORY_ALIGNMENT);
+    size_t aligned_size = ALIGN_UP(size, MEMORY_ALIGNMENT);
     util_mutex_lock(&pool->metadata.lock);
     if (pool->metadata.size_left < aligned_size) {
         size_t pool_size = MINIMUM_LINEAR_POOL_SIZE;
@@ -117,7 +117,7 @@ void *umf_ba_linear_alloc(umf_ba_linear_pool_t *pool, size_t size) {
             pool_size - offsetof(umf_ba_next_linear_pool_t, data);
         if (usable_size < aligned_size) {
             pool_size += aligned_size - usable_size;
-            pool_size = align_size(pool_size, ba_os_get_page_size());
+            pool_size = ALIGN_UP(pool_size, ba_os_get_page_size());
         }
 
         assert(pool_size - offsetof(umf_ba_next_linear_pool_t, data) >=

--- a/src/utils/utils_common.h
+++ b/src/utils/utils_common.h
@@ -86,15 +86,8 @@ static inline void align_ptr_size(void **ptr, size_t *size, size_t alignment) {
     *size = s;
 }
 
-static inline size_t align_size(size_t size, size_t alignment) {
-    // align size to 'alignment' bytes
-    size_t rest = size & (alignment - 1);
-    if (rest) {
-        return (size - rest + alignment);
-    } else {
-        return size;
-    }
-}
+#define ALIGN_UP(value, align) (((value) + (align)-1) & ~((align)-1))
+#define ALIGN_DOWN(value, align) ((value) & ~((align)-1))
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add `ALIGN_UP` and `ALIGN_DOWN` macros and remove `align_size()`. Replace `align_size()` with `ALIGN_UP()`.