### PR TITLE
Always install examples

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -63,8 +63,6 @@ jobs:
 
     - name: Test UMF installation and uninstallation
       # The '--shared-library' parameter is added to the installation test when the UMF is built as a shared library
-      # pool tracking and scalable pool (always ON in this job) has to be enabled for the basic example to be built
-      # The '--examples' parameter is added to the installation test when examples are built
       run: >
         python3 ${{github.workspace}}/test/test_installation.py
         --build-dir ${{env.BUILD_DIR}}
@@ -74,7 +72,6 @@ jobs:
         --jemalloc-pool
         --scalable-pool
         ${{ matrix.shared_library == 'ON' && '--shared-library' || ''}}
-        ${{ matrix.pool_tracking == 'ON' && '--examples' || '' }}
 
   ubuntu-build:
     name: Ubuntu
@@ -162,8 +159,6 @@ jobs:
 
     - name: Test UMF installation and uninstallation
       # The '--shared-library' parameter is added to the installation test when the UMF is built as a shared library
-      # OS provider, pool tracking and scalable pool (always ON in this job) has to be enabled for the basic example to be built
-      # The '--examples' parameter is added to the installation test when examples are built
       run: >
         python3 ${{github.workspace}}/test/test_installation.py
         --build-dir ${{env.BUILD_DIR}}
@@ -173,7 +168,6 @@ jobs:
         --jemalloc-pool
         --scalable-pool
         ${{ matrix.shared_library == 'ON' && '--shared-library' || '' }}
-        ${{ matrix.pool_tracking == 'ON' && '--examples' || '' }}
 
   windows-build:
     name: Windows
@@ -253,8 +247,6 @@ jobs:
 
     - name: Test UMF installation and uninstallation
       # The '--shared-library' parameter is added to the installation test when the UMF is built as a shared library
-      # OS provider, pool tracking and scalable pool (always ON in this job) has to be enabled for the basic example to be built
-      # The '--examples' parameter is added to the installation test when examples are built
       run: >
         python3 ${{github.workspace}}/test/test_installation.py
         --build-dir ${{env.BUILD_DIR}}
@@ -264,7 +256,6 @@ jobs:
         --jemalloc-pool
         --scalable-pool
         ${{ matrix.shared_library == 'ON' && '--shared-library' || ''}}
-        ${{ matrix.pool_tracking == 'ON' && '--examples' || '' }}
 
   macos-build:
     name: MacOS
@@ -314,4 +305,3 @@ jobs:
         --disjoint-pool
         --jemalloc-pool
         --scalable-pool
-        --examples

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,6 +379,9 @@ endif()
 install(FILES ${CMAKE_SOURCE_DIR}/LICENSE.TXT
         DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME}/")
 
+install(FILES examples/basic/basic.c
+        DESTINATION "${CMAKE_INSTALL_DOCDIR}/examples")
+
 # Add the list of installed targets to the install. This includes the namespace
 # which all installed targets will be prefixed with, e.g. for the headers target
 # users will depend on ${PROJECT_NAME}::headers.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,12 +145,6 @@ target_include_directories(
     umf_headers INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
                           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
-# Add the include directory and the headers target to the install.
-install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/"
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
-install(TARGETS umf_headers EXPORT ${PROJECT_NAME}-targets)
-
 if(WINDOWS)
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
     # set PATH to DLLs on Windows
@@ -375,12 +369,20 @@ if(UMF_FORMAT_CODE_STYLE)
         COMMENT "Format files using clang-format and cmake-format")
 endif()
 
-# Add license to the installation path
+# --------------------------------------------------------------------------- #
+# Configure make install/uninstall and packages
+# --------------------------------------------------------------------------- #
 install(FILES ${CMAKE_SOURCE_DIR}/LICENSE.TXT
         DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME}/")
 
 install(FILES examples/basic/basic.c
         DESTINATION "${CMAKE_INSTALL_DOCDIR}/examples")
