### PR TITLE
Use non-root user in dockers by default

### DIFF
--- a/.github/docker/ubuntu-20.04.Dockerfile
+++ b/.github/docker/ubuntu-20.04.Dockerfile
@@ -61,3 +61,4 @@ RUN pip3 install --no-cache-dir -r /opt/umf/requirements.txt
 ENV USER test_user
 ENV USERPASS pass
 RUN useradd -m "${USER}" -g sudo -p "$(mkpasswd ${USERPASS})"
+USER test_user

--- a/.github/docker/ubuntu-22.04.Dockerfile
+++ b/.github/docker/ubuntu-22.04.Dockerfile
@@ -60,3 +60,4 @@ RUN pip3 install --no-cache-dir -r /opt/umf/requirements.txt
 ENV USER test_user
 ENV USERPASS pass
 RUN useradd -m "${USER}" -g sudo -p "$(mkpasswd ${USERPASS})"
+USER test_user

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -38,7 +38,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           exit-code: 1  # Fail if issue found
-          # See .trivyignore file with suppressions
+          # file with suppressions: .trivyignore (in root dir)
 
       - name: Upload results
         uses: github/codeql-action/upload-sarif@e8893c57a1f3a2b659b6b55564fdfdbbd2982911 # v3.24.0

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,10 +1,6 @@
 # Docs: https://aquasecurity.github.io/trivy/latest/docs/configuration/filtering/#trivyignore
 
 # In docker files:
-# non-root user is always created within docker, but we switch it only in CI workflows;
-# not enforcing non-root user makes it easier for developers to use their own users in local container
-AVD-DS-0002
-
-# In docker files:
-# HEALTHCHECK is not required for development, nor in CI (failed docker = failed CI)
+# HEALTHCHECK is not required for development, nor in CI (failed docker = failed CI).
+# We're not hosting any application with usage of the dockers.
 AVD-DS-0026


### PR DESCRIPTION
### Description
'Least Privilege User' rule is really important and we should not skip it by default.

### Checklist

- [x] CI workflows execute properly