### PR TITLE
catch any possible errors from logger in Disjoint Pool

### DIFF
--- a/src/pool/pool_disjoint.cpp
+++ b/src/pool/pool_disjoint.cpp
@@ -446,10 +446,14 @@ Slab::~Slab() {
             const char *message = "";
             int error = 0;
 
-            umfMemoryProviderGetLastNativeError(
-                umfGetLastFailedMemoryProvider(), &message, &error);
-            LOG_ERR("Native error msg: %s, native error code: %d", message,
-                    error);
+            try {
+                umfMemoryProviderGetLastNativeError(
+                    umfGetLastFailedMemoryProvider(), &message, &error);
+                LOG_ERR("Native error msg: %s, native error code: %d", message,
+                        error);
+            } catch (...) {
+                // ignore any additional errors from logger
+            }
         }
     }
 }


### PR DESCRIPTION
Catch any possible errors from logger in Disjoint Pool.

### Description

This is the fix for the Coverity issue https://scan3.scan.coverity.com/#/project-view/65229/15141?selectedIssue=449677
Coverity says the logger may use a mocked-up version of fputs from the Google test (/test/utils/utils_log.cpp), which can throw errors.

### Checklist

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly

