### PR TITLE
Build pool libs as shared if umf is shared also

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -102,13 +102,13 @@ endif()
 add_umf_benchmark(
     NAME ubench
     SRCS ubench.c
-    LIBS ${LIBS_OPTIONAL}
+    LIBS ${LIBS_OPTIONAL} umf_utils
     LIBDIRS ${LIB_DIRS})
 
 if(UMF_BUILD_BENCHMARKS_MT)
     add_umf_benchmark(
         NAME multithreaded
         SRCS multithread.cpp
-        LIBS ${LIBS_OPTIONAL} ${CMAKE_THREAD_LIBS_INIT}
+        LIBS ${LIBS_OPTIONAL} ${CMAKE_THREAD_LIBS_INIT} umf_utils
         LIBDIRS ${LIB_DIRS})
 endif()

--- a/src/pool/CMakeLists.txt
+++ b/src/pool/CMakeLists.txt
@@ -5,30 +5,24 @@
 if(UMF_BUILD_SHARED_LIBRARY)
     set(POOL_EXTRA_SRCS ${BA_SOURCES})
     set(POOL_COMPILE_DEFINITIONS UMF_SHARED_LIBRARY)
-    set(POOL_EXTRA_LIBS $<BUILD_INTERFACE:umf_utils>)
+    set(POOL_EXTRA_LIBS $<BUILD_INTERFACE:umf> $<BUILD_INTERFACE:umf_utils>)
+    set(POOL_LIBRARY_TYPE SHARED)
+else()
+    set(POOL_LIBRARY_TYPE STATIC)
 endif()
 
 # libumf_pool_disjoint
 if(UMF_BUILD_LIBUMF_POOL_DISJOINT)
     add_umf_library(
         NAME disjoint_pool
-        TYPE STATIC
+        TYPE ${POOL_LIBRARY_TYPE}
         SRCS pool_disjoint.cpp ${POOL_EXTRA_SRCS}
+        LINUX_MAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/libdisjoint_pool.map
+        WINDOWS_DEF_FILE ${CMAKE_CURRENT_SOURCE_DIR}/libdisjoint_pool.def
         LIBS ${POOL_EXTRA_LIBS})
     target_compile_definitions(disjoint_pool
                                PRIVATE ${POOL_COMPILE_DEFINITIONS})
-
     add_library(${PROJECT_NAME}::disjoint_pool ALIAS disjoint_pool)
-
-    add_dependencies(disjoint_pool umf)
-
-    target_link_libraries(disjoint_pool PRIVATE umf)
-
-    target_include_directories(
-        disjoint_pool
-        PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/umf/pools>
-               $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-
     install(TARGETS disjoint_pool EXPORT ${PROJECT_NAME}-targets)
 endif()
 
@@ -36,10 +30,13 @@ endif()
 if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
     add_umf_library(
         NAME jemalloc_pool
-        TYPE STATIC
+        TYPE ${POOL_LIBRARY_TYPE}
         SRCS pool_jemalloc.c ${POOL_EXTRA_SRCS}
+        LINUX_MAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/libjemalloc_pool.map
+        WINDOWS_DEF_FILE ${CMAKE_CURRENT_SOURCE_DIR}/libjemalloc_pool.def
         LIBS jemalloc ${POOL_EXTRA_LIBS})
     target_include_directories(jemalloc_pool PRIVATE ${JEMALLOC_INCLUDE_DIRS})
+    target_link_directories(jemalloc_pool PRIVATE ${JEMALLOC_LIBRARY_DIRS})
     target_compile_definitions(jemalloc_pool
                                PRIVATE ${POOL_COMPILE_DEFINITIONS})
     add_library(${PROJECT_NAME}::jemalloc_pool ALIAS jemalloc_pool)
@@ -56,10 +53,13 @@ if(UMF_BUILD_LIBUMF_POOL_SCALABLE)
 
     add_umf_library(
         NAME scalable_pool
-        TYPE STATIC
+        TYPE ${POOL_LIBRARY_TYPE}
         SRCS pool_scalable.c ${POOL_EXTRA_SRCS}
+        LINUX_MAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/libscalable_pool.map
+        WINDOWS_DEF_FILE ${CMAKE_CURRENT_SOURCE_DIR}/libscalable_pool.def
         LIBS ${LIBS_POOL_SCALABLE})
     target_include_directories(scalable_pool PRIVATE ${TBB_INCLUDE_DIRS})
+    target_link_directories(scalable_pool PRIVATE ${TBB_LIBRARY_DIRS})
     target_compile_definitions(scalable_pool
                                PRIVATE ${POOL_COMPILE_DEFINITIONS})
     add_library(${PROJECT_NAME}::scalable_pool ALIAS scalable_pool)

--- a/src/pool/libdisjoint_pool.def
+++ b/src/pool/libdisjoint_pool.def
@@ -1,0 +1,15 @@
+;;;; Begin Copyright Notice
+; Copyright (C) 2024 Intel Corporation
+; Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+;;;;  End Copyright Notice
+
+LIBRARY libdisjoint_pool
+
+VERSION 1.0
+
+EXPORTS
+    DllMain
+    umfDisjointPoolOps
+    umfDisjointPoolSharedLimitsCreate
+    umfDisjointPoolSharedLimitsDestroy

--- a/src/pool/libdisjoint_pool.map
+++ b/src/pool/libdisjoint_pool.map
@@ -1,0 +1,12 @@
+# Copyright (C) 2024 Intel Corporation
+# Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+UMF_1.0 {
+    global:
+        umfDisjointPoolOps;
+        umfDisjointPoolSharedLimitsCreate;
+        umfDisjointPoolSharedLimitsDestroy;
+    local:
+        *;
+};

