### PR TITLE
Disable CMake build type checks on Windows

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -226,7 +226,6 @@ jobs:
         -B ${{env.BUILD_DIR}}
         ${{matrix.toolset}}
         -DCMAKE_PREFIX_PATH="${{env.VCPKG_PATH}}"
-        -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
         -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
         -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
         -DUMF_BUILD_SHARED_LIBRARY=${{matrix.shared_library}}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,6 +15,10 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'windows-latest']
+        include: 
+          # Windows doesn't recognize 'CMAKE_BUILD_TYPE', it uses '--config' param in build command to determine the build type
+          - os: ubuntu-latest
+            extra_build_option: '-DCMAKE_BUILD_TYPE=Release'
     runs-on: ${{matrix.os}}
 
     steps:
@@ -44,7 +48,7 @@ jobs:
         run: >
           cmake
           -B ${{env.BUILD_DIR}}
-          -DCMAKE_BUILD_TYPE=Release
+          ${{matrix.extra_build_option}}
           -DCMAKE_PREFIX_PATH="${{env.VCPKG_PATH}}"
           -DUMF_BUILD_SHARED_LIBRARY=ON
           -DUMF_BUILD_BENCHMARKS=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,31 +41,51 @@ set(UMF_PROXY_LIB_BASED_ON_POOL
 set_property(CACHE UMF_PROXY_LIB_BASED_ON_POOL
              PROPERTY STRINGS ${KNOWN_PROXY_LIB_POOLS})
 
-set(KNOWN_BUILD_TYPES Release Debug RelWithDebInfo MinSizeRel)
-string(REPLACE ";" " " KNOWN_BUILD_TYPES_STR "${KNOWN_BUILD_TYPES}")
-
-if(NOT CMAKE_BUILD_TYPE)
-    message(
-        STATUS
-            "No build type selected (CMAKE_BUILD_TYPE), defaulting to Release")
-    set(CMAKE_BUILD_TYPE "Release")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    set(LINUX TRUE)
+    set(OS_NAME "linux")
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    set(WINDOWS TRUE)
+    set(OS_NAME "windows")
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(MACOSX TRUE)
+    set(OS_NAME "macosx")
 else()
-    message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
-    if(NOT CMAKE_BUILD_TYPE IN_LIST KNOWN_BUILD_TYPES)
-        message(
-            WARNING
-                "Unusual build type was set (${CMAKE_BUILD_TYPE}), please make sure it is a correct one. "
-                "The following ones are supported by default: ${KNOWN_BUILD_TYPES_STR}."
-        )
-    endif()
+    message(FATAL_ERROR "Unknown OS type")
 endif()
 
-set(CMAKE_BUILD_TYPE
-    "${CMAKE_BUILD_TYPE}"
-    CACHE STRING
-          "Choose the type of build, options are: ${KNOWN_BUILD_TYPES_STR} ..."
-          FORCE)
-set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS ${KNOWN_BUILD_TYPES})
+# This build type check is not possible on Windows when CMAKE_BUILD_TYPE is not
+# set, because in this case the build type is determined after a CMake
+# configuration is done (at the build time)
+if(NOT WINDOWS)
+    set(KNOWN_BUILD_TYPES Release Debug RelWithDebInfo MinSizeRel)
+    string(REPLACE ";" " " KNOWN_BUILD_TYPES_STR "${KNOWN_BUILD_TYPES}")
+
+    if(NOT CMAKE_BUILD_TYPE)
+        message(
+            STATUS
+                "No build type selected (CMAKE_BUILD_TYPE), defaulting to Release"
+        )
+        set(CMAKE_BUILD_TYPE "Release")
+    else()
+        message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
+        if(NOT CMAKE_BUILD_TYPE IN_LIST KNOWN_BUILD_TYPES)
+            message(
+                WARNING
+                    "Unusual build type was set (${CMAKE_BUILD_TYPE}), please make sure it is a correct one. "
+                    "The following ones are supported by default: ${KNOWN_BUILD_TYPES_STR}."
+            )
+        endif()
+    endif()
+
+    set(CMAKE_BUILD_TYPE
+        "${CMAKE_BUILD_TYPE}"
+        CACHE
+            STRING
+            "Choose the type of build, options are: ${KNOWN_BUILD_TYPES_STR} ..."
+            FORCE)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS ${KNOWN_BUILD_TYPES})
+endif()
 
 # For using the options listed in the OPTIONS_REQUIRING_CXX variable a C++17
 # compiler is required. Moreover, if these options are not set, CMake will set
