### PR TITLE
Make compile definitions for libumf and pool private

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,7 +70,7 @@ set(UMF_SOURCES_WINDOWS libumf_windows.c)
 # Compile definitions for UMF library.
 #
 # TODO: Cleanup the compile definitions across all the CMake files
-set(UMF_PUBLIC_COMPILE_DEFINITIONS "")
+set(UMF_PRIVATE_COMPILE_DEFINITIONS "")
 
 set(UMF_SOURCES_LINUX
     ${UMF_SOURCES_LINUX}
@@ -106,8 +106,8 @@ if(UMF_BUILD_SHARED_LIBRARY)
         LIBS ${UMF_LIBS}
         LINUX_MAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/libumf.map
         WINDOWS_DEF_FILE ${CMAKE_CURRENT_SOURCE_DIR}/libumf.def)
-    set(UMF_PUBLIC_COMPILE_DEFINITIONS ${UMF_PUBLIC_COMPILE_DEFINITIONS}
-                                       "UMF_SHARED_LIBRARY")
+    set(UMF_PRIVATE_COMPILE_DEFINITIONS ${UMF_PRIVATE_COMPILE_DEFINITIONS}
+                                        "UMF_SHARED_LIBRARY")
     set_target_properties(umf PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                                          ${CMAKE_UMF_OUTPUT_DIRECTORY})
 else()
@@ -119,13 +119,13 @@ else()
 endif()
 
 if(UMF_ENABLE_POOL_TRACKING)
-    set(UMF_PUBLIC_COMPILE_DEFINITIONS ${UMF_PUBLIC_COMPILE_DEFINITIONS}
-                                       "UMF_ENABLE_POOL_TRACKING")
+    set(UMF_PRIVATE_COMPILE_DEFINITIONS ${UMF_PRIVATE_COMPILE_DEFINITIONS}
+                                        "UMF_ENABLE_POOL_TRACKING")
 endif()
 
 target_link_directories(umf PRIVATE ${UMF_PRIVATE_LIBRARY_DIRS})
 
-target_compile_definitions(umf PUBLIC ${UMF_PUBLIC_COMPILE_DEFINITIONS})
+target_compile_definitions(umf PRIVATE ${UMF_PRIVATE_COMPILE_DEFINITIONS})
 
 if(UMF_BUILD_LEVEL_ZERO_PROVIDER)
     target_sources(umf PRIVATE provider/provider_level_zero.c)

--- a/src/pool/CMakeLists.txt
+++ b/src/pool/CMakeLists.txt
@@ -15,7 +15,8 @@ if(UMF_BUILD_LIBUMF_POOL_DISJOINT)
         TYPE STATIC
         SRCS pool_disjoint.cpp ${POOL_EXTRA_SRCS}
         LIBS ${POOL_EXTRA_LIBS})
-    target_compile_definitions(disjoint_pool PUBLIC ${POOL_COMPILE_DEFINITIONS})
+    target_compile_definitions(disjoint_pool
+                               PRIVATE ${POOL_COMPILE_DEFINITIONS})
 
     add_library(${PROJECT_NAME}::disjoint_pool ALIAS disjoint_pool)
 
@@ -39,7 +40,8 @@ if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
         SRCS pool_jemalloc.c ${POOL_EXTRA_SRCS}
         LIBS jemalloc ${POOL_EXTRA_LIBS})
     target_include_directories(jemalloc_pool PRIVATE ${JEMALLOC_INCLUDE_DIRS})
-    target_compile_definitions(jemalloc_pool PUBLIC ${POOL_COMPILE_DEFINITIONS})
+    target_compile_definitions(jemalloc_pool
+                               PRIVATE ${POOL_COMPILE_DEFINITIONS})
     add_library(${PROJECT_NAME}::jemalloc_pool ALIAS jemalloc_pool)
     install(TARGETS jemalloc_pool EXPORT ${PROJECT_NAME}-targets)
 endif()
@@ -58,7 +60,8 @@ if(UMF_BUILD_LIBUMF_POOL_SCALABLE)
         SRCS pool_scalable.c ${POOL_EXTRA_SRCS}
         LIBS ${LIBS_POOL_SCALABLE})
     target_include_directories(scalable_pool PRIVATE ${TBB_INCLUDE_DIRS})
-    target_compile_definitions(scalable_pool PUBLIC ${POOL_COMPILE_DEFINITIONS})
+    target_compile_definitions(scalable_pool
+                               PRIVATE ${POOL_COMPILE_DEFINITIONS})
     add_library(${PROJECT_NAME}::scalable_pool ALIAS scalable_pool)
     install(TARGETS scalable_pool EXPORT ${PROJECT_NAME}-targets)
 endif()


### PR DESCRIPTION
They are only intended to be used by umf itself. Making them public makes them visible to the users of umf which is not desired.

<!-- Provide a short summary of your changes in the Title above -->

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