--- a/src/pool/libjemalloc_pool.def
+++ b/src/pool/libjemalloc_pool.def
@@ -1,0 +1,13 @@
+;;;; Begin Copyright Notice
+; Copyright (C) 2024 Intel Corporation
+; Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+;;;;  End Copyright Notice
+
+LIBRARY libjemalloc_pool
+
+VERSION 1.0
+
+EXPORTS
+    DllMain
+    umfJemallocPoolOps

--- a/src/pool/libjemalloc_pool.map
+++ b/src/pool/libjemalloc_pool.map
@@ -1,0 +1,10 @@
+# Copyright (C) 2024 Intel Corporation
+# Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+UMF_1.0 {
+    global:
+        umfJemallocPoolOps;
+    local:
+        *;
+};

--- a/src/pool/libscalable_pool.def
+++ b/src/pool/libscalable_pool.def
@@ -1,0 +1,13 @@
+;;;; Begin Copyright Notice
+; Copyright (C) 2024 Intel Corporation
+; Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+;;;;  End Copyright Notice
+
+LIBRARY libscalable_pool
+
+VERSION 1.0
+
+EXPORTS
+    DllMain
+    umfScalablePoolOps

--- a/src/pool/libscalable_pool.map
+++ b/src/pool/libscalable_pool.map
@@ -1,0 +1,10 @@
+# Copyright (C) 2024 Intel Corporation
+# Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+UMF_1.0 {
+    global:
+        umfScalablePoolOps;
+    local:
+        *;
+};

--- a/src/pool/pool_disjoint.cpp
+++ b/src/pool/pool_disjoint.cpp
@@ -19,12 +19,14 @@
 #include <utility>
 #include <vector>
 
-// TODO: replace with logger?
+// TODO use logger
 #include <iostream>
 
+#include <umf/memory_pool.h>
+#include <umf/memory_pool_ops.h>
+#include <umf/pools/pool_disjoint.h>
+
 #include "../cpp_helpers.hpp"
-#include "pool_disjoint.h"
-#include "umf.h"
 #include "utils_log.h"
 #include "utils_math.h"
 #include "utils_sanitizers.h"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -225,14 +225,15 @@ add_umf_test(
 if(UMF_PROXY_LIB_ENABLED AND UMF_BUILD_SHARED_LIBRARY)
     add_umf_test(
         NAME proxy_lib_basic
-        SRCS test_proxy_lib.cpp
-        LIBS umf_proxy)
+        SRCS ${BA_SOURCES_FOR_TEST} test_proxy_lib.cpp
+        LIBS umf_proxy ${UMF_UTILS_FOR_TEST})
 
     # the memoryPool test run with the proxy library
     add_umf_test(
         NAME proxy_lib_memoryPool
-        SRCS memoryPoolAPI.cpp malloc_compliance_tests.cpp
-        LIBS umf_proxy)
+        SRCS ${BA_SOURCES_FOR_TEST} memoryPoolAPI.cpp
+             malloc_compliance_tests.cpp
+        LIBS umf_proxy ${UMF_UTILS_FOR_TEST})
     target_compile_definitions(umf_test-proxy_lib_memoryPool
                                PUBLIC UMF_PROXY_LIB_ENABLED=1)
 endif()

--- a/test/c_api/disjoint_pool.c
+++ b/test/c_api/disjoint_pool.c
@@ -4,7 +4,8 @@
 
 #include <stdlib.h>
 
-#include "pool_disjoint.h"
+#include <umf/pools/pool_disjoint.h>
+
 #include "provider_null.h"
 #include "test_helpers.h"
 

--- a/test/pools/disjoint_pool.cpp
+++ b/test/pools/disjoint_pool.cpp
@@ -2,9 +2,10 @@
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <umf/pools/pool_disjoint.h>
+
 #include "pool.hpp"
 #include "poolFixtures.hpp"
-#include "pool_disjoint.h"
 #include "provider.hpp"
 #include "provider_null.h"
 #include "provider_trace.h"

--- a/test/test_installation.py
+++ b/test/test_installation.py
@@ -93,9 +93,9 @@ class UmfInstaller:
             f"lib/cmake/umf/umf-targets-{self.build_type}.cmake",
             "lib/cmake/umf/umf-targets.cmake",
         ]
-        for pool in self.pools:
-            lib.append(f"lib/{lib_prefix}{pool}.{lib_ext_static}")
         lib_ext = lib_ext_shared if self.shared_library else lib_ext_static
+        for pool in self.pools:
+            lib.append(f"lib/{lib_prefix}{pool}.{lib_ext}")
         lib.append(f"lib/{lib_prefix}umf.{lib_ext}")
         if is_umf_proxy:
             lib.append(f"lib/{lib_prefix}umf_proxy.{lib_ext_shared}")


### PR DESCRIPTION
### Description

Build memory pool libs (disjoint, scalable, etc.) as shared if the main libumf is also built as shared lib.

Ref: #387

### Checklist

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly

