### PR TITLE
Run sanitizers on self-hosted runner

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -18,7 +18,7 @@ jobs:
         compiler: [{c: icx, cxx: icpx}]
         # TSAN is mutually exclusive with other sanitizers
         sanitizers: [{asan: ON, ubsan: ON, tsan: OFF}, {asan: OFF, ubsan: OFF, tsan: ON}]
-    runs-on: ubuntu-22.04
+    runs-on: 'intel-ubuntu-latest'
     container:
       image: intel/oneapi:latest
       volumes:
@@ -69,7 +69,7 @@ jobs:
         compiler: [{c: gcc, cxx: g++}, {c: clang, cxx: clang++}]
         # TSAN is mutually exclusive with other sanitizers
         sanitizers: [{asan: ON, ubsan: ON, tsan: OFF}, {asan: OFF, ubsan: OFF, tsan: ON}]
-    runs-on: ubuntu-22.04
+    runs-on: 'intel-ubuntu-latest'
 
     steps:
     - name: Checkout


### PR DESCRIPTION
### Description
Sanitizer CI jobs fail when ran on the specific version of a ubuntu runner hosted by GitHub:
```
Image: ubuntu-22.04
Version: 20240310.1.0
```
The UMF tests fail with an error:
```
FATAL: ThreadSanitizer: unexpected memory mapping 0x7e16b9472000-0x7e16b9900000
```
even if there are no threads spawned by a test.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly

