### PR TITLE
[CI] Bump actions' versions in scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Run analysis
-      uses: ossf/scorecard-action@e38b1902ae4f44df626f11ba0734b14fb91f8f86 # v2.1.2
+      uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
       with:
         results_file: scorecard_results.sarif
         results_format: sarif
@@ -37,7 +37,7 @@ jobs:
 
     # Upload the results as artifacts to the repository Actions tab.
     - name: Upload artifact
-      uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # 4.0.0
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # 4.3.1
       with:
         name: Scorecard results
         path: scorecard_results.sarif
@@ -45,6 +45,6 @@ jobs:
 
     # Upload the results to GitHub's code scanning dashboard.
     - name: Upload to code-scanning
-      uses: github/codeql-action/upload-sarif@b7bf0a3ed3ecfa44160715d7c442788f65f0f923 # v3.23.2
+      uses: github/codeql-action/upload-sarif@05963f47d870e2cb19a537396c1f668a348c7d8f # v3.24.8
       with:
         sarif_file: scorecard_results.sarif


### PR DESCRIPTION
### Description
It looks like they changed something in the key generation/signing/whatever.
Bumping the version of the scorecard's action fixed the issue, we observed on some of the recent builds.

// Before:
https://github.com/oneapi-src/unified-memory-framework/actions/runs/8378598819/job/22944503805#step:4:1124

// After:
Verified on my fork's main: https://github.com/lukaszstolarczuk/unified-memory-framework/actions/runs/8379660048/job/22947119974#step:4:1295

### Checklist
- [x] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
