### PR TITLE
close tbb handle on scalable pool finalize

### DIFF
--- a/src/pool/pool_scalable.c
+++ b/src/pool/pool_scalable.c
@@ -34,79 +34,78 @@ typedef void (*raw_free_tbb_type)(intptr_t, void *, size_t);
 static __TLS umf_result_t TLS_last_allocation_error;
 static __TLS umf_result_t TLS_last_free_error;
 
-struct mem_pool_policy_s {
+typedef struct tbb_mem_pool_policy_t {
     raw_alloc_tbb_type pAlloc;
     raw_free_tbb_type pFree;
     size_t granularity;
     int version;
     unsigned fixed_pool : 1, keep_all_memory : 1, reserved : 30;
-};
+} tbb_mem_pool_policy_t;
 
-struct tbb_callbacks {
+typedef struct tbb_callbacks_t {
     void *(*pool_malloc)(void *, size_t);
     void *(*pool_realloc)(void *, void *, size_t);
     void *(*pool_aligned_malloc)(void *, size_t, size_t);
     bool (*pool_free)(void *, void *);
-    int (*pool_create_v1)(intptr_t, const struct mem_pool_policy_s *, void **);
+    int (*pool_create_v1)(intptr_t, const struct tbb_mem_pool_policy_t *,
+                          void **);
     bool (*pool_destroy)(void *);
     void *(*pool_identify)(void *object);
     size_t (*pool_msize)(void *, void *);
-};
+    void *lib_handle;
+} tbb_callbacks_t;
 
-struct tbb_memory_pool {
+typedef struct tbb_memory_pool_t {
     umf_memory_provider_handle_t mem_provider;
     void *tbb_pool;
-};
+    tbb_callbacks_t tbb_callbacks;
+} tbb_memory_pool_t;
 
