### PR TITLE
remove fopen_s and fix error in logger

### DIFF
--- a/src/utils/utils_log.c
+++ b/src/utils/utils_log.c
@@ -156,20 +156,23 @@ void util_log_init(void) {
             len = strlen(arg);
         }
 
-        if (len <= MAX_FILE_PATH) {
-            memcpy(file, arg, len);
-            file[len] = '\0';
-            loggerConfig.output = fopen(file, "w");
+        if (len > MAX_FILE_PATH) {
+            loggerConfig.output = stderr;
+            LOG_ERR("Cannot open output file - path too long");
+            loggerConfig.output = NULL;
+            return;
         }
+
+        memcpy(file, arg, len);
+        file[len] = '\0';
+        loggerConfig.output = fopen(file, "w");
         if (!loggerConfig.output) {
             loggerConfig.output = stderr;
             LOG_ERR("Cannot open output file %s - logging disabled", file);
             loggerConfig.output = NULL;
             return;
         }
-    }
-
-    else {
+    } else {
         loggerConfig.output = stderr;
         LOG_ERR("Logging output not set - logging disabled");
         loggerConfig.output = NULL;

--- a/src/utils/utils_log.c
+++ b/src/utils/utils_log.c
@@ -159,13 +159,7 @@ void util_log_init(void) {
         if (len <= MAX_FILE_PATH) {
             memcpy(file, arg, len);
             file[len] = '\0';
-#ifdef _WIN32
-            if (fopen_s(&loggerConfig.output, file, "w")) {
-                loggerConfig.output = NULL;
-            }
-#else
             loggerConfig.output = fopen(file, "w");
-#endif
         }
         if (!loggerConfig.output) {
             loggerConfig.output = stderr;

--- a/test/utils/utils_log.cpp
+++ b/test/utils/utils_log.cpp
@@ -90,6 +90,7 @@ void helper_checkConfig(util_log_config_t *expected, util_log_config_t *is) {
 }
 
 TEST_F(test, parseEnv_errors) {
+    expected_message = "";
     loggerConfig = {0, 0, LOG_ERROR, LOG_ERROR, NULL};
     expect_fput_count = 0;
     expected_stream = stderr;
@@ -105,6 +106,9 @@ TEST_F(test, parseEnv_errors) {
     helper_checkConfig(&b, &loggerConfig);
     helper_log_init("_level:debug");
     helper_checkConfig(&b, &loggerConfig);
+    expect_fput_count = 1;
+    expected_message = "[ERROR UMF] Cannot open output file - path too long\n";
+    helper_log_init(("output:file," + std::string(300, 'x')).c_str());
 }
 
 TEST_F(test, parseEnv) {
@@ -148,17 +152,20 @@ TEST_F(test, parseEnv) {
                                              output.first + ";" +
                                              timestamp.first + ";" + pid.first;
                         b = loggerConfig = {0, 0, LOG_ERROR, LOG_ERROR, NULL};
+                        expect_fput_count = 0;
+                        expect_fopen_count = 0;
+                        expected_stream = stderr;
+                        expected_message = "";
+                        expected_filename = "";
+                        auto n = output.first.find(',');
+                        if (n != std::string::npos) {
+                            expected_filename = output.first.substr(n + 1);
+                        }
+
                         if (output.second != NULL) {
                             b.output = output.second;
                             if (output.second == MOCK_FILE_PTR) {
                                 expect_fopen_count = 1;
-                            } else {
-                                expect_fopen_count = 0;
-                            }
-                            auto n = output.first.find(',');
-                            if (n != std::string::npos) {
-                                expected_filename =
-                                    output.first.substr(n + 1).c_str();
                             }
                             expected_stream = output.second;
                             b.timestamp = timestamp.second;
@@ -168,13 +175,14 @@ TEST_F(test, parseEnv) {
                             b.level = (util_log_level_t)logLevel.second;
                             if (logLevel.second <= LOG_INFO) {
                                 expect_fput_count = 1;
-                            } else {
-                                expect_fput_count = 0;
                             }
                         } else {
                             expect_fput_count = 1;
-                            expect_fopen_count = 0;
-                            expected_stream = stderr;
+                            if (expected_filename.size() > MAX_FILE_PATH) {
+                                expected_message =
+                                    "[ERROR UMF] Cannot open output file - "
+                                    "path too long\n";
+                            }
                         }
                         helper_log_init(envVar.c_str());
                         helper_checkConfig(&b, &loggerConfig);

--- a/test/utils/utils_log.cpp
+++ b/test/utils/utils_log.cpp
@@ -17,12 +17,6 @@ FILE *mock_fopen(const char *filename, const char *mode) {
     return MOCK_FILE_PTR;
 }
 
-int mock_fopen_s(FILE **f, const char *filename, const char *mode) {
-    *f = mock_fopen(filename, mode);
-
-    return 0;
-}
-
 std::string expected_message = "";
 FILE *expected_stream;
 int expect_fput_count = 0;
@@ -64,7 +58,6 @@ int mock_util_env_var(const char *envvar, char *buffer, size_t buffer_size) {
 }
 
 #define fopen(A, B) mock_fopen(A, B)
-#define fopen_s(A, B, C) mock_fopen_s(A, B, C)
 #define fputs(A, B) mock_fputs(A, B)
 #define fflush(A) mock_fflush(A)
 #define util_env_var(A, B, C) mock_util_env_var(A, B, C)


### PR DESCRIPTION
remove usage of fopen_s and fix error message in the logger.
check commit descriptions for details. 

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
