### PR TITLE
Move functions from utils_common.h to utils_common.c

### DIFF
--- a/src/base_alloc/base_alloc.c
+++ b/src/base_alloc/base_alloc.c
@@ -167,7 +167,7 @@ umf_ba_pool_t *umf_ba_create(size_t size) {
     char *data_ptr = (char *)&pool->data;
     size_t size_left = pool_size - offsetof(umf_ba_pool_t, data);
 
-    align_ptr_size((void **)&data_ptr, &size_left, MEMORY_ALIGNMENT);
+    util_align_ptr_size((void **)&data_ptr, &size_left, MEMORY_ALIGNMENT);
 
     // init free_lock
     os_mutex_t *mutex = util_mutex_init(&pool->metadata.free_lock);
@@ -208,7 +208,7 @@ void *umf_ba_alloc(umf_ba_pool_t *pool) {
         size_t size_left =
             pool->metadata.pool_size - offsetof(umf_ba_next_pool_t, data);
 
-        align_ptr_size((void **)&data_ptr, &size_left, MEMORY_ALIGNMENT);
+        util_align_ptr_size((void **)&data_ptr, &size_left, MEMORY_ALIGNMENT);
         ba_divide_memory_into_chunks(pool, data_ptr, size_left);
     }
 
@@ -281,7 +281,7 @@ void umf_ba_destroy(umf_ba_pool_t *pool) {
     // Do not destroy if we are running in the proxy library,
     // because it may need those resources till
     // the very end of exiting the application.
-    if (pool->metadata.n_allocs && is_running_in_proxy_lib()) {
+    if (pool->metadata.n_allocs && util_is_running_in_proxy_lib()) {
         return;
     }
 

--- a/src/base_alloc/base_alloc_linear.c
+++ b/src/base_alloc/base_alloc_linear.c
@@ -97,7 +97,7 @@ umf_ba_linear_pool_t *umf_ba_linear_create(size_t pool_size) {
     void *data_ptr = &pool->data;
     size_t size_left = pool_size - offsetof(umf_ba_linear_pool_t, data);
 
-    align_ptr_size(&data_ptr, &size_left, MEMORY_ALIGNMENT);
+    util_align_ptr_size(&data_ptr, &size_left, MEMORY_ALIGNMENT);
 
     pool->metadata.pool_size = pool_size;
     pool->metadata.data_ptr = data_ptr;
@@ -145,7 +145,7 @@ void *umf_ba_linear_alloc(umf_ba_linear_pool_t *pool, size_t size) {
         void *data_ptr = &new_pool->data;
         size_t size_left =
             new_pool->pool_size - offsetof(umf_ba_next_linear_pool_t, data);
-        align_ptr_size(&data_ptr, &size_left, MEMORY_ALIGNMENT);
+        util_align_ptr_size(&data_ptr, &size_left, MEMORY_ALIGNMENT);
 
         pool->metadata.data_ptr = data_ptr;
         pool->metadata.size_left = size_left;
@@ -239,7 +239,7 @@ void umf_ba_linear_destroy(umf_ba_linear_pool_t *pool) {
     // Do not destroy if we are running in the proxy library,
     // because it may need those resources till
     // the very end of exiting the application.
-    if (is_running_in_proxy_lib()) {
+    if (util_is_running_in_proxy_lib()) {
         return;
     }
 

--- a/src/critnib/critnib.c
+++ b/src/critnib/critnib.c
@@ -60,6 +60,7 @@
 #include "base_alloc.h"
 #include "base_alloc_global.h"
 #include "critnib.h"
+#include "utils_assert.h"
 #include "utils_common.h"
 #include "utils_concurrency.h"
 

--- a/src/memory_pool.c
+++ b/src/memory_pool.c
@@ -9,7 +9,7 @@
 
 #include "libumf.h"
 #include "memory_pool_internal.h"
-#include "utils_common.h"
+#include "utils_assert.h"
 
 #include <umf/memory_pool.h>
 #include <umf/memory_pool_ops.h>

--- a/src/memory_provider.c
+++ b/src/memory_provider.c
@@ -18,7 +18,7 @@
 #include "base_alloc_global.h"
 #include "libumf.h"
 #include "memory_provider_internal.h"
-#include "utils_common.h"
+#include "utils_assert.h"
 
 typedef struct umf_memory_provider_t {
     umf_memory_provider_ops_t ops;

--- a/src/provider/provider_tracking.c
+++ b/src/provider/provider_tracking.c
@@ -361,7 +361,7 @@ static void check_if_tracker_is_empty(umf_memory_tracker_handle_t hTracker,
         // Do not assert if we are running in the proxy library,
         // because it may need those resources till
         // the very end of exiting the application.
-        if (!is_running_in_proxy_lib()) {
+        if (!util_is_running_in_proxy_lib()) {
             if (pool) {
                 fprintf(stderr,
                         "ASSERT: tracking provider of pool %p is not empty! "
@@ -514,7 +514,7 @@ void umfMemoryTrackerDestroy(umf_memory_tracker_handle_t handle) {
     // Do not destroy if we are running in the proxy library,
     // because it may need those resources till
     // the very end of exiting the application.
-    if (is_running_in_proxy_lib()) {
+    if (util_is_running_in_proxy_lib()) {
         return;
     }
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -5,6 +5,10 @@
 include(${UMF_CMAKE_SOURCE_DIR}/cmake/helpers.cmake)
 include(FindThreads)
 
+set(UMF_UTILS_SOURCES_COMMON
+    utils_common.c
+)
+
 set(UMF_UTILS_SOURCES_POSIX
     utils_posix_common.c
     utils_posix_concurrency.c
@@ -31,9 +35,9 @@ if(USE_VALGRIND)
 endif()
 
 if(LINUX OR MACOSX)
-    set(UMF_UTILS_SOURCES ${UMF_UTILS_SOURCES_POSIX})
+    set(UMF_UTILS_SOURCES ${UMF_UTILS_SOURCES_COMMON} ${UMF_UTILS_SOURCES_POSIX})
 elseif(WINDOWS)
-    set(UMF_UTILS_SOURCES ${UMF_UTILS_SOURCES_WINDOWS})
+    set(UMF_UTILS_SOURCES ${UMF_UTILS_SOURCES_COMMON} ${UMF_UTILS_SOURCES_WINDOWS})
 endif()
 
 add_umf_library(NAME umf_utils

--- a/src/utils/utils_assert.h
+++ b/src/utils/utils_assert.h
@@ -1,0 +1,65 @@
+/*
+ *
+ * Copyright (C) 2023-2024 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ */
+
+#ifndef UMF_ASSERT_H
+#define UMF_ASSERT_H 1
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define NOFUNCTION                                                             \
+    do {                                                                       \
+    } while (0)
+
+#ifdef NDEBUG
+#define ASSERT(x) NOFUNCTION
+#define ASSERTne(x, y) NOFUNCTION
+#else
+#define ASSERT(x)                                                              \
+    do {                                                                       \
+        if (!(x)) {                                                            \
+            fprintf(stderr,                                                    \
+                    "Assertion failed: " #x " at " __FILE__ " line %d.\n",     \
+                    __LINE__);                                                 \
+            abort();                                                           \
+        }                                                                      \
+    } while (0)
+#define ASSERTne(x, y)                                                         \
+    do {                                                                       \
+        long X = (x);                                                          \
+        long Y = (y);                                                          \
+        if (X == Y) {                                                          \
+            fprintf(stderr,                                                    \
+                    "Assertion failed: " #x " != " #y                          \
+                    ", both are %ld, at " __FILE__ " line %d.\n",              \
+                    X, __LINE__);                                              \
+            abort();                                                           \
+        }                                                                      \
+    } while (0)
+#endif
+
+#define UMF_CHECK(condition, errorStatus)                                      \
+    do {                                                                       \
+        if (!(condition)) {                                                    \
+            fprintf(stderr, "UMF check failed: " #condition " in %s\n",        \
+                    __func__);                                                 \
+            return errorStatus;                                                \
+        }                                                                      \
+    } while (0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UMF_ASSERT_H */

--- a/src/utils/utils_common.c
+++ b/src/utils/utils_common.c
@@ -1,0 +1,35 @@
+/*
+ *
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ */
+
+#include "utils_common.h"
+#include "utils_assert.h"
+
+// align a pointer and a size
+void util_align_ptr_size(void **ptr, size_t *size, size_t alignment) {
+    uintptr_t p = (uintptr_t)*ptr;
+    size_t s = *size;
+
+    // align pointer to 'alignment' bytes and adjust the size
+    size_t rest = p & (alignment - 1);
+    if (rest) {
+        p += alignment - rest;
+        s -= alignment - rest;
+    }
+
+    ASSERT((p & (alignment - 1)) == 0);
+    ASSERT((s & (alignment - 1)) == 0);
+
+    *ptr = (void *)p;
+    *size = s;
+}
+
+// check if we are running in the proxy library
+int util_is_running_in_proxy_lib(void) {
+    return util_env_var_has_str("LD_PRELOAD", "libumf_proxy.so");
+}

--- a/src/utils/utils_common.h
+++ b/src/utils/utils_common.h
@@ -10,9 +10,9 @@
 #ifndef UMF_COMMON_H
 #define UMF_COMMON_H 1
 
+#include <assert.h>
+#include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -21,10 +21,17 @@ extern "C" {
 #define DO_WHILE_EMPTY                                                         \
     do {                                                                       \
     } while (0)
+
 #define DO_WHILE_EXPRS(expression)                                             \
     do {                                                                       \
         expression;                                                            \
     } while (0)
+
+#define ALIGN_UP(value, align) (((value) + (align)-1) & ~((align)-1))
+#define ALIGN_DOWN(value, align) ((value) & ~((align)-1))
+
+#define VALGRIND_ANNOTATE_NEW_MEMORY(p, s) DO_WHILE_EMPTY
+#define VALGRIND_HG_DRD_DISABLE_CHECKING(p, s) DO_WHILE_EMPTY
 
 #ifdef _WIN32 /* Windows */
 
@@ -55,76 +62,14 @@ int util_env_var(const char *envvar, char *buffer, size_t buffer_size);
 int util_env_var_has_str(const char *envvar, const char *str);
 
 // check if we are running in the proxy library
-static inline int is_running_in_proxy_lib(void) {
-    return util_env_var_has_str("LD_PRELOAD", "libumf_proxy.so");
-}
+int util_is_running_in_proxy_lib(void);
 
 size_t util_get_page_size(void);
+
 char *util_strncpy(char *dest, size_t destSize, const char *src, size_t n);
 
-#define NOFUNCTION                                                             \
-    do {                                                                       \
-    } while (0)
-#define VALGRIND_ANNOTATE_NEW_MEMORY(p, s) NOFUNCTION
-#define VALGRIND_HG_DRD_DISABLE_CHECKING(p, s) NOFUNCTION
-
-#ifdef NDEBUG
-#define ASSERT(x) NOFUNCTION
-#define ASSERTne(x, y) ASSERT(x != y)
-#else
-#define ASSERT(x)                                                              \
-    do {                                                                       \
-        if (!(x)) {                                                            \
-            fprintf(stderr,                                                    \
-                    "Assertion failed: " #x " at " __FILE__ " line %d.\n",     \
-                    __LINE__);                                                 \
-            abort();                                                           \
-        }                                                                      \
-    } while (0)
-#define ASSERTne(x, y)                                                         \
-    do {                                                                       \
-        long X = (x);                                                          \
-        long Y = (y);                                                          \
-        if (X == Y) {                                                          \
-            fprintf(stderr,                                                    \
-                    "Assertion failed: " #x " != " #y                          \
-                    ", both are %ld, at " __FILE__ " line %d.\n",              \
-                    X, __LINE__);                                              \
-            abort();                                                           \
-        }                                                                      \
-    } while (0)
-#endif
-
-#define UMF_CHECK(condition, errorStatus)                                      \
-    do {                                                                       \
-        if (!(condition)) {                                                    \
-            fprintf(stderr, "UMF check failed: " #condition " in %s\n",        \
-                    __func__);                                                 \
-            return errorStatus;                                                \
-        }                                                                      \
-    } while (0)
-
 // align a pointer and a size
-static inline void align_ptr_size(void **ptr, size_t *size, size_t alignment) {
-    uintptr_t p = (uintptr_t)*ptr;
-    size_t s = *size;
-
-    // align pointer to 'alignment' bytes and adjust the size
-    size_t rest = p & (alignment - 1);
-    if (rest) {
-        p += alignment - rest;
-        s -= alignment - rest;
-    }
-
-    ASSERT((p & (alignment - 1)) == 0);
-    ASSERT((s & (alignment - 1)) == 0);
-
-    *ptr = (void *)p;
-    *size = s;
-}
-
-#define ALIGN_UP(value, align) (((value) + (align)-1) & ~((align)-1))
-#define ALIGN_DOWN(value, align) ((value) & ~((align)-1))
+void util_align_ptr_size(void **ptr, size_t *size, size_t alignment);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Description

Move functions from `utils_common.h` to `utils_common.c` and assert-related stuff to `utils_assert.h`.

This change is required to enable the proxy library on Windows - it needs some macros from `utils_common.h`,
but the `stdlib.h` cannot be included on Windows due to "_inconsistent DLL linkage_".

### Checklist

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
