### PR TITLE
Do not print anything if allocation size results in os allocation

### DIFF
--- a/src/base_alloc/base_alloc_global.c
+++ b/src/base_alloc/base_alloc_global.c
@@ -163,12 +163,11 @@ void *umf_ba_global_aligned_alloc(size_t size, size_t alignment) {
 
     int ac_index = size_to_idx(size);
     if (ac_index >= NUM_ALLOCATION_CLASSES) {
-#ifndef NDEBUG
-        fprintf(stderr,
-                "base_alloc: allocation size (%zu) larger than the biggest "
-                "allocation class. Falling back to OS memory allocation.\n",
-                size);
-#endif
+        // TODO: use logger here
+        // fprintf(stderr,
+        //         "base_alloc: allocation size (%zu) larger than the biggest "
+        //         "allocation class. Falling back to OS memory allocation.\n",
+        //         size);
         return add_metadata_and_align(ba_os_alloc(size), size, alignment);
     }
 


### PR DESCRIPTION
this messes up match files in UR. This should only be printed if requested (using logger).

<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
