### PR TITLE
Split memory provider ops to mandatory and optional fields

### DIFF
--- a/src/cpp_helpers.hpp
+++ b/src/cpp_helpers.hpp
@@ -88,9 +88,11 @@ template <typename T> umf_memory_provider_ops_t providerOpsBase() {
     UMF_ASSIGN_OP_NORETURN(ops, T, get_last_native_error);
     UMF_ASSIGN_OP(ops, T, get_recommended_page_size, UMF_RESULT_ERROR_UNKNOWN);
     UMF_ASSIGN_OP(ops, T, get_min_page_size, UMF_RESULT_ERROR_UNKNOWN);
-    UMF_ASSIGN_OP(ops, T, purge_lazy, UMF_RESULT_ERROR_UNKNOWN);
-    UMF_ASSIGN_OP(ops, T, purge_force, UMF_RESULT_ERROR_UNKNOWN);
     UMF_ASSIGN_OP(ops, T, get_name, "");
+    UMF_ASSIGN_OP(ops.ext, T, purge_lazy, UMF_RESULT_ERROR_UNKNOWN);
+    UMF_ASSIGN_OP(ops.ext, T, purge_force, UMF_RESULT_ERROR_UNKNOWN);
+    UMF_ASSIGN_OP(ops.ext, T, allocation_merge, UMF_RESULT_ERROR_UNKNOWN);
+    UMF_ASSIGN_OP(ops.ext, T, allocation_split, UMF_RESULT_ERROR_UNKNOWN);
     return ops;
 }
 } // namespace detail

