### PR TITLE
[CI] Update runner's label for GPU workflow

### DIFF
--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -17,11 +17,10 @@ jobs:
 
     strategy:
       matrix:
-        os: ['ubuntu-22.04']
         build_type: [Release]
         compiler: [{c: gcc, cxx: g++}]
         shared_library: ['ON', 'OFF']
-    runs-on: level_zero
+    runs-on:  [ "DSS-LEVEL_ZERO", "DSS-UBUNTU" ]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description
Using new runners require updated labels

### Checklist

- [x] CI workflows execute properly

// previe of the execution: https://github.com/oneapi-src/unified-memory-framework/actions/runs/8251864728/job/22597511622#step:1:2
