### PR TITLE
Add allocation class for a critnib node of size 152 bytes

### DIFF
--- a/src/base_alloc/base_alloc_global.c
+++ b/src/base_alloc/base_alloc_global.c
@@ -26,8 +26,8 @@ static UTIL_ONCE_FLAG ba_is_initialized = UTIL_ONCE_FLAG_INIT;
 
 // allocation classes need to be consecutive powers of 2
 #define ALLOCATION_CLASSES                                                     \
-    { 16, 32, 64, 128 }
-#define NUM_ALLOCATION_CLASSES 4
+    { 16, 32, 64, 128, 256 }
+#define NUM_ALLOCATION_CLASSES 5
 
 struct base_alloc_t {
     size_t ac_sizes[NUM_ALLOCATION_CLASSES];


### PR DESCRIPTION
Memory Tracker allocates a lot of critnib nodes of size 152 bytes.
Make a separate allocation class for them, because each such allocation
causes an allocation of 4kB page now and a lot of the following messages:
```
base_alloc: allocation size (152) larger than the biggest allocation class. Falling back to OS memory allocation.
```

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
