### PR TITLE
Fix: make umf_ba_linear_alloc(0) always return NULL

### DIFF
--- a/src/base_alloc/base_alloc_linear.c
+++ b/src/base_alloc/base_alloc_linear.c
@@ -251,14 +251,7 @@ void umf_ba_linear_destroy(umf_ba_linear_pool_t *pool) {
     if (pool->metadata.global_n_allocs) {
         fprintf(stderr, "umf_ba_linear_destroy(): global_n_allocs = %zu\n",
                 pool->metadata.global_n_allocs);
-        // This assert fails sporadically on Windows only.
-        // TODO: fix this issue and uncomment this assert
-        // It is safe to comment it out temporarily,
-        // because the linear base allocator is used
-        // in the proxy library only but umf_ba_linear_destroy()
-        // is skipped, so this code is never run in real life.
-        //
-        // assert(pool->metadata.global_n_allocs == 0);
+        assert(pool->metadata.global_n_allocs == 0);
     }
 #endif /* NDEBUG */
 

--- a/src/base_alloc/base_alloc_linear.c
+++ b/src/base_alloc/base_alloc_linear.c
@@ -118,6 +118,9 @@ umf_ba_linear_pool_t *umf_ba_linear_create(size_t pool_size) {
 }
 
 void *umf_ba_linear_alloc(umf_ba_linear_pool_t *pool, size_t size) {
+    if (size == 0) {
+        return NULL;
+    }
     size_t aligned_size = ALIGN_UP(size, MEMORY_ALIGNMENT);
     util_mutex_lock(&pool->metadata.lock);
     if (pool->metadata.size_left < aligned_size) {

--- a/test/test_base_alloc_linear.cpp
+++ b/test/test_base_alloc_linear.cpp
@@ -73,10 +73,11 @@ TEST_F(test, baseAllocLinearMultiThreadedAllocMemset) {
         } buffer[ITERATIONS];
 
         for (int i = 0; i < ITERATIONS; i++) {
-            buffer[i].size =
-                (size_t)((rand() / (double)RAND_MAX) * MAX_ALLOCATION_SIZE);
-            buffer[i].ptr =
-                (unsigned char *)umf_ba_linear_alloc(pool, buffer[i].size);
+            // size must be greater than 0
+            size_t size = (size_t)(1 + (MAX_ALLOCATION_SIZE - 1) *
+                                           (rand() / (double)RAND_MAX));
+            buffer[i].size = size;
+            buffer[i].ptr = (unsigned char *)umf_ba_linear_alloc(pool, size);
             UT_ASSERTne(buffer[i].ptr, NULL);
             memset(buffer[i].ptr, (i + TID) & 0xFF, buffer[i].size);
         }


### PR DESCRIPTION
**Fix: make `umf_ba_linear_alloc(0)` always return `NULL`**

`umf_ba_linear_alloc(0)` didn't return NULL and
`umf_ba_linear_free(umf_ba_linear_alloc(0))` always failed,
because `pool_contains_ptr(umf_ba_linear_alloc(0))` always
returned false, since `umf_ba_linear_alloc(0)` pointed
at the very end of the pool (`ptr == (char *)pool + pool_size`).

Fixes: #260

**Revert "Skip temporarily the assert in umf_ba_linear_destroy()"**

This reverts commit 66ac900d7d08832a57353a7cb650d6bfaa0b9068.

### Checklist

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
