### PR TITLE
Use getenv() also on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,7 +102,16 @@ else()
                     LIBS ${UMF_LIBS})
 endif()
 
+# PUBLIC compile definitions
 target_compile_definitions(umf PUBLIC ${UMF_COMPILE_DEFINITIONS})
+
+# PRIVATE compile definitions
+if(WINDOWS)
+    # Disable the warning:
+    # warning C4996: 'getenv': This function or variable may be unsafe.
+    # Consider using _dupenv_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS.
+    target_compile_definitions(umf PRIVATE _CRT_SECURE_NO_WARNINGS)
+endif()
 
 if (UMF_ENABLE_POOL_TRACKING)
     target_sources(umf PRIVATE memory_pool_tracking.c)

--- a/src/utils/utils_common.h
+++ b/src/utils/utils_common.h
@@ -36,30 +36,12 @@ extern "C" {
 
 #define __TLS __declspec(thread)
 
-static inline char *util_getenv(const char *name) {
-    char *buffer;
-    size_t numberOfElements;
-    errno_t err = _dupenv_s(&buffer, &numberOfElements, name);
-    if (err) {
-        return NULL;
-    }
-
-    return buffer;
-}
-
-static inline void util_free_getenv(char *val) { free(val); }
-
 // TODO: implement util_get_page_size() for Windows
 static inline size_t util_get_page_size(void) { return 4096; }
 
 #else /* Linux */
 
 #define __TLS __thread
-
-static inline char *util_getenv(const char *name) { return getenv(name); }
-static inline void util_free_getenv(const char *val) {
-    (void)val; // unused
-}
 
 static inline size_t util_get_page_size(void) { return sysconf(_SC_PAGE_SIZE); }
 
@@ -68,12 +50,11 @@ static inline size_t util_get_page_size(void) { return sysconf(_SC_PAGE_SIZE); }
 // check if we are running in the proxy library
 static inline int is_running_in_proxy_lib(void) {
     int is_in_proxy_lib_val = 0;
-    char *ld_preload = util_getenv("LD_PRELOAD");
+    char *ld_preload = getenv("LD_PRELOAD");
     if (ld_preload && strstr(ld_preload, "libumf_proxy.so")) {
         is_in_proxy_lib_val = 1;
     }
 
-    util_free_getenv(ld_preload);
     return is_in_proxy_lib_val;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -145,6 +145,14 @@ add_umf_test(NAME base_alloc
 add_umf_test(NAME base_alloc_linear
             SRCS ${BA_SOURCES_FOR_TEST} test_base_alloc_linear.cpp
             LIBS umf_utils)
+
+if(WINDOWS)
+    # Disable the warning:
+    # warning C4996: 'getenv': This function or variable may be unsafe.
+    # Consider using _dupenv_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS.
+    target_compile_definitions(umf_test-base_alloc_linear PRIVATE _CRT_SECURE_NO_WARNINGS)
+endif()
+
 if(LINUX)
     # TODO: fix this on windows
     add_umf_test(NAME base_alloc_global


### PR DESCRIPTION
Remove `util_free_getenv()` and replace `util_getenv()` with `getenv()`. Define `_CRT_SECURE_NO_WARNINGS` to disable the warning:
```
warning C4996: 'getenv': This function or variable may be unsafe.
Consider using _dupenv_s instead. To disable deprecation,
use _CRT_SECURE_NO_WARNINGS.
```