### PR TITLE
add _CRT_SECURE_NO_WARNINGS definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ install(
 if(WINDOWS)
     # set PATH to DLLs on Windows
     set(DLL_PATH_LIST "PATH=path_list_append:../bin/$<CONFIG>")
+    add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 endif()
 
 if(UMF_BUILD_OS_MEMORY_PROVIDER AND (LINUX OR WINDOWS))

--- a/examples/basic/basic.c
+++ b/examples/basic/basic.c
@@ -13,8 +13,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "utils_common.h"
-
 int main(void) {
     // A result object for storing UMF API result status
     umf_result_t res;
@@ -51,7 +49,7 @@ int main(void) {
 
     // Write to the allocated memory
     memset(ptr_provider, '\0', alloc_size);
-    util_strncpy(ptr_provider, alloc_size, strSource, strlen(strSource) + 1);
+    strncpy(ptr_provider, strSource, alloc_size);
     printf("%s %p with the memory provider at %p\n", (char *)ptr_provider,
            (void *)ptr_provider, (void *)provider);
 
@@ -87,7 +85,7 @@ int main(void) {
     }
 
     // Write a string to allocated memory
-    util_strncpy(ptr, alloc_size, strSource, strlen(strSource) + 1);
+    strncpy(ptr, strSource, alloc_size);
     printf("%s %p\n", ptr, (void *)ptr);
 
     // Retrieve a memory pool from a pointer, available with memory tracking

--- a/src/utils/utils_common.h
+++ b/src/utils/utils_common.h
@@ -66,8 +66,6 @@ int util_is_running_in_proxy_lib(void);
 
 size_t util_get_page_size(void);
 
-char *util_strncpy(char *dest, size_t destSize, const char *src, size_t n);
-
 // align a pointer and a size
 void util_align_ptr_size(void **ptr, size_t *size, size_t alignment);
 

--- a/src/utils/utils_posix_common.c
+++ b/src/utils/utils_posix_common.c
@@ -50,8 +50,3 @@ size_t util_get_page_size(void) {
     util_init_once(&Page_size_is_initialized, _util_get_page_size);
     return Page_size;
 }
-
-char *util_strncpy(char *dest, size_t destSize, const char *src, size_t n) {
-    (void)destSize; // unused
-    return strncpy(dest, src, n);
-}

--- a/src/utils/utils_windows_common.c
+++ b/src/utils/utils_windows_common.c
@@ -46,11 +46,3 @@ size_t util_get_page_size(void) {
     util_init_once(&Page_size_is_initialized, _util_get_page_size);
     return Page_size;
 }
-
-char *util_strncpy(char *dest, size_t destSize, const char *src, size_t n) {
-    if (strncpy_s(dest, destSize, src, n)) {
-        return NULL;
-    }
-
-    return dest;
-}


### PR DESCRIPTION
This commit introduces the _CRT_SECURE_NO_WARNINGS definition and removes the usage of strncpy_s from UMF to demonstrate that change works correctly.

The rationale for this change can be found in this issue:

Closes: oneapi-src/unified-memory-framework#317

<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