-static struct tbb_callbacks g_tbb_ops;
-static UTIL_ONCE_FLAG tbb_is_initialized = UTIL_ONCE_FLAG_INIT;
-static bool Init_tbb_global_state_failed;
+static int init_tbb_callbacks(tbb_callbacks_t *tbb_callbacks) {
+    assert(tbb_callbacks);
 
-static void init_tbb_global_state(void) {
     const char so_name[] = "libtbbmalloc.so.2";
-    void *tbb_handle = dlopen(so_name, RTLD_LAZY);
-    if (!tbb_handle) {
+    tbb_callbacks->lib_handle = dlopen(so_name, RTLD_LAZY);
+    if (!tbb_callbacks->lib_handle) {
         fprintf(stderr, "%s not found.\n", so_name);
-        Init_tbb_global_state_failed = true;
-        return;
+        return -1;
     }
 
-    struct tbb_callbacks tbb_ops;
-
-    *(void **)&tbb_ops.pool_malloc =
-        dlsym(tbb_handle, "_ZN3rml11pool_mallocEPNS_10MemoryPoolEm");
-    *(void **)&tbb_ops.pool_realloc =
-        dlsym(tbb_handle, "_ZN3rml12pool_reallocEPNS_10MemoryPoolEPvm");
-    *(void **)&tbb_ops.pool_aligned_malloc =
-        dlsym(tbb_handle, "_ZN3rml19pool_aligned_mallocEPNS_10MemoryPoolEmm");
-    *(void **)&tbb_ops.pool_free =
-        dlsym(tbb_handle, "_ZN3rml9pool_freeEPNS_10MemoryPoolEPv");
-    *(void **)&tbb_ops.pool_create_v1 = dlsym(
-        tbb_handle,
+    *(void **)&tbb_callbacks->pool_malloc = dlsym(
+        tbb_callbacks->lib_handle, "_ZN3rml11pool_mallocEPNS_10MemoryPoolEm");
+    *(void **)&tbb_callbacks->pool_realloc =
+        dlsym(tbb_callbacks->lib_handle,
+              "_ZN3rml12pool_reallocEPNS_10MemoryPoolEPvm");
+    *(void **)&tbb_callbacks->pool_aligned_malloc =
+        dlsym(tbb_callbacks->lib_handle,
+              "_ZN3rml19pool_aligned_mallocEPNS_10MemoryPoolEmm");
+    *(void **)&tbb_callbacks->pool_free = dlsym(
+        tbb_callbacks->lib_handle, "_ZN3rml9pool_freeEPNS_10MemoryPoolEPv");
+    *(void **)&tbb_callbacks->pool_create_v1 = dlsym(
+        tbb_callbacks->lib_handle,
         "_ZN3rml14pool_create_v1ElPKNS_13MemPoolPolicyEPPNS_10MemoryPoolE");
-    *(void **)&tbb_ops.pool_destroy =
-        dlsym(tbb_handle, "_ZN3rml12pool_destroyEPNS_10MemoryPoolE");
-    *(void **)&tbb_ops.pool_identify =
-        dlsym(tbb_handle, "_ZN3rml13pool_identifyEPv");
-    *(void **)&tbb_ops.pool_msize =
-        dlsym(tbb_handle, "_ZN3rml10pool_msizeEPNS_10MemoryPoolEPv");
+    *(void **)&tbb_callbacks->pool_destroy = dlsym(
+        tbb_callbacks->lib_handle, "_ZN3rml12pool_destroyEPNS_10MemoryPoolE");
+    *(void **)&tbb_callbacks->pool_identify =
+        dlsym(tbb_callbacks->lib_handle, "_ZN3rml13pool_identifyEPv");
+    *(void **)&tbb_callbacks->pool_msize = dlsym(
+        tbb_callbacks->lib_handle, "_ZN3rml10pool_msizeEPNS_10MemoryPoolEPv");
 
-    if (!tbb_ops.pool_malloc || !tbb_ops.pool_realloc ||
-        !tbb_ops.pool_aligned_malloc || !tbb_ops.pool_free ||
-        !tbb_ops.pool_create_v1 || !tbb_ops.pool_destroy ||
-        !tbb_ops.pool_identify) {
+    if (!tbb_callbacks->pool_malloc || !tbb_callbacks->pool_realloc ||
+        !tbb_callbacks->pool_aligned_malloc || !tbb_callbacks->pool_free ||
+        !tbb_callbacks->pool_create_v1 || !tbb_callbacks->pool_destroy ||
+        !tbb_callbacks->pool_identify) {
         fprintf(stderr, "Could not find symbols in %s.\n", so_name);
-        dlclose(tbb_handle);
-        Init_tbb_global_state_failed = true;
-        return;
+        dlclose(tbb_callbacks->lib_handle);
+        return -1;
     }
 
-    g_tbb_ops = tbb_ops;
+    return 0;
 }
 
 static void *tbb_raw_alloc_wrapper(intptr_t pool_id, size_t *raw_bytes) {
     void *resPtr;
-    struct tbb_memory_pool *pool = (struct tbb_memory_pool *)pool_id;
+    tbb_memory_pool_t *pool = (tbb_memory_pool_t *)pool_id;
     umf_result_t ret =
         umfMemoryProviderAlloc(pool->mem_provider, *raw_bytes, 0, &resPtr);
     if (ret != UMF_RESULT_SUCCESS) {
@@ -118,7 +117,7 @@ static void *tbb_raw_alloc_wrapper(intptr_t pool_id, size_t *raw_bytes) {
 }
 
 static void tbb_raw_free_wrapper(intptr_t pool_id, void *ptr, size_t bytes) {
-    struct tbb_memory_pool *pool = (struct tbb_memory_pool *)pool_id;
+    tbb_memory_pool_t *pool = (tbb_memory_pool_t *)pool_id;
     umf_result_t ret = umfMemoryProviderFree(pool->mem_provider, ptr, bytes);
     if (ret != UMF_RESULT_SUCCESS) {
         TLS_last_free_error = ret;
@@ -134,30 +133,30 @@ static umf_result_t tbb_pool_initialize(umf_memory_provider_handle_t provider,
     (void)params; // unused
 
     const size_t GRANULARITY = 2 * 1024 * 1024;
-    struct mem_pool_policy_s policy = {.pAlloc = tbb_raw_alloc_wrapper,
-                                       .pFree = tbb_raw_free_wrapper,
-                                       .granularity = GRANULARITY,
-                                       .version = 1,
-                                       .fixed_pool = false,
-                                       .keep_all_memory = false,
-                                       .reserved = 0};
+    tbb_mem_pool_policy_t policy = {.pAlloc = tbb_raw_alloc_wrapper,
+                                    .pFree = tbb_raw_free_wrapper,
+                                    .granularity = GRANULARITY,
+                                    .version = 1,
+                                    .fixed_pool = false,
+                                    .keep_all_memory = false,
+                                    .reserved = 0};
 
-    util_init_once(&tbb_is_initialized, init_tbb_global_state);
-    if (Init_tbb_global_state_failed) {
-        fprintf(stderr, "loading TBB symbols failed\n");
-        return UMF_RESULT_ERROR_UNKNOWN;
-    }
-
-    struct tbb_memory_pool *pool_data =
-        umf_ba_global_alloc(sizeof(struct tbb_memory_pool));
+    tbb_memory_pool_t *pool_data =
+        umf_ba_global_alloc(sizeof(tbb_memory_pool_t));
     if (!pool_data) {
         fprintf(stderr, "cannot allocate memory for metadata\n");
         return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
 
+    int ret = init_tbb_callbacks(&pool_data->tbb_callbacks);
+    if (ret != 0) {
+        fprintf(stderr, "loading TBB symbols failed\n");
+        return UMF_RESULT_ERROR_UNKNOWN;
+    }
+
     pool_data->mem_provider = provider;
-    int ret = g_tbb_ops.pool_create_v1((intptr_t)pool_data, &policy,
-                                       &(pool_data->tbb_pool));
+    ret = pool_data->tbb_callbacks.pool_create_v1((intptr_t)pool_data, &policy,
+                                                  &(pool_data->tbb_pool));
     if (ret != TBBMALLOC_OK) {
         return UMF_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC;
     }
@@ -168,16 +167,16 @@ static umf_result_t tbb_pool_initialize(umf_memory_provider_handle_t provider,
 }
 
 static void tbb_pool_finalize(void *pool) {
-    util_init_once(&tbb_is_initialized, init_tbb_global_state);
-    struct tbb_memory_pool *pool_data = (struct tbb_memory_pool *)pool;
-    g_tbb_ops.pool_destroy(pool_data->tbb_pool);
-    umf_ba_global_free(pool_data, sizeof(struct tbb_memory_pool));
+    tbb_memory_pool_t *pool_data = (tbb_memory_pool_t *)pool;
+    pool_data->tbb_callbacks.pool_destroy(pool_data->tbb_pool);
+    dlclose(pool_data->tbb_callbacks.lib_handle);
+    umf_ba_global_free(pool_data, sizeof(tbb_memory_pool_t));
 }
 
 static void *tbb_malloc(void *pool, size_t size) {
-    struct tbb_memory_pool *pool_data = (struct tbb_memory_pool *)pool;
+    tbb_memory_pool_t *pool_data = (tbb_memory_pool_t *)pool;
     TLS_last_allocation_error = UMF_RESULT_SUCCESS;
-    void *ptr = g_tbb_ops.pool_malloc(pool_data->tbb_pool, size);
+    void *ptr = pool_data->tbb_callbacks.pool_malloc(pool_data->tbb_pool, size);
     if (ptr == NULL) {
         if (TLS_last_allocation_error == UMF_RESULT_SUCCESS) {
             TLS_last_allocation_error = UMF_RESULT_ERROR_UNKNOWN;
@@ -202,9 +201,10 @@ static void *tbb_calloc(void *pool, size_t num, size_t size) {
 }
 
 static void *tbb_realloc(void *pool, void *ptr, size_t size) {
-    struct tbb_memory_pool *pool_data = (struct tbb_memory_pool *)pool;
+    tbb_memory_pool_t *pool_data = (tbb_memory_pool_t *)pool;
     TLS_last_allocation_error = UMF_RESULT_SUCCESS;
-    void *new_ptr = g_tbb_ops.pool_realloc(pool_data->tbb_pool, ptr, size);
+    void *new_ptr =
+        pool_data->tbb_callbacks.pool_realloc(pool_data->tbb_pool, ptr, size);
     if (new_ptr == NULL) {
         if (TLS_last_allocation_error == UMF_RESULT_SUCCESS) {
             TLS_last_allocation_error = UMF_RESULT_ERROR_UNKNOWN;
@@ -216,10 +216,10 @@ static void *tbb_realloc(void *pool, void *ptr, size_t size) {
 }
 
 static void *tbb_aligned_malloc(void *pool, size_t size, size_t alignment) {
-    struct tbb_memory_pool *pool_data = (struct tbb_memory_pool *)pool;
+    tbb_memory_pool_t *pool_data = (tbb_memory_pool_t *)pool;
     TLS_last_allocation_error = UMF_RESULT_SUCCESS;
-    void *ptr =
-        g_tbb_ops.pool_aligned_malloc(pool_data->tbb_pool, size, alignment);
+    void *ptr = pool_data->tbb_callbacks.pool_aligned_malloc(
+        pool_data->tbb_pool, size, alignment);
     if (ptr == NULL) {
         if (TLS_last_allocation_error == UMF_RESULT_SUCCESS) {
             TLS_last_allocation_error = UMF_RESULT_ERROR_UNKNOWN;
@@ -243,8 +243,8 @@ static umf_result_t tbb_free(void *pool, void *ptr) {
     // other threads.
     utils_annotate_release(pool);
 
-    struct tbb_memory_pool *pool_data = (struct tbb_memory_pool *)pool;
-    if (g_tbb_ops.pool_free(pool_data->tbb_pool, ptr)) {
+    tbb_memory_pool_t *pool_data = (tbb_memory_pool_t *)pool;
+    if (pool_data->tbb_callbacks.pool_free(pool_data->tbb_pool, ptr)) {
         return UMF_RESULT_SUCCESS;
     }
 
@@ -256,8 +256,8 @@ static umf_result_t tbb_free(void *pool, void *ptr) {
 }
 
 static size_t tbb_malloc_usable_size(void *pool, void *ptr) {
-    struct tbb_memory_pool *pool_data = (struct tbb_memory_pool *)pool;
-    return g_tbb_ops.pool_msize(pool_data->tbb_pool, ptr);
+    tbb_memory_pool_t *pool_data = (tbb_memory_pool_t *)pool;
+    return pool_data->tbb_callbacks.pool_msize(pool_data->tbb_pool, ptr);
 }
 
 static umf_result_t tbb_get_last_allocation_error(void *pool) {


### PR DESCRIPTION
The handle received from dlopen() was never closed - this PR fixes that. This is also one of the problems reported by the Coverity (#437908)