+
+# Add the include directory and the headers target to the install.
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/"
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(TARGETS umf_headers EXPORT ${PROJECT_NAME}-targets)
 
 # Add the list of installed targets to the install. This includes the namespace
 # which all installed targets will be prefixed with, e.g. for the headers target
@@ -408,6 +410,7 @@ install(FILES ${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}-config.cmake
               ${PROJECT_BINARY_DIR}/cmake/${PROJECT_NAME}-config-version.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 
+# Configure uninstall commands
 configure_file("${PROJECT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
                "${PROJECT_BINARY_DIR}/cmake_uninstall.cmake" IMMEDIATE @ONLY)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -28,9 +28,6 @@ if(UMF_BUILD_LIBUMF_POOL_SCALABLE AND UMF_ENABLE_POOL_TRACKING)
         set_property(TEST ${EXAMPLE_NAME} PROPERTY ENVIRONMENT_MODIFICATION
                                                    "${DLL_PATH_LIST}")
     endif()
-
-    install(FILES basic/basic.c DESTINATION "${CMAKE_INSTALL_DOCDIR}/examples")
-
 else()
     message(
         STATUS

--- a/test/test_installation.py
+++ b/test/test_installation.py
@@ -25,7 +25,6 @@ class UmfInstaller:
     build_type (str): Debug or Release build type passed to the script
     shared_library (bool): Determines if the UMF was built as a shared library
     pools (List[str]): A list of enabled pools during the UMF compilation
-    examples (bool): Determines if the UMF examples were built
     match_list (List[str]): A list of relative paths of files that should be installed
     """
 
@@ -37,7 +36,6 @@ class UmfInstaller:
         build_type: str,
         shared_library: bool,
         pools: List[str],
-        examples: bool,
     ):
         self.workspace_dir = workspace_dir
         self.build_dir = build_dir
@@ -45,7 +43,6 @@ class UmfInstaller:
         self.build_type = build_type
         self.shared_library = shared_library
         self.pools = pools
-        self.examples = examples
         self.match_list = self._create_match_list()
 
     def _create_match_list(self) -> List[str]:
@@ -114,16 +111,15 @@ class UmfInstaller:
             "share/doc",
             "share/doc/unified-memory-framework",
         ]
-        if self.examples:
-            examples_dir = Path(self.workspace_dir, "examples")
-            examples_dirs = [dir for dir in examples_dir.iterdir() if dir.is_dir()]
-            examples = [
-                f"share/doc/unified-memory-framework/examples/{file_path.name}"
-                for example_dir in examples_dirs
-                for file_path in example_dir.iterdir()
-            ]
-            examples.insert(0, "share/doc/unified-memory-framework/examples")
-            share.extend(examples)
+        examples_dir = Path(self.workspace_dir, "examples")
+        examples_dirs = [dir for dir in examples_dir.iterdir() if dir.is_dir()]
+        examples = [
+            f"share/doc/unified-memory-framework/examples/{file_path.name}"
+            for example_dir in examples_dirs
+            for file_path in example_dir.iterdir()
+        ]
+        examples.insert(0, "share/doc/unified-memory-framework/examples")
+        share.extend(examples)
         share.append("share/doc/unified-memory-framework/LICENSE.TXT")
 
         all_files = bin + include + lib + share
@@ -260,11 +256,6 @@ class UmfInstallationTester:
             action="store_true",
             help="Add this argument if the UMF was built with Scalable Pool enabled",
         )
-        self.parser.add_argument(
-            "--examples",
-            action="store_true",
-            help="Add this argument if the examples were built",
-        )
         return self.parser.parse_args()
 
     def run(self) -> None:
@@ -290,7 +281,6 @@ class UmfInstallationTester:
             self.args.build_type,
             self.args.shared_library,
             pools,
-            self.args.examples,
         )
 
         print("Installation test - BEGIN", flush=True)


### PR DESCRIPTION
### Description
Examples are installed in system as a documentation, hence only the source files are installed, not binaries... so we can install examples all the time, not under an `if`.

A minor cleanup in the installation area of CMake is done as well (in a sep. commit).

### Checklist
- [x] CI workflows execute properly