### PR TITLE
Do not link directly with libc

### DIFF
--- a/src/pool/CMakeLists.txt
+++ b/src/pool/CMakeLists.txt
@@ -36,12 +36,10 @@ endif()
 # libumf_pool_jemalloc
 if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
     if(LINUX)
-        # TODO: we link directly with libc to force using malloc from glibc
-        # This is a temporary fix for https://github.com/oneapi-src/unified-memory-framework/issues/161
         add_umf_library(NAME jemalloc_pool
                         TYPE STATIC
                         SRCS pool_jemalloc.c ${POOL_EXTRA_SRCS}
-                        LIBS c jemalloc umf_utils)
+                        LIBS jemalloc umf_utils)
         target_compile_definitions(jemalloc_pool PUBLIC ${POOL_COMPILE_DEFINITIONS})
         add_library(${PROJECT_NAME}::jemalloc_pool ALIAS jemalloc_pool)
         install(TARGETS jemalloc_pool

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -106,11 +106,9 @@ endif()
 
 if(UMF_BUILD_OS_MEMORY_PROVIDER)
     if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
-        # TODO: we link directly with libc to force using malloc from glibc
-        # This is a temporary fix for https://github.com/oneapi-src/unified-memory-framework/issues/161
         add_umf_test(NAME jemalloc_pool
                     SRCS pools/jemalloc_pool.cpp malloc_compliance_tests.cpp
-                    LIBS c jemalloc_pool)
+                    LIBS jemalloc_pool)
     endif()
 else()
     message(STATUS "The jemalloc_pool test is DISABLED, because it uses OS_MEMORY_PROVIDER, while the UMF_BUILD_OS_MEMORY_PROVIDER option is set to OFF")


### PR DESCRIPTION
Do not link directly with libc.
It was used to force using malloc from glibc.
We do not need it any more, because we use our own base allocator now.