### PR TITLE
Make sure TRACKER is not used after being destroyed

### DIFF
--- a/src/libumf_linux.c
+++ b/src/libumf_linux.c
@@ -19,7 +19,10 @@ void __attribute__((constructor)) umfCreate(void) {
 }
 
 void __attribute__((destructor)) umfDestroy(void) {
-    umfMemoryTrackerDestroy(TRACKER);
+    umf_memory_tracker_handle_t t = TRACKER;
+    // make sure TRACKER is not used after being destroyed
+    TRACKER = NULL;
+    umfMemoryTrackerDestroy(t);
 }
 
 void libumfInit(void) {

--- a/src/provider/provider_tracking.c
+++ b/src/provider/provider_tracking.c
@@ -81,6 +81,16 @@ static umf_result_t umfMemoryTrackerRemove(umf_memory_tracker_handle_t hTracker,
 umf_memory_pool_handle_t umfMemoryTrackerGetPool(const void *ptr) {
     assert(ptr);
 
+    if (TRACKER == NULL) {
+        fprintf(stderr, "tracker is not created\n");
+        return NULL;
+    }
+
+    if (TRACKER->map == NULL) {
+        fprintf(stderr, "tracker's map is not created\n");
+        return NULL;
+    }
+
     uintptr_t rkey;
     tracker_value_t *rvalue;
     int found = critnib_find(TRACKER->map, (uintptr_t)ptr, FIND_LE,


### PR DESCRIPTION
Make sure TRACKER is not used after being destroyed.
Also add checks to umfMemoryTrackerGetPool()
to detect if TRACKER or its map is not initialized.