### PR TITLE
Make umf_utils an interface library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 
 add_subdirectory(utils)
 
-set(UMF_LIBS umf_utils)
+set(UMF_LIBS $<BUILD_INTERFACE:umf_utils>)
 
 set(BA_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/base_alloc/base_alloc.c

--- a/src/pool/CMakeLists.txt
+++ b/src/pool/CMakeLists.txt
@@ -5,6 +5,7 @@
 if(UMF_BUILD_SHARED_LIBRARY)
     set(POOL_EXTRA_SRCS ${BA_SOURCES})
     set(POOL_COMPILE_DEFINITIONS UMF_SHARED_LIBRARY)
+    set(POOL_EXTRA_LIBS $<BUILD_INTERFACE:umf_utils>)
 endif()
 
 # libumf_pool_disjoint
@@ -13,7 +14,7 @@ if(UMF_BUILD_LIBUMF_POOL_DISJOINT)
         NAME disjoint_pool
         TYPE STATIC
         SRCS pool_disjoint.cpp ${POOL_EXTRA_SRCS}
-        LIBS umf_utils)
+        LIBS ${POOL_EXTRA_LIBS})
     target_compile_definitions(disjoint_pool PUBLIC ${POOL_COMPILE_DEFINITIONS})
 
     add_library(${PROJECT_NAME}::disjoint_pool ALIAS disjoint_pool)
@@ -36,7 +37,7 @@ if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
         NAME jemalloc_pool
         TYPE STATIC
         SRCS pool_jemalloc.c ${POOL_EXTRA_SRCS}
-        LIBS jemalloc umf_utils)
+        LIBS jemalloc ${POOL_EXTRA_LIBS})
     target_include_directories(jemalloc_pool PRIVATE ${JEMALLOC_INCLUDE_DIRS})
     target_compile_definitions(jemalloc_pool PUBLIC ${POOL_COMPILE_DEFINITIONS})
     add_library(${PROJECT_NAME}::jemalloc_pool ALIAS jemalloc_pool)
@@ -46,9 +47,9 @@ endif()
 # libumf_pool_scalable
 if(UMF_BUILD_LIBUMF_POOL_SCALABLE)
     if(LINUX)
-        set(LIBS_POOL_SCALABLE dl umf_utils)
+        set(LIBS_POOL_SCALABLE dl ${POOL_EXTRA_LIBS})
     else()
-        set(LIBS_POOL_SCALABLE umf_utils)
+        set(LIBS_POOL_SCALABLE ${POOL_EXTRA_LIBS})
     endif()
 
     add_umf_library(

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -37,23 +37,18 @@ elseif(WINDOWS)
                           ${UMF_UTILS_SOURCES_WINDOWS})
 endif()
 
-add_umf_library(
-    NAME umf_utils
-    TYPE STATIC
-    SRCS ${UMF_UTILS_SOURCES}
-    LIBS ${CMAKE_THREAD_LIBS_INIT})
-
+add_library(umf_utils INTERFACE)
 add_library(${PROJECT_NAME}::utils ALIAS umf_utils)
+
+target_sources(umf_utils INTERFACE ${UMF_UTILS_SOURCES})
+target_link_libraries(umf_utils INTERFACE ${CMAKE_THREAD_LIBS_INIT})
 
 target_include_directories(
     umf_utils
-    PUBLIC ${VALGRIND_INCLUDE_DIRS}
-           $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+    INTERFACE ${VALGRIND_INCLUDE_DIRS}
+              $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+              $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 if(USE_VALGRIND)
-    target_compile_definitions(umf_utils PUBLIC UMF_VG_ENABLED=1)
+    target_compile_definitions(umf_utils INTERFACE UMF_VG_ENABLED=1)
 endif()
-
-install(TARGETS umf_utils EXPORT ${PROJECT_NAME}-targets)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,6 +66,7 @@ function(add_umf_test)
         PRIVATE ${UMF_CMAKE_SOURCE_DIR}/include
                 ${UMF_CMAKE_SOURCE_DIR}/src
                 ${UMF_CMAKE_SOURCE_DIR}/src/base_alloc
+                ${UMF_CMAKE_SOURCE_DIR}/src/utils
                 ${UMF_TEST_DIR}/common
                 ${UMF_TEST_DIR})
 
@@ -94,14 +95,22 @@ add_umf_test(NAME base SRCS base.cpp)
 add_umf_test(NAME memoryPool SRCS memoryPoolAPI.cpp malloc_compliance_tests.cpp)
 add_umf_test(NAME memoryProvider SRCS memoryProviderAPI.cpp)
 