--- a/src/provider/provider_level_zero.c
+++ b/src/provider/provider_level_zero.c
@@ -263,11 +263,11 @@ static struct umf_memory_provider_ops_t UMF_LEVEL_ZERO_MEMORY_PROVIDER_OPS = {
     .get_last_native_error = ze_memory_provider_get_last_native_error,
     .get_recommended_page_size = ze_memory_provider_get_recommended_page_size,
     .get_min_page_size = ze_memory_provider_get_min_page_size,
-    .purge_lazy = ze_memory_provider_purge_lazy,
-    .purge_force = ze_memory_provider_purge_force,
     .get_name = ze_memory_provider_get_name,
-    .allocation_split = ze_memory_provider_allocation_split,
-    .allocation_merge = ze_memory_provider_allocation_merge,
+    .ext.purge_lazy = ze_memory_provider_purge_lazy,
+    .ext.purge_force = ze_memory_provider_purge_force,
+    .ext.allocation_merge = ze_memory_provider_allocation_merge,
+    .ext.allocation_split = ze_memory_provider_allocation_split,
 };
 
 umf_memory_provider_ops_t *umfLevelZeroMemoryProviderOps(void) {

--- a/src/provider/provider_os_memory.c
+++ b/src/provider/provider_os_memory.c
@@ -662,11 +662,11 @@ static umf_memory_provider_ops_t UMF_OS_MEMORY_PROVIDER_OPS = {
     .get_last_native_error = os_get_last_native_error,
     .get_recommended_page_size = os_get_recommended_page_size,
     .get_min_page_size = os_get_min_page_size,
-    .purge_lazy = os_purge_lazy,
-    .purge_force = os_purge_force,
     .get_name = os_get_name,
-    .allocation_split = os_allocation_split,
-    .allocation_merge = os_allocation_merge};
+    .ext.purge_lazy = os_purge_lazy,
+    .ext.purge_force = os_purge_force,
+    .ext.allocation_merge = os_allocation_merge,
+    .ext.allocation_split = os_allocation_split};
 
 umf_memory_provider_ops_t *umfOsMemoryProviderOps(void) {
     return &UMF_OS_MEMORY_PROVIDER_OPS;

--- a/src/provider/provider_tracking.c
+++ b/src/provider/provider_tracking.c
@@ -438,11 +438,11 @@ umf_memory_provider_ops_t UMF_TRACKING_MEMORY_PROVIDER_OPS = {
     .get_last_native_error = trackingGetLastError,
     .get_min_page_size = trackingGetMinPageSize,
     .get_recommended_page_size = trackingGetRecommendedPageSize,
-    .purge_force = trackingPurgeForce,
-    .purge_lazy = trackingPurgeLazy,
     .get_name = trackingName,
-    .allocation_split = trackingAllocationSplit,
-    .allocation_merge = trackingAllocationMerge};
+    .ext.purge_force = trackingPurgeForce,
+    .ext.purge_lazy = trackingPurgeLazy,
+    .ext.allocation_split = trackingAllocationSplit,
+    .ext.allocation_merge = trackingAllocationMerge};
 
 umf_result_t umfTrackingMemoryProviderCreate(
     umf_memory_provider_handle_t hUpstream, umf_memory_pool_handle_t hPool,

--- a/test/common/provider.hpp
+++ b/test/common/provider.hpp
@@ -52,6 +52,7 @@ typedef struct provider_base_t {
                                    [[maybe_unused]] size_t *pageSize) noexcept {
         return UMF_RESULT_ERROR_UNKNOWN;
     }
+    const char *get_name() noexcept { return "base"; }
     umf_result_t purge_lazy([[maybe_unused]] void *ptr,
                             [[maybe_unused]] size_t size) noexcept {
         return UMF_RESULT_ERROR_UNKNOWN;
@@ -60,7 +61,18 @@ typedef struct provider_base_t {
                              [[maybe_unused]] size_t size) noexcept {
         return UMF_RESULT_ERROR_UNKNOWN;
     }
-    const char *get_name() noexcept { return "base"; }
+
+    umf_result_t allocation_merge([[maybe_unused]] void *lowPtr,
+                                  [[maybe_unused]] void *highPtr,
+                                  [[maybe_unused]] size_t totalSize) {
+        return UMF_RESULT_ERROR_UNKNOWN;
+    }
+
+    umf_result_t allocation_split([[maybe_unused]] void *ptr,
+                                  [[maybe_unused]] size_t totalSize,
+                                  [[maybe_unused]] size_t firstSize) {
+        return UMF_RESULT_ERROR_UNKNOWN;
+    }
 } provider_base_t;
 
 umf_memory_provider_ops_t BASE_PROVIDER_OPS =

--- a/test/common/provider_null.c
+++ b/test/common/provider_null.c
@@ -56,6 +56,11 @@ static umf_result_t nullGetPageSize(void *provider, void *ptr,
     return UMF_RESULT_SUCCESS;
 }
 
+static const char *nullName(void *provider) {
+    (void)provider;
+    return "null";
+}
+
 static umf_result_t nullPurgeLazy(void *provider, void *ptr, size_t size) {
     (void)provider;
     (void)ptr;
@@ -70,9 +75,22 @@ static umf_result_t nullPurgeForce(void *provider, void *ptr, size_t size) {
     return UMF_RESULT_SUCCESS;
 }
 
-static const char *nullName(void *provider) {
+static umf_result_t nullAllocationMerge(void *provider, void *lowPtr,
+                                        void *highPtr, size_t totalSize) {
     (void)provider;
-    return "null";
+    (void)lowPtr;
+    (void)highPtr;
+    (void)totalSize;
+    return UMF_RESULT_SUCCESS;
+}
+
+static umf_result_t nullAllocationSplit(void *provider, void *ptr,
+                                        size_t totalSize, size_t firstSize) {
+    (void)provider;
+    (void)ptr;
+    (void)totalSize;
+    (void)firstSize;
+    return UMF_RESULT_SUCCESS;
 }
 
 umf_memory_provider_ops_t UMF_NULL_PROVIDER_OPS = {
@@ -84,7 +102,9 @@ umf_memory_provider_ops_t UMF_NULL_PROVIDER_OPS = {
     .get_last_native_error = nullGetLastError,
     .get_recommended_page_size = nullGetRecommendedPageSize,
     .get_min_page_size = nullGetPageSize,
-    .purge_lazy = nullPurgeLazy,
-    .purge_force = nullPurgeForce,
     .get_name = nullName,
+    .ext.purge_lazy = nullPurgeLazy,
+    .ext.purge_force = nullPurgeForce,
+    .ext.allocation_merge = nullAllocationMerge,
+    .ext.allocation_split = nullAllocationSplit,
 };


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

As we agreed on our sync, the memory provider ops structure is split into mandatory and optional fields. Mandatory fields should be always initialized with a pointer to the appropriate function. Optional fields can be NULL. If an optional field is NULL the UMF initializes it with a default implementation that returns `UMF_RESULT_ERROR_NOT_SUPPORTED` error code.

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [x] New tests added, especially if they will fail without my changes
