### PR TITLE
Level Zero memory provider should NOT be built by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(unified-memory-framework VERSION 0.1.0 LANGUAGES C)
 # Build Options
 option(UMF_BUILD_SHARED_LIBRARY "Build UMF as shared library" OFF)
 option(UMF_BUILD_OS_MEMORY_PROVIDER "Build OS memory provider" ON)
-option(UMF_BUILD_LEVEL_ZERO_PROVIDER "Build Level Zero memory provider" ON)
+option(UMF_BUILD_LEVEL_ZERO_PROVIDER "Build Level Zero memory provider" OFF)
 option(UMF_BUILD_LIBUMF_POOL_DISJOINT "Build the libumf_pool_disjoint static library" OFF)
 option(UMF_BUILD_LIBUMF_POOL_JEMALLOC "Build the libumf_pool_jemalloc static library" OFF)
 option(UMF_BUILD_LIBUMF_POOL_SCALABLE "Build the libumf_pool_scalable static library" OFF)


### PR DESCRIPTION
Level Zero memory provider should NOT be built by default (`UMF_BUILD_LEVEL_ZERO_PROVIDER` should be OFF by default). Fix also its name in the README.md file.

Fixes: #288