### PR TITLE
Bump pygments version

### DIFF
--- a/third_party/requirements.txt
+++ b/third_party/requirements.txt
@@ -3,7 +3,7 @@
 clang-format==15.0.7
 cmake-format==0.6.13
 # Generating HTML documentation
-pygments==2.5.2
+pygments==2.15.0
 sphinxcontrib_applehelp==1.0.4
 sphinxcontrib_devhelp==1.0.2
 sphinxcontrib_htmlhelp==2.0.1


### PR DESCRIPTION
Current version of pygments is affected by some vulnerabilities - bump it to the least unaffected version.

// preview of built docs: https://lukaszstolarczuk.github.io/unified-memory-framework/