### PR TITLE
Enable pool tracking in the tests of the proxy library

### DIFF
--- a/.github/workflows/proxy_lib.yml
+++ b/.github/workflows/proxy_lib.yml
@@ -41,7 +41,7 @@ jobs:
           -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
           -DUMF_BUILD_LIBUMF_POOL_DISJOINT=ON
           -DUMF_BUILD_LIBUMF_POOL_SCALABLE=ON
-          -DUMF_ENABLE_POOL_TRACKING=OFF
+          -DUMF_ENABLE_POOL_TRACKING=ON
 
       - name: Build UMF
         run: cmake --build ${{github.workspace}}/build -j $(nproc)


### PR DESCRIPTION
Enable pool tracking in the tests of the proxy library: UMF_ENABLE_POOL_TRACKING=ON