### PR TITLE
build-only docs w/o deploy on pr push

### DIFF
--- a/.github/workflows/pr_push.yml
+++ b/.github/workflows/pr_push.yml
@@ -100,6 +100,26 @@ jobs:
     - name: Check clang-format
       run: cmake --build build --target clang-format-check
 
+  DocsBuild:
+    name: Build docs
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Install doxygen
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y doxygen
+
+    - name: Install pip requirements
+      run: python3 -m pip install -r third_party/requirements.txt
+
+    - name: Build the documentation
+      working-directory: scripts
+      run: python3 generate_docs.py
+
   Spellcheck:
     uses: ./.github/workflows/spellcheck.yml
   Build:

--- a/include/umf/providers/provider_level_zero.h
+++ b/include/umf/providers/provider_level_zero.h
@@ -24,12 +24,9 @@ typedef enum umf_usm_memory_type_t {
 
 /// @brief Level Zero Memory Provider settings struct
 typedef struct level_zero_memory_provider_params_t {
-    void *level_zero_context_handle;
-    void *level_zero_device_handle;
-    umf_usm_memory_type_t memory_type;
-    uint32_t level_zero_host_mem_alloc_flags;
-    uint32_t level_zero_device_mem_alloc_flags;
-    uint32_t level_zero_device_local_mem_ordinal;
+    void *level_zero_context_handle;   ///< Handle to the Level Zero context
+    void *level_zero_device_handle;    ///< Handle to the Level Zero device
+    umf_usm_memory_type_t memory_type; ///< Allocation memory type
 } level_zero_memory_provider_params_t;
 
 umf_memory_provider_ops_t *umfLevelZeroMemoryProviderOps(void);


### PR DESCRIPTION
Build docs (without pushing them to GH pages) on PR to avoid CI failures on the main.
Requires #287 (already merged @ldorau)