### PR TITLE
Revert "Fix ubuntu-22.04 runner issue"

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -34,10 +34,6 @@ jobs:
         apt-get update
         apt-get install -y cmake libnuma-dev libjemalloc-dev libtbb-dev libhwloc-dev
 
-    # Remove this once https://github.com/actions/runner-images/issues/9491 was fixed
-    - name: Decrease ASLR entropy due to the issue
-      run: sysctl vm.mmap_rnd_bits=28
-
     - name: Configure build
       run: >
         cmake
@@ -82,10 +78,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y clang cmake libhwloc-dev libnuma-dev libjemalloc-dev libtbb-dev
-
-    # Remove this once https://github.com/actions/runner-images/issues/9491 was fixed
-    - name: Decrease ASLR entropy due to the issue
-      run: sudo sysctl vm.mmap_rnd_bits=28
 
     - name: Configure build
       run: >


### PR DESCRIPTION
This reverts commit ca322eb1ddb6d18f83e51719cdf300503ab9f974.

Issue in GHA images was resolved, we can revert the temporary WA.

### Checklist
- [x] CI workflows execute properly