### PR TITLE
Add more suppresions for helgrind for disjoint pool test

### DIFF
--- a/test/supp/helgrind-umf_test-disjointPool.supp
+++ b/test/supp/helgrind-umf_test-disjointPool.supp
@@ -11,3 +11,19 @@
    fun:mutex_unlock_WRK
    fun:pthread_mutex_unlock
 }
+
+{
+   Incompatibility with helgrind's implementation ("pthread_mutex_lock with a pthread_rwlock_t* argument")
+   Helgrind:Misc
+   obj:*vgpreload_helgrind-amd64-linux.so
+   fun:*gthread_mutex_lock*pthread_mutex_t
+   ...
+}
+
+{
+   Incompatibility with helgrind's implementation ("pthread_mutex_unlock with a pthread_rwlock_t* argument")
+   Helgrind:Misc
+   obj:*vgpreload_helgrind-amd64-linux.so
+   fun:*gthread_mutex_unlock*pthread_mutex_t
+   ...
+}

--- a/test/test_valgrind.sh
+++ b/test/test_valgrind.sh
@@ -83,9 +83,6 @@ for test in $(ls -1 umf_test-*); do
 	# skip tests incompatible with valgrind
 	FILTER=""
 	case $test in
-	umf_test-disjointPool) # TODO: temporarily skip failing disjointPool tests - fix it
-		FILTER='--gtest_filter="-*pow2AlignedAlloc"'
-		;;
 	umf_test-memspace_host_all)
 		FILTER='--gtest_filter="-*allocsSpreadAcrossAllNumaNodes"'
 		;;


### PR DESCRIPTION
### Description

1) Add more suppressions for helgrind for disjointPool test

    This is a continuation of #405.
    This patch adds missing suppressions.

    Ref: #405
    Fixes: #338

2) Revert "Temporarily skip disjointPool tests failing under valgrind"

    This reverts commit 2648539890172e26648d573d615acc7d800741f6.

### Checklist

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
