### PR TITLE
add utils_fprintf and use it in print_numa_nodes()

### DIFF
--- a/src/provider/provider_os_memory.c
+++ b/src/provider/provider_os_memory.c
@@ -16,6 +16,7 @@
 
 #include "base_alloc_global.h"
 #include "provider_os_memory_internal.h"
+#include "utils_log.h"
 #include <umf.h>
 #include <umf/memory_provider_ops.h>
 #include <umf/providers/provider_os_memory.h>
@@ -318,24 +319,26 @@ static void print_numa_nodes(os_memory_provider_t *os_provider, void *addr,
 
     hwloc_bitmap_t nodeset = hwloc_bitmap_alloc();
     if (!nodeset) {
-        fprintf(stderr,
-                "cannot print assigned NUMA node due to allocation failure\n");
+        util_fprintf(
+            stderr,
+            "cannot print assigned NUMA node due to allocation failure\n");
         return;
     }
 
     int ret = hwloc_get_area_memlocation(os_provider->topo, addr, 1, nodeset,
                                          HWLOC_MEMBIND_BYNODESET);
     if (ret) {
-        fprintf(stderr, "cannot print assigned NUMA node (errno = %i)\n",
-                errno);
+        util_fprintf(stderr, "cannot print assigned NUMA node (errno = %i)\n",
+                     errno);
         perror("get_mempolicy()");
     } else {
         if (hwloc_bitmap_list_snprintf(os_provider->nodeset_str_buf,
                                        NODESET_STR_BUF_LEN, nodeset)) {
-            printf("alloc(%zu) = 0x%llx, allocate on NUMA nodes = %s\n", size,
-                   (unsigned long long)addr, os_provider->nodeset_str_buf);
+            util_fprintf(
+                stdout, "alloc(%zu) = 0x%llx, allocate on NUMA nodes = %s\n",
+                size, (unsigned long long)addr, os_provider->nodeset_str_buf);
         } else {
-            fprintf(stderr, "cannot print assigned NUMA node\n");
+            util_fprintf(stderr, "cannot print assigned NUMA node\n");
         }
     }
 

--- a/src/utils/utils_log.h
+++ b/src/utils/utils_log.h
@@ -19,8 +19,11 @@ typedef enum { LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR } util_log_level_t;
 void util_log_init(void);
 #ifdef _WIN32
 void util_log(util_log_level_t level, const char *format, ...);
+void util_fprintf(FILE *stream, const char *format, ...);
 #else
 void util_log(util_log_level_t level, const char *format, ...)
+    __attribute__((format(printf, 2, 3)));
+void util_fprintf(FILE *stream, const char *format, ...)
     __attribute__((format(printf, 2, 3)));
 #endif
 #define LOG_DEBUG(...) util_log(LOG_DEBUG, __VA_ARGS__);

--- a/test/utils/utils_log.cpp
+++ b/test/utils/utils_log.cpp
@@ -261,7 +261,7 @@ TEST_F(test, long_log) {
     expected_message = "[DEBUG UMF] " + std::string(8191, 'x') + "\n";
     helper_test_log(LOG_DEBUG, "%s", std::string(8191, 'x').c_str());
     expected_message =
-        "[DEBUG UMF] " + std::string(8191, 'x') + "[truncated...]\n";
+        "[DEBUG UMF] " + std::string(8191, 'x') + TRUNCATED_STR + "\n";
     helper_test_log(LOG_DEBUG, "%s", std::string(8192, 'x').c_str());
 }
 
@@ -318,4 +318,19 @@ TEST_F(test, log_macros) {
     LOG_ERR("example log");
     EXPECT_EQ(fput_count, expect_fput_count);
     EXPECT_EQ(fflush_count, expect_fflush_count);
+}
+
+template <typename... Args> void helper_test_fprintf(Args... args) {
+    fput_count = 0;
+    util_fprintf(args...);
+    EXPECT_EQ(fput_count, expect_fput_count);
+}
+
+TEST_F(test, long_print) {
+    expect_fput_count = 1;
+    expected_message = std::string(8191, 'x');
+    expected_stream = stderr;
+    helper_test_fprintf(stderr, "%s", std::string(8191, 'x').c_str());
+    expected_message = std::string(8191, 'x') + TRUNCATED_STR;
+    helper_test_fprintf(stderr, "%s", std::string(8192, 'x').c_str());
 }


### PR DESCRIPTION
The print_numa_nodes function is expected to print something to STDOUT (or STDERR in case of error), though its output should not be controlled by the logger. This patch adds a malloc-less fprintf function and converts print_numa_nodes() to use it instead of the system one.

<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
