### PR TITLE
Don't force UMF_PROXY_LIB_BASED_ON_POOL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,7 @@ option(USE_VALGRIND "Enable Valgrind instrumentation" OFF)
 set(UMF_PROXY_LIB_BASED_ON_POOL
     SCALABLE
     CACHE STRING
-          "A UMF pool the proxy library is based on (SCALABLE or JEMALLOC)"
-          FORCE)
+          "A UMF pool the proxy library is based on (SCALABLE or JEMALLOC)")
 
 set(KNOWN_BUILD_TYPES Release Debug RelWithDebInfo MinSizeRel)
 string(REPLACE ";" " " KNOWN_BUILD_TYPES_STR "${KNOWN_BUILD_TYPES}")


### PR DESCRIPTION
### Description
FORCE make it always come back to the default value. In our use case it's only needed to set the value if empty or missing.

### Checklist

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
- [ ] Potentially extend testing in CI with proxy_lib using jemalloc
