### PR TITLE
Fix uninstallation random failures on Windows

### DIFF
--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -9,14 +9,7 @@ string(REGEX REPLACE "\n" ";" files "${files}")
 foreach(file ${files})
 	message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
 	if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
-		execute_process(
-			COMMAND @CMAKE_COMMAND@ -E remove $ENV{DESTDIR}${file}
-			OUTPUT_VARIABLE rm_out
-			RESULT_VARIABLE rm_retval
-		)
-		if(NOT "${rm_retval}" STREQUAL 0)
-			message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
-		endif(NOT "${rm_retval}" STREQUAL 0)
+		FILE(REMOVE $ENV{DESTDIR}${file})
 	else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
 		message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
 	endif(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")


### PR DESCRIPTION


<!-- Provide a short summary of your changes in the Title above -->

### Description
On Windows, the 'uninstall' target failed randomly. The CMake command used for deleting files, 'cmake -E remove' seems to be not reliable. Changing the tool used for files deletion to 'rm'.
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
