### PR TITLE
Fix OOM test for HOST ALL memspace

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -135,22 +135,22 @@ if(UMF_BUILD_OS_MEMORY_PROVIDER AND LINUX) # OS-specific functions are implement
                  LIBS umf_utils ${LIBNUMA_LIBRARIES})
     add_umf_test(NAME memspace_host_all
                  SRCS memspaces/memspace_host_all.cpp
-                 LIBS ${LIBNUMA_LIBRARIES})
+                 LIBS umf_utils ${LIBNUMA_LIBRARIES})
 endif()
 
 # TODO add support for Windows
 if(UMF_BUILD_LEVEL_ZERO_PROVIDER AND LINUX)
-    # we have two test binaries here that use the same sources, but differ in 
-    # the way they are linked to the Level Zero (statically or at runtime using 
+    # we have two test binaries here that use the same sources, but differ in
+    # the way they are linked to the Level Zero (statically or at runtime using
     # dlopen)
     add_umf_test(NAME provider_level_zero
                  SRCS providers/provider_level_zero.cpp
                  LIBS umf_utils ze_loader)
-                
+
     add_umf_test(NAME provider_level_zero_dlopen
                  SRCS providers/provider_level_zero.cpp
                  LIBS umf_utils)
-    target_compile_definitions(umf_test-provider_level_zero_dlopen 
+    target_compile_definitions(umf_test-provider_level_zero_dlopen
                  PUBLIC USE_DLOPEN=1)
 endif()
 

--- a/test/supp/umf_test-memspace_host_all.supp
+++ b/test/supp/umf_test-memspace_host_all.supp
@@ -1,0 +1,21 @@
+{
+   4,608 bytes in 2 blocks are possibly lost in loss record 242 of 246
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:malloc
+   fun:_dlfo_mappings_segment_allocate
+   fun:_dl_find_object_update_1
+   fun:_dl_find_object_update
+   fun:dl_open_worker_begin
+   fun:_dl_catch_exception
+   fun:dl_open_worker
+   fun:_dl_catch_exception
+   fun:_dl_open
+   fun:dlopen_doit
+   fun:_dl_catch_exception
+   fun:_dl_catch_error
+   fun:_dlerror_run
+   fun:dlopen_implementation
+   fun:dlopen@@GLIBC_*
+}


### PR DESCRIPTION
Adjust alloc size to 4MB. Add an access to each allocation so that pages are actually allocated on the selected NUMA nodes.

~~Fixes: https://github.com/oneapi-src/unified-memory-framework/issues/285~~

This also fixes the nightly workflow fails here:  https://github.com/oneapi-src/unified-memory-framework/actions/runs/8148821384.
Nightly workflow run with these changes on my fork: https://github.com/kswiecicki/unified-memory-framework/actions/runs/8188227540.