### PR TITLE
Fix condition to make scheduled Coverity work as planned

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -58,7 +58,7 @@ jobs:
         tar czvf cov-int_umf.tgz cov-int
 
     - name: Push to Coverity Scan
-      if: ${{ github.event.inputs.cov_push_tarball == 'true' }}
+      if: ${{ github.event_name == 'schedule' || github.event.inputs.cov_push_tarball == 'true' }}
       run: |
         BRANCH_NAME=$(echo ${GITHUB_REF_NAME})
         COMMIT_ID=$(echo $GITHUB_SHA)


### PR DESCRIPTION


<!-- Provide a short summary of your changes in the Title above -->

### Description

Missing 'schedule' event caused lack of pushing to Coverity server when runned as a planned job.
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