@@ -88,19 +108,6 @@ find_package(PkgConfig)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(helpers)
-
-if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    set(LINUX TRUE)
-    set(OS_NAME "linux")
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-    set(WINDOWS TRUE)
-    set(OS_NAME "windows")
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    set(MACOSX TRUE)
-    set(OS_NAME "macosx")
-else()
-    message(FATAL_ERROR "Unknown OS type")
-endif()
 
 # needed when UMF is used as an external project
 set(UMF_CMAKE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
@@ -190,13 +197,18 @@ if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
 endif()
 
 # set UMF_PROXY_LIB_ENABLED
-if(WINDOWS AND NOT (CMAKE_BUILD_TYPE STREQUAL "Release"))
+if(WINDOWS)
     # TODO: enable the proxy library in the Debug build on Windows
+    #
+    # In MSVC builds, there is no way to determine the actual build type during
+    # the CMake configuration step. Therefore, this message is printed in all
+    # MSVC builds.
     message(
         STATUS
-            "Disabling the proxy library, because it is supported only in the Release build on Windows (CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE})"
+            "The proxy library will be built, however it is supported only in the Release build on Windows"
     )
-elseif(UMF_PROXY_LIB_BASED_ON_POOL STREQUAL SCALABLE)
+endif()
+if(UMF_PROXY_LIB_BASED_ON_POOL STREQUAL SCALABLE)
     if(UMF_BUILD_LIBUMF_POOL_SCALABLE)
         set(UMF_PROXY_LIB_ENABLED ON)
         set(PROXY_LIB_USES_SCALABLE_POOL ON)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -2,8 +2,14 @@
 # Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    message(WARNING "The benchmarks SHOULD NOT be run in the Debug build type!")
+# In MSVC builds, there is no way to determine the actual build type during the
+# CMake configuration step. Therefore, this message is printed in all MSVC
+# builds.
+if(WINDOWS OR NOT CMAKE_BUILD_TYPE STREQUAL "Release")
+    message(
+        STATUS
+            "The benchmarks SHOULD NOT be run in the Debug build type! The benchmarks will be built, however their output is relevant only in the Release build!"
+    )
 endif()
 
 if(UMF_BUILD_BENCHMARKS_MT)

--- a/test/test_installation.py
+++ b/test/test_installation.py
@@ -67,11 +67,7 @@ class UmfInstaller:
             lib_prefix = "lib"
 
         # Currently the proxy library uses and requires the scalable pool
-        # The proxy library does not work in the Debug build on Windows yet.
-        if ("scalable_pool" in self.pools) and not (platform.system() == "Windows" and self.build_type == "debug"):
-            is_umf_proxy = True
-        else:
-            is_umf_proxy = False
+        is_umf_proxy = True if "scalable_pool" in self.pools else False
 
         bin = []
         if platform.system() == "Windows" and (self.shared_library or is_umf_proxy):


### PR DESCRIPTION


<!-- Provide a short summary of your changes in the Title above -->

### Description
Do not rely on the `CMAKE_BUILD_TYPE` configuration variable in Windows builds. This variable is ignored by `MSVC`, the build type is determined during the build time based on the `--config` parameter.

There seems to be no way for disabling the proxy library build based on the used config, so this change provides just notification messages on all Windows builds and builds proxy library always.

Fixes: #362 
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
