### PR TITLE
Destroy global base allocator in the library destructor

### DIFF
--- a/src/base_alloc/base_alloc_global.h
+++ b/src/base_alloc/base_alloc_global.h
@@ -15,6 +15,7 @@ extern "C" {
 #endif
 
 umf_ba_pool_t *umf_ba_get_pool(size_t size);
+void umf_ba_destroy_global(void);
 
 #ifdef __cplusplus
 }

--- a/src/base_alloc/base_alloc_linux.c
+++ b/src/base_alloc/base_alloc_linux.c
@@ -12,6 +12,15 @@
 #include <unistd.h>
 
 #include "base_alloc.h"
+#include "base_alloc_global.h"
+
+// The highest possible priority (101) is used, because the constructor should be called
+// as the first one and the destructor as the last one in order to avoid use-after-free.
+void __attribute__((constructor(101))) umf_ba_constructor(void) {}
+
+void __attribute__((destructor(101))) umf_ba_destructor(void) {
+    umf_ba_destroy_global();
+}
 
 void *ba_os_alloc(size_t size) {
     return mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS,

--- a/src/libumf_windows.c
+++ b/src/libumf_windows.c
@@ -17,7 +17,10 @@ umf_memory_tracker_handle_t TRACKER = NULL;
 
 static void umfCreate(void) { TRACKER = umfMemoryTrackerCreate(); }
 
-static void umfDestroy(void) { umfMemoryTrackerDestroy(TRACKER); }
+static void umfDestroy(void) {
+    umfMemoryTrackerDestroy(TRACKER);
+    umf_ba_destroy_global();
+}
 
 #if defined(UMF_SHARED_LIBRARY)
 BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {


### PR DESCRIPTION
The global base allocator should be destroyed in the library destructor in order to avoid use-after-free.