### PR TITLE
Add memcheck and asan annotations

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,6 +40,7 @@ jobs:
         -DUMF_BUILD_LIBUMF_POOL_DISJOINT=ON
         -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
         -DUMF_BUILD_LEVEL_ZERO_PROVIDER=OFF
+        -DUSE_VALGRIND=1
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config Debug -j$(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ option(USE_ASAN "Enable AddressSanitizer checks" OFF)
 option(USE_UBSAN "Enable UndefinedBehaviorSanitizer checks" OFF)
 option(USE_TSAN "Enable ThreadSanitizer checks" OFF)
 option(USE_MSAN "Enable MemorySanitizer checks" OFF)
+option(USE_VALGRIND "Enable Valgrind instrumentation" OFF)
 
 # For using the options listed in the OPTIONS_REQUIRING_CXX variable
 # a C++17 compiler is required. Moreover, if these options are not set,

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ List of options provided by CMake:
 | USE_UBSAN | Enable UndefinedBehaviorSanitizer checks | ON/OFF | OFF |
 | USE_TSAN | Enable ThreadSanitizer checks | ON/OFF | OFF |
 | USE_MSAN | Enable MemorySanitizer checks | ON/OFF | OFF |
+| USE_VALGRIND | Enable Valgrind instrumentation | ON/OFF | OFF |
 
 ## Architecture: memory pools and providers
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -17,6 +17,19 @@ set(UMF_UTILS_SOURCES_WINDOWS
     utils_windows_math.c
 )
 
+if(USE_VALGRIND)
+    if (USE_ASAN OR USE_TSAN OR USE_UBSAN OR USE_MSAN)
+        message(FATAL_ERROR "Cannot use valgrind and sanitizers together")
+    endif()
+
+    if(PkgConfig_FOUND)
+        pkg_check_modules(VALGRIND valgrind)
+    endif()
+    if(NOT VALGRIND_FOUND)
+        find_package(VALGRIND REQUIRED valgrind)
+    endif()
+endif()
+
 if(LINUX OR MACOSX)
     set(UMF_UTILS_SOURCES ${UMF_UTILS_SOURCES_POSIX})
 elseif(WINDOWS)
@@ -30,11 +43,16 @@ add_umf_library(NAME umf_utils
 
 add_library(${PROJECT_NAME}::utils ALIAS umf_utils)
 
-target_include_directories(umf_utils PUBLIC 
+target_include_directories(umf_utils PUBLIC
+    ${VALGRIND_INCLUDE_DIRS}
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
+
+if(USE_VALGRIND)
+    target_compile_definitions(umf_utils PUBLIC UMF_VG_ENABLED=1)
+endif()
 
 install(TARGETS umf_utils
         EXPORT ${PROJECT_NAME}-targets)

--- a/src/utils/utils_sanitizers.h
+++ b/src/utils/utils_sanitizers.h
@@ -13,17 +13,106 @@
 #define __SANITIZE_THREAD__ 1
 #endif
 #endif
+#if __has_feature(address_sanitizer)
+#ifndef __SANITIZE_ADDRESS__
+#define __SANITIZE_ADDRESS__ 1
+#endif
+#endif
+#endif
+
+#if UMF_VG_ENABLED
+#undef UMF_VG_MEMCHECK_ENABLED
+#undef UMF_VG_HELGRIND_ENABLED
+#undef UMF_VG_DRD_ENABLED
+
+#define UMF_VG_MEMCHECK_ENABLED 1
+#define UMF_VG_HELGRIND_ENABLED 1
+#define UMF_VG_DRD_ENABLED 1
+#endif
+
+#if UMF_VG_MEMCHECK_ENABLED || UMF_VG_HELGRIND_ENABLED || UMF_VG_DRD_ENABLED
+#define UMF_ANY_VG_TOOL_ENABLED 1
+#endif
+
+#if UMF_ANY_VG_TOOL_ENABLED
+#include <valgrind.h>
+#endif
+
+#if UMF_VG_MEMCHECK_ENABLED
+#include <memcheck.h>
+#endif
+
+#if UMF_VG_HELGRIND_ENABLED
+#include <helgrind.h>
+#endif
+
+#if UMF_VG_DRD_ENABLED
+#include <drd.h>
 #endif
 
 #if __SANITIZE_THREAD__
 #include <sanitizer/tsan_interface.h>
 #endif
 
+#if __SANITIZE_ADDRESS__
+#include <sanitizer/asan_interface.h>
+#endif
+
+#if UMF_VG_MEMCHECK_ENABLED
+#define VALGRIND_DO_MALLOCLIKE_BLOCK VALGRIND_MALLOCLIKE_BLOCK
+#define VALGRIND_DO_FREELIKE_BLOCK VALGRIND_FREELIKE_BLOCK
+#define VALGRIND_DO_CREATE_MEMPOOL VALGRIND_CREATE_MEMPOOL
+#define VALGRIND_DO_DESTROY_MEMPOOL VALGRIND_DESTROY_MEMPOOL
+#define VALGRIND_DO_MEMPOOL_ALLOC VALGRIND_MEMPOOL_ALLOC
+#define VALGRIND_DO_MEMPOOL_FREE VALGRIND_MEMPOOL_FREE
+#else
+#define VALGRIND_DO_MALLOCLIKE_BLOCK(ptr, size, rzB, is_zeroed)                \
+    do {                                                                       \
+        (void)(ptr);                                                           \
+        (void)(size);                                                          \
+        (void)(rzB);                                                           \
+        (void)(is_zeroed);                                                     \
+    } while (0)
+
+#define VALGRIND_DO_FREELIKE_BLOCK(ptr, rzB)                                   \
+    do {                                                                       \
+        (void)(ptr);                                                           \
+        (void)(rzB);                                                           \
+    } while (0)
+
+#define VALGRIND_DO_CREATE_MEMPOOL(pool, rzB, is_zeroed)                       \
+    do {                                                                       \
+        (void)(pool);                                                          \
+        (void)(rzB);                                                           \
+        (void)(is_zeroed);                                                     \
+    } while (0)
+
+#define VALGRIND_DO_DESTROY_MEMPOOL(pool)                                      \
+    do {                                                                       \
+        (void)(pool);                                                          \
+    } while (0)
+
+#define VALGRIND_DO_MEMPOOL_ALLOC(pool, ptr, size)                             \
+    do {                                                                       \
+        (void)(pool);                                                          \
+        (void)(ptr);                                                           \
+        (void)(size);                                                          \
+    } while (0)
+
+#define VALGRIND_DO_MEMPOOL_FREE(pool, ptr)                                    \
+    do {                                                                       \
+        (void)(pool);                                                          \
+        (void)(ptr);                                                           \
+    } while (0)
+#endif
+
+#include <stdlib.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void utils_annotate_acquire(void *ptr) {
+static inline void utils_annotate_acquire(void *ptr) {
 #if __SANITIZE_THREAD__
     __tsan_acquire(ptr);
 #else
@@ -31,11 +120,46 @@ void utils_annotate_acquire(void *ptr) {
 #endif
 }
 
-void utils_annotate_release(void *ptr) {
+static inline void utils_annotate_release(void *ptr) {
 #if __SANITIZE_THREAD__
     __tsan_release(ptr);
 #else
     (void)ptr;
+#endif
+}
+
+// mark memory as accessible, defined
+static inline void utils_annotate_memory_defined(void *ptr, size_t size) {
+#ifdef __SANITIZE_ADDRESS__
+    __asan_unpoison_memory_region(ptr, size);
+#elif UMF_VG_MEMCHECK_ENABLED
+    VALGRIND_MAKE_MEM_DEFINED(ptr, size);
+#else
+    (void)ptr;
+    (void)size;
+#endif
+}
+
+// mark memory as accessible, undefined
+static inline void utils_annotate_memory_undefined(void *ptr, size_t size) {
+#ifdef __SANITIZE_ADDRESS__
+    __asan_unpoison_memory_region(ptr, size);
+#elif UMF_VG_MEMCHECK_ENABLED
+    VALGRIND_MAKE_MEM_UNDEFINED(ptr, size);
+#else
+    (void)ptr;
+    (void)size;
+#endif
+}
+
+static inline void utils_annotate_memory_inaccessible(void *ptr, size_t size) {
+#ifdef __SANITIZE_ADDRESS__
+    __asan_poison_memory_region(ptr, size);
+#elif UMF_VG_MEMCHECK_ENABLED
+    VALGRIND_MAKE_MEM_NOACCESS(ptr, size);
+#else
+    (void)ptr;
+    (void)size;
 #endif
 }
 

--- a/test/common/pool.hpp
+++ b/test/common/pool.hpp
@@ -45,6 +45,7 @@ bool isReallocSupported(umf_memory_pool_handle_t hPool) {
     static constexpr size_t allocSize = 8;
     bool supported = false;
     auto *ptr = umfPoolMalloc(hPool, allocSize);
+    memset(ptr, 0, allocSize);
     auto *new_ptr = umfPoolRealloc(hPool, ptr, allocSize * 2);
 
     if (new_ptr) {

--- a/test/poolFixtures.hpp
+++ b/test/poolFixtures.hpp
@@ -115,6 +115,7 @@ TEST_P(umfPoolTest, reallocFree) {
     static constexpr size_t multiplier = 3;
     auto *ptr = umfPoolMalloc(pool.get(), allocSize);
     ASSERT_NE(ptr, nullptr);
+    memset(ptr, 0, allocSize);
     auto *new_ptr = umfPoolRealloc(pool.get(), ptr, allocSize * multiplier);
     ASSERT_NE(new_ptr, nullptr);
     std::memset(new_ptr, 0, allocSize * multiplier);

--- a/test/supp/umf_test-jemalloc_pool.supp
+++ b/test/supp/umf_test-jemalloc_pool.supp
@@ -1,0 +1,8 @@
+{
+   realloc false-positive suppresion - see pool_jemalloc.c for more details
+   Memcheck:Addr8
+   fun:memmove
+   ...
+   fun:do_rallocx
+   fun:je_realloc
+}


### PR DESCRIPTION
Closes https://github.com/oneapi-src/unified-memory-framework/issues/217

TBB pool is not annotated because tbb keeps metadata inline and hence we cannot mark the memory as undefined/unaccessible on free.

Ref: https://valgrind.org/docs/manual/valgrind_manual.pdf