-add_umf_test(
-    NAME logger
-    SRCS utils/utils_log.cpp
-    LIBS umf_utils)
+if(UMF_BUILD_SHARED_LIBRARY)
+    # if build as shared library, utils symbols won't be visible in tests
+    set(UMF_UTILS_FOR_TEST umf_utils)
+endif()
+
+if(UMF_BUILD_SHARED_LIBRARY)
+    add_umf_test(NAME logger SRCS utils/utils_log.cpp
+                                  ../src/utils/utils_common.c)
+else()
+    add_umf_test(NAME logger SRCS utils/utils_log.cpp)
+endif()
+
 add_umf_test(
     NAME utils_common
     SRCS utils/utils.cpp
-    LIBS umf_utils)
+    LIBS ${UMF_UTILS_FOR_TEST})
 
 if(UMF_BUILD_LIBUMF_POOL_DISJOINT)
     add_umf_test(
@@ -149,11 +158,11 @@ if(LINUX) # OS-specific functions are implemented only for Linux now
     add_umf_test(
         NAME provider_os_memory
         SRCS provider_os_memory.cpp
-        LIBS umf_utils)
+        LIBS ${UMF_UTILS_FOR_TEST})
     add_umf_test(
         NAME provider_os_memory_multiple_numa_nodes
         SRCS provider_os_memory_multiple_numa_nodes.cpp
-        LIBS umf_utils ${LIBNUMA_LIBRARIES})
+        LIBS ${UMF_UTILS_FOR_TEST} ${LIBNUMA_LIBRARIES})
     add_umf_test(
         NAME memspace_numa
         SRCS memspaces/memspace_numa.cpp
@@ -161,15 +170,15 @@ if(LINUX) # OS-specific functions are implemented only for Linux now
     add_umf_test(
         NAME provider_os_memory_config
         SRCS provider_os_memory_config.cpp
-        LIBS umf_utils ${LIBNUMA_LIBRARIES})
+        LIBS ${UMF_UTILS_FOR_TEST} ${LIBNUMA_LIBRARIES})
     add_umf_test(
         NAME memspace_host_all
         SRCS memspaces/memspace_host_all.cpp
-        LIBS umf_utils ${LIBNUMA_LIBRARIES})
+        LIBS ${UMF_UTILS_FOR_TEST} ${LIBNUMA_LIBRARIES})
     add_umf_test(
         NAME memspace_highest_capacity
         SRCS memspaces/memspace_highest_capacity.cpp
-        LIBS umf_utils ${LIBNUMA_LIBRARIES})
+        LIBS ${UMF_UTILS_FOR_TEST} ${LIBNUMA_LIBRARIES})
 endif()
 
 # TODO add support for Windows
@@ -182,12 +191,12 @@ if(UMF_BUILD_GPU_TESTS
     add_umf_test(
         NAME provider_level_zero
         SRCS providers/provider_level_zero.cpp
-        LIBS umf_utils ze_loader)
+        LIBS ${UMF_UTILS_FOR_TEST} ze_loader)
 
     add_umf_test(
         NAME provider_level_zero_dlopen
         SRCS providers/provider_level_zero.cpp
-        LIBS umf_utils)
+        LIBS ${UMF_UTILS_FOR_TEST})
     target_compile_definitions(umf_test-provider_level_zero_dlopen
                                PUBLIC USE_DLOPEN=1)
 endif()
@@ -200,17 +209,17 @@ endif()
 add_umf_test(
     NAME base_alloc
     SRCS ${BA_SOURCES_FOR_TEST} test_base_alloc.cpp
-    LIBS umf_utils)
+    LIBS ${UMF_UTILS_FOR_TEST})
 add_umf_test(
     NAME base_alloc_linear
     SRCS ${BA_SOURCES_FOR_TEST} test_base_alloc_linear.cpp
-    LIBS umf_utils)
+    LIBS ${UMF_UTILS_FOR_TEST})
 
 add_umf_test(
     NAME base_alloc_global
     SRCS ${BA_SOURCES_FOR_TEST} pools/pool_base_alloc.cpp
          malloc_compliance_tests.cpp
-    LIBS umf_utils)
+    LIBS ${UMF_UTILS_FOR_TEST})
 
 # tests for the proxy library
 if(UMF_PROXY_LIB_ENABLED AND UMF_BUILD_SHARED_LIBRARY)

--- a/test/memspaces/memspace_highest_capacity.cpp
+++ b/test/memspaces/memspace_highest_capacity.cpp
@@ -6,7 +6,6 @@
 #include "memspace_helpers.hpp"
 #include "memspace_internal.h"
 #include "test_helpers.h"
-#include "utils_sanitizers.h"
 
 #include <numa.h>
 #include <numaif.h>

--- a/test/test_installation.py
+++ b/test/test_installation.py
@@ -103,7 +103,6 @@ class UmfInstaller:
         lib.append(f"lib/{lib_prefix}umf.{lib_ext}")
         if is_umf_proxy:
             lib.append(f"lib/{lib_prefix}umf_proxy.{lib_ext_shared}")
-        lib.append(f"lib/{lib_prefix}umf_utils.{lib_ext_static}")
 
         share = []
         share = [


### PR DESCRIPTION
So that users of umf pools (which are static libraries) do not have to link with umf_utils themselves.

It's not possible to link static libraries to other static libraries.

<!-- Provide a short summary of your changes in the Title above -->


<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
