### PR TITLE
Use global base alloc in critnib

### DIFF
--- a/src/critnib/critnib.c
+++ b/src/critnib/critnib.c
@@ -129,9 +129,6 @@ struct critnib {
     uint64_t remove_count;
 
     struct os_mutex_t mutex; /* writes/removes */
-
-    umf_ba_pool_t *pool_nodes;
-    umf_ba_pool_t *pool_leaves;
 };
 
 /*
@@ -191,25 +188,10 @@ struct critnib *critnib_new(void) {
         goto err_free_critnib;
     }
 
-    c->pool_nodes = umf_ba_create(sizeof(struct critnib_node));
-    if (!c->pool_nodes) {
-        goto err_util_mutex_destroy;
-    }
-
-    c->pool_leaves = umf_ba_create(sizeof(struct critnib_leaf));
-    if (!c->pool_leaves) {
-        goto err_destroy_pool_nodes;
-    }
-
     VALGRIND_HG_DRD_DISABLE_CHECKING(&c->root, sizeof(c->root));
     VALGRIND_HG_DRD_DISABLE_CHECKING(&c->remove_count, sizeof(c->remove_count));
 
     return c;
-
-err_destroy_pool_nodes:
-    umf_ba_destroy(c->pool_nodes);
-err_util_mutex_destroy:
-    util_mutex_destroy_not_free(&c->mutex);
 err_free_critnib:
     umf_ba_global_free(c);
     return NULL;
@@ -220,7 +202,7 @@ err_free_critnib:
  */
 static void delete_node(struct critnib *c, struct critnib_node *__restrict n) {
     if (is_leaf(n)) {
-        umf_ba_free(c->pool_leaves, to_leaf(n));
+        umf_ba_global_free(to_leaf(n));
     } else {
         for (int i = 0; i < SLNODES; i++) {
             if (n->child[i]) {
@@ -228,7 +210,7 @@ static void delete_node(struct critnib *c, struct critnib_node *__restrict n) {
             }
         }
 
-        umf_ba_free(c->pool_nodes, n);
+        umf_ba_global_free(n);
     }
 }
 
@@ -244,23 +226,21 @@ void critnib_delete(struct critnib *c) {
 
     for (struct critnib_node *m = c->deleted_node; m;) {
         struct critnib_node *mm = m->child[0];
-        umf_ba_free(c->pool_nodes, m);
+        umf_ba_global_free(m);
         m = mm;
     }
 
     for (struct critnib_leaf *k = c->deleted_leaf; k;) {
         struct critnib_leaf *kk = k->value;
-        umf_ba_free(c->pool_leaves, k);
+        umf_ba_global_free(k);
         k = kk;
     }
 
     for (int i = 0; i < DELETED_LIFE; i++) {
-        umf_ba_free(c->pool_nodes, c->pending_del_nodes[i]);
-        umf_ba_free(c->pool_leaves, c->pending_del_leaves[i]);
+        umf_ba_global_free(c->pending_del_nodes[i]);
+        umf_ba_global_free(c->pending_del_leaves[i]);
     }
 
-    umf_ba_destroy(c->pool_nodes);
-    umf_ba_destroy(c->pool_leaves);
     umf_ba_global_free(c);
 }
 
@@ -288,7 +268,7 @@ static void free_node(struct critnib *__restrict c,
  */
 static struct critnib_node *alloc_node(struct critnib *__restrict c) {
     if (!c->deleted_node) {
-        return umf_ba_alloc(c->pool_nodes);
+        return umf_ba_global_alloc(sizeof(struct critnib_node));
     }
 
     struct critnib_node *n = c->deleted_node;
@@ -319,7 +299,7 @@ static void free_leaf(struct critnib *__restrict c,
  */
 static struct critnib_leaf *alloc_leaf(struct critnib *__restrict c) {
     if (!c->deleted_leaf) {
-        return umf_ba_alloc(c->pool_leaves);
+        return umf_ba_global_alloc(sizeof(struct critnib_leaf));
     }
 
     struct critnib_leaf *k = c->deleted_leaf;


### PR DESCRIPTION
To avoid wasting memory. This will improve memory utilization especially for IPC-related changes where each memory provider can have it's own critnib instance for caching handles.

<!-- Provide a short summary of your changes in the Title above -->

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
