### PR TITLE
Disable proxy lib tests on Windows Debug

### DIFF
--- a/.cmake-format
+++ b/.cmake-format
@@ -26,7 +26,8 @@ with section("parse"):
       'kwargs': {
         'NAME': '*', 
         'SRCS': '*', 
-        'LIBS': '*'}},
+        'LIBS': '*',
+        'CFGS': '*'}},
     'add_umf_library': {
       "pargs": 0,
       "flags": [],

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,7 +30,7 @@ function(add_umf_test)
     # * SRCS - source files
     # * LIBS - libraries to be linked with
     set(oneValueArgs NAME)
-    set(multiValueArgs SRCS LIBS)
+    set(multiValueArgs SRCS LIBS CFGS)
     cmake_parse_arguments(
         ARG
         ""
@@ -73,6 +73,7 @@ function(add_umf_test)
     add_test(
         NAME ${TEST_NAME}
         COMMAND ${TEST_TARGET_NAME}
+        CONFIGURATIONS ${ARG_CFGS}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
     set_tests_properties(${TEST_NAME} PROPERTIES LABELS "umf")
@@ -223,14 +224,20 @@ add_umf_test(
 
 # tests for the proxy library
 if(UMF_PROXY_LIB_ENABLED AND UMF_BUILD_SHARED_LIBRARY)
+    # The CFGS variable can be removed when the issue of running the proxy
+    # library on Windows with Debug configuration is fixed.
+    if(WINDOWS)
+        set(CONFIGS Release RelWithDebInfo MinSizeRel)
+    endif()
     add_umf_test(
         NAME proxy_lib_basic
         SRCS test_proxy_lib.cpp
-        LIBS umf_proxy)
-
+        LIBS umf_proxy
+        CFGS ${CONFIGS})
     # the memoryPool test run with the proxy library
     add_umf_test(
         NAME proxy_lib_memoryPool
         SRCS memoryPoolAPI.cpp malloc_compliance_tests.cpp
-        LIBS umf_proxy)
+        LIBS umf_proxy
+        CFGS ${CONFIGS})
 endif()


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description
Fixes: #399

This PR disables the two tests which use proxy lib when ctest is run for a Debug config on Windows:
```
ctest -C Debug
```
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
