### PR TITLE
Fix ba_leak_free and ba_leak_pool_contains_pointer in proxy library

### DIFF
--- a/src/proxy_lib/proxy_lib.c
+++ b/src/proxy_lib/proxy_lib.c
@@ -140,33 +140,39 @@ static void ba_leak_create(void) { Base_alloc_leak = umf_ba_linear_create(0); }
 
 // it does not implement destroy(), because we cannot destroy non-freed memory
 
-static inline void *ba_leak_malloc(size_t size) {
+static void ba_leak_init_once(void) {
     util_init_once(&Base_alloc_leak_initialized, ba_leak_create);
+}
+
+static inline void *ba_leak_malloc(size_t size) {
+    ba_leak_init_once();
     return umf_ba_linear_alloc(Base_alloc_leak, size);
 }
 
 static inline void *ba_leak_calloc(size_t nmemb, size_t size) {
-    util_init_once(&Base_alloc_leak_initialized, ba_leak_create);
+    ba_leak_init_once();
     // umf_ba_linear_alloc() returns zeroed memory
     return umf_ba_linear_alloc(Base_alloc_leak, nmemb * size);
 }
 
 static inline void *ba_leak_realloc(void *ptr, size_t size, size_t max_size) {
-    util_init_once(&Base_alloc_leak_initialized, ba_leak_create);
+    ba_leak_init_once();
     return ba_generic_realloc(Base_alloc_leak, ptr, size, max_size);
 }
 
 static inline void *ba_leak_aligned_alloc(size_t alignment, size_t size) {
-    util_init_once(&Base_alloc_leak_initialized, ba_leak_create);
+    ba_leak_init_once();
     void *ptr = umf_ba_linear_alloc(Base_alloc_leak, size + alignment);
     return (void *)ALIGN_UP((uintptr_t)ptr, alignment);
 }
 
 static inline int ba_leak_free(void *ptr) {
+    ba_leak_init_once();
     return umf_ba_linear_free(Base_alloc_leak, ptr);
 }
 
 static inline size_t ba_leak_pool_contains_pointer(void *ptr) {
+    ba_leak_init_once();
     return umf_ba_linear_pool_contains_pointer(Base_alloc_leak, ptr);
 }
 


### PR DESCRIPTION
Add missing initialization of the linear base allocator.
