### PR TITLE
Make umf_ba_global_alloc(0) always return NULL

### DIFF
--- a/src/base_alloc/base_alloc_global.c
+++ b/src/base_alloc/base_alloc_global.c
@@ -150,6 +150,10 @@ static void *get_original_alloc(void *user_ptr, size_t *total_size,
 void *umf_ba_global_aligned_alloc(size_t size, size_t alignment) {
     util_init_once(&ba_is_initialized, umf_ba_create_global);
 
+    if (size == 0) {
+        return NULL;
+    }
+
     // for metadata
     size += ALLOC_METADATA_SIZE;
 


### PR DESCRIPTION
Make `umf_ba_global_alloc(0)` always return NULL, because it makes no sense to allocate a chunk of memory for size == 0.

Ref: #371

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
