### PR TITLE
Simplify getenv implementation

### DIFF
--- a/src/utils/utils_common.c
+++ b/src/utils/utils_common.c
@@ -31,6 +31,15 @@ void util_align_ptr_size(void **ptr, size_t *size, size_t alignment) {
     *size = s;
 }
 
+int util_env_var_has_str(const char *envvar, const char *str) {
+    char *value = getenv(envvar);
+    if (value && strstr(value, str)) {
+        return 1;
+    }
+
+    return 0;
+}
+
 // check if we are running in the proxy library
 int util_is_running_in_proxy_lib(void) {
     return util_env_var_has_str("LD_PRELOAD", "libumf_proxy.so");

--- a/src/utils/utils_common.h
+++ b/src/utils/utils_common.h
@@ -43,21 +43,6 @@ extern "C" {
 
 #endif /* _WIN32 */
 
-// utils_env_var - populate the given buffer with the value
-//                of the given environment variable
-// Return value
-// If the function succeeds, the return value is the number of characters
-// stored in the buffer pointed to by buffer, not including
-// the terminating null character.
-//
-// If the buffer is not large enough to hold the data, then:
-// 1) the return value equals (-1) * the buffer size (in characters)
-//    required to hold the string and its terminating null character,
-// 2) the content of the buffer is undefined.
-//
-// If the function fails, the return value is zero.
-int util_env_var(const char *envvar, char *buffer, size_t buffer_size);
-
 // Check if the environment variable contains the given string.
 int util_env_var_has_str(const char *envvar, const char *str);
 

--- a/src/utils/utils_log.c
+++ b/src/utils/utils_log.c
@@ -133,9 +133,9 @@ void util_log(util_log_level_t level, const char *format, ...) {
 static const char *bool_to_str(int b) { return b ? "yes" : "no"; }
 
 void util_log_init(void) {
-    char envVar[MAX_ENV_LEN];
+    const char *envVar = getenv("UMF_LOG");
 
-    if (util_env_var("UMF_LOG", envVar, sizeof(envVar)) <= 0) {
+    if (!envVar) {
         return;
     }
 

--- a/src/utils/utils_posix_common.c
+++ b/src/utils/utils_posix_common.c
@@ -17,33 +17,6 @@
 static UTIL_ONCE_FLAG Page_size_is_initialized = UTIL_ONCE_FLAG_INIT;
 static size_t Page_size;
 
-int util_env_var(const char *envvar, char *buffer, size_t buffer_size) {
-    char *value = getenv(envvar);
-    if (!value) {
-        return 0;
-    }
-
-    size_t len = strlen(value) + 1;
-    if (len > buffer_size) {
-        return -len;
-    }
-
-    strncpy(buffer, value, buffer_size - 1);
-    // make sure the string is NULL-terminated
-    buffer[buffer_size - 1] = 0;
-
-    return (len - 1);
-}
-
-int util_env_var_has_str(const char *envvar, const char *str) {
-    char *value = getenv(envvar);
-    if (value && strstr(value, str)) {
-        return 1;
-    }
-
-    return 0;
-}
-
 static void _util_get_page_size(void) { Page_size = sysconf(_SC_PAGE_SIZE); }
 
 size_t util_get_page_size(void) {

--- a/src/utils/utils_windows_common.c
+++ b/src/utils/utils_windows_common.c
@@ -18,24 +18,6 @@
 static UTIL_ONCE_FLAG Page_size_is_initialized = UTIL_ONCE_FLAG_INIT;
 static size_t Page_size;
 
-int util_env_var(const char *envvar, char *buffer, size_t buffer_size) {
-    int ret = GetEnvironmentVariableA(envvar, buffer, (DWORD)buffer_size);
-    if (ret >= buffer_size) {
-        return -ret;
-    }
-
-    return ret;
-}
-
-int util_env_var_has_str(const char *envvar, const char *str) {
-    char buffer[BUFFER_SIZE];
-    if (util_env_var(envvar, buffer, BUFFER_SIZE) > 0) {
-        return (strstr(buffer, str) != NULL);
-    }
-
-    return 0;
-}
-
 static void _util_get_page_size(void) {
     SYSTEM_INFO SystemInfo;
     GetSystemInfo(&SystemInfo);

--- a/test/utils/utils_log.cpp
+++ b/test/utils/utils_log.cpp
@@ -47,22 +47,8 @@ int mock_fflush(FILE *stream) {
 }
 
 extern "C" {
+
 const char *env_variable = "";
-
-int mock_util_env_var(const char *envvar, char *buffer, size_t buffer_size) {
-    (void)envvar;
-    if (!env_variable) {
-        return 0;
-    }
-
-    size_t len = strlen(env_variable) + 1;
-    len = buffer_size < len ? buffer_size : len;
-
-    memcpy(buffer, env_variable, len);
-
-    return (int)len;
-}
-
 #define fopen(A, B) mock_fopen(A, B)
 #define fopen_s(A, B, C) mock_fopen_s(A, B, C)
 #define fputs(A, B) mock_fputs(A, B)


### PR DESCRIPTION
### Description

Commit 683a26e (add _CRT_SECURE_NO_WARNINGS definition, 2024-03-13) removed need to use not standard, secure implementations of some CRT functions on windows. This allows use getenv on all supported OSes what simplifies getting and parsing environment variables.

ref: oneapi-src/unified-memory-framework#317

<!-- Provide a short summary of your changes in the Title above -->

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
