### PR TITLE
Print size of the exceeding allocation in the debug message

### DIFF
--- a/src/base_alloc/base_alloc_global.c
+++ b/src/base_alloc/base_alloc_global.c
@@ -161,8 +161,9 @@ void *umf_ba_global_aligned_alloc(size_t size, size_t alignment) {
     if (ac_index >= NUM_ALLOCATION_CLASSES) {
 #ifndef NDEBUG
         fprintf(stderr,
-                "base_alloc: allocation size larger than the biggest "
-                "allocation class. Falling back to OS memory allocation.\n");
+                "base_alloc: allocation size (%zu) larger than the biggest "
+                "allocation class. Falling back to OS memory allocation.\n",
+                size);
 #endif
         return add_metadata_and_align(ba_os_alloc(size), size, alignment);
     }


### PR DESCRIPTION
### Description

Print size of the exceeding allocation in the debug message

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
