### PR TITLE
Add memspace "highest bandwidth"

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,11 @@ using umfMemspaceHostAllGet.
 Memspace backed by all available NUMA nodes discovered on the platform sorted by capacity.
 Can be retrieved using umfMemspaceHighestCapacityGet.
 
+#### Highest bandwidth memspace
+
+Memspace backed by an aggregated list of NUMA nodes identified as highest bandwidth after selecting each available NUMA node as the initiator.
+Querying the bandwidth value requires HMAT support on the platform. Calling `umfMemspaceHighestBandwidthGet()` will return NULL if it's not supported.
+
 ### Proxy library
 
 UMF provides the UMF proxy library (`umf_proxy`) that makes it possible

--- a/include/umf/memspace.h
+++ b/include/umf/memspace.h
@@ -56,6 +56,11 @@ umf_memspace_handle_t umfMemspaceHostAllGet(void);
 ///
 umf_memspace_handle_t umfMemspaceHighestCapacityGet(void);
 
+/// \brief Retrieves predefined highest bandwidth memspace.
+/// \return highest bandwidth memspace handle on success or NULL on failure.
+///
+umf_memspace_handle_t umfMemspaceHighestBandwidthGet(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/scripts/qemu/run-build.sh
+++ b/scripts/qemu/run-build.sh
@@ -40,7 +40,7 @@ make -j $(nproc)
 echo password | sudo sync;
 echo password | sudo sh -c "/usr/bin/echo 3 > /proc/sys/vm/drop_caches"
 
-ctest --output-on-failure
+ctest --verbose
 
 # run tests bound to a numa node
 numactl -N 0 ctest --output-on-failure

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,7 +81,8 @@ set(UMF_SOURCES_COMMON_LINUX_MACOSX
     memory_targets/memory_target_numa.c
     memspaces/memspace_numa.c
     memspaces/memspace_host_all.c
-    memspaces/memspace_highest_capacity.c)
+    memspaces/memspace_highest_capacity.c
+    memspaces/memspace_highest_bandwidth.c)
 
 set(UMF_SOURCES_LINUX ${UMF_SOURCES_LINUX} ${UMF_SOURCES_COMMON_LINUX_MACOSX}
                       provider/provider_os_memory_linux.c)

--- a/src/libumf.map
+++ b/src/libumf.map
@@ -30,6 +30,7 @@ UMF_1.0 {
         umfMemoryProviderPutIPCHandle;
         umfMemspaceCreateFromNumaArray;
         umfMemspaceDestroy;
+        umfMemspaceHighestBandwidthGet;
         umfMemspaceHighestCapacityGet;
         umfMemspaceHostAllGet;
         umfOpenIPCHandle;

--- a/src/libumf_linux.c
+++ b/src/libumf_linux.c
@@ -29,6 +29,7 @@ void __attribute__((destructor)) umfDestroy(void) {
     umfMemoryTrackerDestroy(t);
     umfMemspaceHostAllDestroy();
     umfMemspaceHighestCapacityDestroy();
+    umfMemspaceHighestBandwidthDestroy();
     umfDestroyTopology();
 }
 

--- a/src/memory_target.c
+++ b/src/memory_target.c
@@ -83,3 +83,14 @@ umf_result_t umfMemoryTargetGetCapacity(umf_memory_target_handle_t memoryTarget,
     assert(capacity);
     return memoryTarget->ops->get_capacity(memoryTarget->priv, capacity);
 }
+
+umf_result_t
+umfMemoryTargetGetBandwidth(umf_memory_target_handle_t srcMemoryTarget,
+                            umf_memory_target_handle_t dstMemoryTarget,
+                            size_t *bandwidth) {
+    assert(srcMemoryTarget);
+    assert(dstMemoryTarget);
+    assert(bandwidth);
+    return srcMemoryTarget->ops->get_bandwidth(
+        srcMemoryTarget->priv, dstMemoryTarget->priv, bandwidth);
+}

--- a/src/memory_target.c
+++ b/src/memory_target.c
@@ -79,8 +79,10 @@ umf_result_t umfMemoryTargetClone(umf_memory_target_handle_t memoryTarget,
 
 umf_result_t umfMemoryTargetGetCapacity(umf_memory_target_handle_t memoryTarget,
                                         size_t *capacity) {
-    assert(memoryTarget);
-    assert(capacity);
+    if (!memoryTarget || !capacity) {
+        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
     return memoryTarget->ops->get_capacity(memoryTarget->priv, capacity);
 }
 
@@ -88,9 +90,10 @@ umf_result_t
 umfMemoryTargetGetBandwidth(umf_memory_target_handle_t srcMemoryTarget,
                             umf_memory_target_handle_t dstMemoryTarget,
                             size_t *bandwidth) {
-    assert(srcMemoryTarget);
-    assert(dstMemoryTarget);
-    assert(bandwidth);
+    if (!srcMemoryTarget || !dstMemoryTarget || !bandwidth) {
+        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
     return srcMemoryTarget->ops->get_bandwidth(
         srcMemoryTarget->priv, dstMemoryTarget->priv, bandwidth);
 }

--- a/src/memory_target.h
+++ b/src/memory_target.h
@@ -37,6 +37,10 @@ umf_result_t umfMemoryTargetClone(umf_memory_target_handle_t memoryTarget,
                                   umf_memory_target_handle_t *outHandle);
 umf_result_t umfMemoryTargetGetCapacity(umf_memory_target_handle_t memoryTarget,
                                         size_t *capacity);
+umf_result_t
+umfMemoryTargetGetBandwidth(umf_memory_target_handle_t srcMemoryTarget,
+                            umf_memory_target_handle_t dstMemoryTarget,
+                            size_t *bandwidth);
 
 #ifdef __cplusplus
 }

--- a/src/memory_target_ops.h
+++ b/src/memory_target_ops.h
@@ -41,6 +41,8 @@ typedef struct umf_memory_target_ops_t {
         umf_memory_provider_handle_t *provider);
 
     umf_result_t (*get_capacity)(void *memoryTarget, size_t *capacity);
+    umf_result_t (*get_bandwidth)(void *srcMemoryTarget, void *dstMemoryTarget,
+                                  size_t *bandwidth);
 } umf_memory_target_ops_t;
 
 #ifdef __cplusplus

--- a/src/memory_targets/memory_target_numa.c
+++ b/src/memory_targets/memory_target_numa.c
@@ -125,6 +125,10 @@ static umf_result_t numa_clone(void *memTarget, void **outMemTarget) {
 }
 
 static umf_result_t numa_get_capacity(void *memTarget, size_t *capacity) {
+    if (!memTarget || !capacity) {
+        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
     hwloc_topology_t topology = umfGetTopology();
     if (!topology) {
         return UMF_RESULT_ERROR_NOT_SUPPORTED;
@@ -147,6 +151,10 @@ static umf_result_t numa_get_capacity(void *memTarget, size_t *capacity) {
 static umf_result_t numa_get_bandwidth(void *srcMemoryTarget,
                                        void *dstMemoryTarget,
                                        size_t *bandwidth) {
+    if (!srcMemoryTarget || !dstMemoryTarget || !bandwidth) {
+        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
     hwloc_topology_t topology = umfGetTopology();
     if (!topology) {
         return UMF_RESULT_ERROR_NOT_SUPPORTED;

--- a/src/memspace_internal.h
+++ b/src/memspace_internal.h
@@ -39,6 +39,18 @@ typedef umf_result_t (*umfGetPropertyFn)(umf_memory_target_handle_t,
 umf_result_t umfMemspaceSortDesc(umf_memspace_handle_t hMemspace,
                                  umfGetPropertyFn getProperty);
 
+typedef umf_result_t (*umfGetTargetFn)(umf_memory_target_handle_t initiator,
+                                       umf_memory_target_handle_t *nodes,
+                                       size_t numNodes,
+                                       umf_memory_target_handle_t *target);
+
+///
+/// \brief Filters the targets using getTarget() to create a new memspace
+///
+umf_result_t umfMemspaceFilter(umf_memspace_handle_t hMemspace,
+                               umfGetTargetFn getTarget,
+                               umf_memspace_handle_t *filteredMemspace);
+
 ///
 /// \brief Destroys memspace
 /// \param hMemspace handle to memspace
@@ -47,6 +59,7 @@ void umfMemspaceDestroy(umf_memspace_handle_t hMemspace);
 
 void umfMemspaceHostAllDestroy(void);
 void umfMemspaceHighestCapacityDestroy(void);
+void umfMemspaceHighestBandwidthDestroy(void);
 
 #ifdef __cplusplus
 }

--- a/src/memspaces/memspace_highest_bandwidth.c
+++ b/src/memspaces/memspace_highest_bandwidth.c
@@ -1,0 +1,103 @@
+/*
+ *
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ */
+
+#include <assert.h>
+#include <ctype.h>
+#include <hwloc.h>
+#include <stdlib.h>
+
+#include "base_alloc_global.h"
+#include "memory_target_numa.h"
+#include "memspace_internal.h"
+#include "memspace_numa.h"
+#include "topology.h"
+#include "utils_common.h"
+#include "utils_concurrency.h"
+#include "utils_log.h"
+
+static umf_result_t getBestBandwidthTarget(umf_memory_target_handle_t initiator,
+                                           umf_memory_target_handle_t *nodes,
+                                           size_t numNodes,
+                                           umf_memory_target_handle_t *target) {
+    size_t bestNodeIdx = 0;
+    size_t bestBandwidth = 0;
+    for (size_t nodeIdx = 0; nodeIdx < numNodes; nodeIdx++) {
+        size_t bandwidth = 0;
+        umf_result_t ret =
+            umfMemoryTargetGetBandwidth(initiator, nodes[nodeIdx], &bandwidth);
+        if (ret) {
+            return ret;
+        }
+
+        if (bandwidth > bestBandwidth) {
+            bestNodeIdx = nodeIdx;
+            bestBandwidth = bandwidth;
+        }
+    }
+
+    *target = nodes[bestNodeIdx];
+
+    return UMF_RESULT_SUCCESS;
+}
+
+static umf_result_t
+umfMemspaceHighestBandwidthCreate(umf_memspace_handle_t *hMemspace) {
+    if (!hMemspace) {
+        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
+    umf_memspace_handle_t hostAllMemspace = umfMemspaceHostAllGet();
+    if (!hostAllMemspace) {
+        return UMF_RESULT_ERROR_UNKNOWN;
+    }
+
+    umf_memspace_handle_t highBandwidthMemspace = NULL;
+    umf_result_t ret = umfMemspaceFilter(
+        hostAllMemspace, getBestBandwidthTarget, &highBandwidthMemspace);
+    if (ret != UMF_RESULT_SUCCESS) {
+        // HWLOC could possibly return an 'EINVAL' error, which in this context
+        // means that the HMAT is unavailable and we can't obtain the
+        // 'bandwidth' value of any NUMA node.
+        return ret;
+    }
+
+    *hMemspace = highBandwidthMemspace;
+    return UMF_RESULT_SUCCESS;
+}
+
+static umf_memspace_handle_t UMF_MEMSPACE_HIGHEST_BANDWIDTH = NULL;
+static UTIL_ONCE_FLAG UMF_MEMSPACE_HBW_INITIALIZED = UTIL_ONCE_FLAG_INIT;
+
+void umfMemspaceHighestBandwidthDestroy(void) {
+    if (UMF_MEMSPACE_HIGHEST_BANDWIDTH) {
+        umfMemspaceDestroy(UMF_MEMSPACE_HIGHEST_BANDWIDTH);
+        UMF_MEMSPACE_HIGHEST_BANDWIDTH = NULL;
+    }
+}
+
+static void umfMemspaceHighestBandwidthInit(void) {
+    umf_result_t ret =
+        umfMemspaceHighestBandwidthCreate(&UMF_MEMSPACE_HIGHEST_BANDWIDTH);
+    if (ret != UMF_RESULT_SUCCESS) {
+        LOG_ERR(
+            "Creating the highest bandwidth memspace failed with a %u error\n",
+            ret);
+        assert(ret == UMF_RESULT_ERROR_NOT_SUPPORTED);
+    }
+
+#if defined(_WIN32) && !defined(UMF_SHARED_LIBRARY)
+    atexit(umfMemspaceHighestBandwidthDestroy);
+#endif
+}
+
+umf_memspace_handle_t umfMemspaceHighestBandwidthGet(void) {
+    util_init_once(&UMF_MEMSPACE_HBW_INITIALIZED,
+                   umfMemspaceHighestBandwidthInit);
+    return UMF_MEMSPACE_HIGHEST_BANDWIDTH;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -173,6 +173,10 @@ if(LINUX) # OS-specific functions are implemented only for Linux now
         NAME memspace_highest_capacity
         SRCS memspaces/memspace_highest_capacity.cpp
         LIBS ${UMF_UTILS_FOR_TEST} ${LIBNUMA_LIBRARIES})
+    add_umf_test(
+        NAME memspace_highest_bandwidth
+        SRCS memspaces/memspace_highest_bandwidth.cpp
+        LIBS ${UMF_UTILS_FOR_TEST} ${LIBNUMA_LIBRARIES})
 endif()
 
 if(UMF_BUILD_GPU_TESTS AND UMF_BUILD_LEVEL_ZERO_PROVIDER)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -176,7 +176,7 @@ if(LINUX) # OS-specific functions are implemented only for Linux now
     add_umf_test(
         NAME memspace_highest_bandwidth
         SRCS memspaces/memspace_highest_bandwidth.cpp
-        LIBS ${UMF_UTILS_FOR_TEST} ${LIBNUMA_LIBRARIES})
+        LIBS ${UMF_UTILS_FOR_TEST} ${LIBNUMA_LIBRARIES} ${LIBHWLOC_LIBRARIES})
 endif()
 
 if(UMF_BUILD_GPU_TESTS AND UMF_BUILD_LEVEL_ZERO_PROVIDER)

--- a/test/memspaces/memspace_highest_bandwidth.cpp
+++ b/test/memspaces/memspace_highest_bandwidth.cpp
@@ -1,0 +1,19 @@
+// Copyright (C) 2024 Intel Corporation
+// Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "memory_target_numa.h"
+#include "memspace_helpers.hpp"
+#include "memspace_internal.h"
+#include "test_helpers.h"
+
+#include <numa.h>
+#include <numaif.h>
+#include <umf/memspace.h>
+
+using umf_test::test;
+
+TEST_F(numaNodesTest, memspaceGet) {
+    umf_memspace_handle_t hMemspace = umfMemspaceHighestBandwidthGet();
+    UT_ASSERTne(hMemspace, nullptr);
+}

--- a/test/memspaces/memspace_highest_bandwidth.cpp
+++ b/test/memspaces/memspace_highest_bandwidth.cpp
@@ -7,13 +7,197 @@
 #include "memspace_internal.h"
 #include "test_helpers.h"
 
-#include <numa.h>
-#include <numaif.h>
+#include <hwloc.h>
+#include <thread>
 #include <umf/memspace.h>
 
 using umf_test::test;
 
-TEST_F(numaNodesTest, memspaceGet) {
-    umf_memspace_handle_t hMemspace = umfMemspaceHighestBandwidthGet();
-    UT_ASSERTne(hMemspace, nullptr);
+// In HWLOC v2.3.0, the 'hwloc_location_type_e' enum is defined inside an
+// 'hwloc_location' struct. In newer versions, this enum is defined globally.
+// To prevent compile errors in C++ tests related this scope change
+// 'hwloc_location_type_e' has been aliased.
+using hwloc_location_type_alias = decltype(hwloc_location::type);
+
+static bool canQueryBandwidth(size_t nodeId) {
+    hwloc_topology_t topology = nullptr;
+    int ret = hwloc_topology_init(&topology);
+    UT_ASSERTeq(ret, 0);
+    ret = hwloc_topology_load(topology);
+    UT_ASSERTeq(ret, 0);
+
+    hwloc_obj_t numaNode =
+        hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, nodeId);
+    UT_ASSERTne(numaNode, nullptr);
+
+    // Setup initiator structure.
+    struct hwloc_location initiator;
+    initiator.location.cpuset = numaNode->cpuset;
+    initiator.type = hwloc_location_type_alias::HWLOC_LOCATION_TYPE_CPUSET;
+
+    hwloc_uint64_t value = 0;
+    ret = hwloc_memattr_get_value(topology, HWLOC_MEMATTR_ID_BANDWIDTH,
+                                  numaNode, &initiator, 0, &value);
+
+    hwloc_topology_destroy(topology);
+    return (ret == 0);
+}
+
+struct memspaceHighestBandwidthTest : ::numaNodesTest {
+    void SetUp() override {
+        ::numaNodesTest::SetUp();
+
+        if (!canQueryBandwidth(nodeIds.front())) {
+            GTEST_SKIP();
+        }
+
+        hMemspace = umfMemspaceHighestBandwidthGet();
+        ASSERT_NE(hMemspace, nullptr);
+    }
+
+    umf_memspace_handle_t hMemspace = nullptr;
+};
+
+struct memspaceHighestBandwidthProviderTest : ::memspaceHighestBandwidthTest {
+    void SetUp() override {
+        ::memspaceHighestBandwidthTest::SetUp();
+
+        if (!canQueryBandwidth(nodeIds.front())) {
+            GTEST_SKIP();
+        }
+
+        umf_result_t ret =
+            umfMemoryProviderCreateFromMemspace(hMemspace, nullptr, &hProvider);
+        ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+        ASSERT_NE(hProvider, nullptr);
+    }
+
+    void TearDown() override {
+        ::memspaceHighestBandwidthTest::TearDown();
+
+        if (hProvider) {
+            umfMemoryProviderDestroy(hProvider);
+        }
+    }
+
+    umf_memory_provider_handle_t hProvider = nullptr;
+};
+
+TEST_F(memspaceHighestBandwidthTest, providerFromMemspace) {
+    umf_memory_provider_handle_t hProvider = nullptr;
+    umf_result_t ret =
+        umfMemoryProviderCreateFromMemspace(hMemspace, nullptr, &hProvider);
+    UT_ASSERTeq(ret, UMF_RESULT_SUCCESS);
+    UT_ASSERTne(hProvider, nullptr);
+
+    umfMemoryProviderDestroy(hProvider);
+}
+
+TEST_F(memspaceHighestBandwidthProviderTest, allocFree) {
+    void *ptr = nullptr;
+    size_t size = SIZE_4K;
+    size_t alignment = 0;
+
+    umf_result_t ret = umfMemoryProviderAlloc(hProvider, size, alignment, &ptr);
+    UT_ASSERTeq(ret, UMF_RESULT_SUCCESS);
+    UT_ASSERTne(ptr, nullptr);
+
+    // Access the allocation, so that all the pages associated with it are
+    // allocated on some NUMA node.
+    memset(ptr, 0xFF, size);
+
+    ret = umfMemoryProviderFree(hProvider, ptr, size);
+    UT_ASSERTeq(ret, UMF_RESULT_SUCCESS);
+}
+
+static std::vector<int> getAllCpus() {
+    std::vector<int> allCpus;
+    for (int i = 0; i < numa_num_possible_cpus(); ++i) {
+        if (numa_bitmask_isbitset(numa_all_cpus_ptr, i)) {
+            allCpus.push_back(i);
+        }
+    }
+
+    return allCpus;
+}
+
+#define MAX_NODES 512
+
+TEST_F(memspaceHighestBandwidthProviderTest, allocLocalMt) {
+    auto pinAllocValidate = [&](umf_memory_provider_handle_t hProvider,
+                                int cpu) {
+        hwloc_topology_t topology = NULL;
+        UT_ASSERTeq(hwloc_topology_init(&topology), 0);
+        UT_ASSERTeq(hwloc_topology_load(topology), 0);
+
+        // Pin current thread to the provided CPU.
+        hwloc_cpuset_t pinCpuset = hwloc_bitmap_alloc();
+        UT_ASSERTeq(hwloc_bitmap_set(pinCpuset, cpu), 0);
+        UT_ASSERTeq(
+            hwloc_set_cpubind(topology, pinCpuset, HWLOC_CPUBIND_THREAD), 0);
+
+        // Confirm that the thread is pinned to the provided CPU.
+        hwloc_cpuset_t curCpuset = hwloc_bitmap_alloc();
+        UT_ASSERTeq(
+            hwloc_get_cpubind(topology, curCpuset, HWLOC_CPUBIND_THREAD), 0);
+        UT_ASSERT(hwloc_bitmap_isequal(curCpuset, pinCpuset));
+        hwloc_bitmap_free(curCpuset);
+        hwloc_bitmap_free(pinCpuset);
+
+        // Allocate some memory.
+        const size_t size = SIZE_4K;
+        const size_t alignment = 0;
+        void *ptr = nullptr;
+
+        umf_result_t ret =
+            umfMemoryProviderAlloc(hProvider, size, alignment, &ptr);
+        UT_ASSERTeq(ret, UMF_RESULT_SUCCESS);
+        UT_ASSERTne(ptr, nullptr);
+
+        // Access the allocation, so that all the pages associated with it are
+        // allocated on some NUMA node.
+        memset(ptr, 0xFF, size);
+
+        // Get the NUMA node responsible for this allocation.
+        int mode = -1;
+        std::vector<size_t> boundNodeIds;
+        size_t allocNodeId = SIZE_MAX;
+        getAllocationPolicy(ptr, maxNodeId, mode, boundNodeIds, allocNodeId);
+
+        // Get the CPUs associated with the specified NUMA node.
+        hwloc_obj_t allocNodeObj =
+            hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, allocNodeId);
+
+        unsigned nNodes = MAX_NODES;
+        std::vector<hwloc_obj_t> localNodes(MAX_NODES);
+        hwloc_location loc;
+        loc.location.object = allocNodeObj,
+        loc.type = hwloc_location_type_alias::HWLOC_LOCATION_TYPE_OBJECT;
+        UT_ASSERTeq(hwloc_get_local_numanode_objs(topology, &loc, &nNodes,
+                                                  localNodes.data(), 0),
+                    0);
+        UT_ASSERT(nNodes <= MAX_NODES);
+
+        // Confirm that the allocation from this thread was made to a local
+        // NUMA node.
+        UT_ASSERT(std::any_of(localNodes.begin(), localNodes.end(),
+                              [&allocNodeObj](hwloc_obj_t node) {
+                                  return node == allocNodeObj;
+                              }));
+
+        ret = umfMemoryProviderFree(hProvider, ptr, size);
+        UT_ASSERTeq(ret, UMF_RESULT_SUCCESS);
+
+        hwloc_topology_destroy(topology);
+    };
+
+    const auto cpus = getAllCpus();
+    std::vector<std::thread> threads;
+    for (auto cpu : cpus) {
+        threads.emplace_back(pinAllocValidate, hProvider, cpu);
+    }
+
+    for (auto &thread : threads) {
+        thread.join();
+    }
 }

--- a/test/memspaces/memspace_numa.cpp
+++ b/test/memspaces/memspace_numa.cpp
@@ -9,6 +9,47 @@
 
 #include <umf/providers/provider_os_memory.h>
 
+struct memspaceNumaTest : ::numaNodesTest {
+    void SetUp() override {
+        ::numaNodesTest::SetUp();
+
+        umf_result_t ret = umfMemspaceCreateFromNumaArray(
+            nodeIds.data(), nodeIds.size(), &hMemspace);
+        ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+        ASSERT_NE(hMemspace, nullptr);
+    }
+
+    void TearDown() override {
+        ::numaNodesTest::TearDown();
+        if (hMemspace) {
+            umfMemspaceDestroy(hMemspace);
+        }
+    }
+
+    umf_memspace_handle_t hMemspace = nullptr;
+};
+
+struct memspaceNumaProviderTest : ::memspaceNumaTest {
+    void SetUp() override {
+        ::memspaceNumaTest::SetUp();
+
+        umf_result_t ret =
+            umfMemoryProviderCreateFromMemspace(hMemspace, nullptr, &hProvider);
+        ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+        ASSERT_NE(hProvider, nullptr);
+    }
+
+    void TearDown() override {
+        ::memspaceNumaTest::TearDown();
+
+        if (hProvider != nullptr) {
+            umfMemoryProviderDestroy(hProvider);
+        }
+    }
+
+    umf_memory_provider_handle_t hProvider = nullptr;
+};
+
 TEST_F(numaNodesTest, createDestroy) {
     umf_memspace_handle_t hMemspace = nullptr;
     umf_result_t ret = umfMemspaceCreateFromNumaArray(

--- a/test/test_valgrind.sh
+++ b/test/test_valgrind.sh
@@ -100,6 +100,9 @@ for test in $(ls -1 umf_test-*); do
 	umf_test-provider_os_memory_multiple_numa_nodes)
 		FILTER='--gtest_filter="-testNuma.checkModeInterleave*:testNumaNodesAllocations/testNumaOnEachNode.checkNumaNodesAllocations*:testNumaNodesAllocations/testNumaOnEachNode.checkModePreferred*:testNumaNodesAllocations/testNumaOnEachNode.checkModeInterleaveSingleNode*:testNumaNodesAllocationsAllCpus/testNumaOnEachCpu.checkModePreferredEmptyNodeset*:testNumaNodesAllocationsAllCpus/testNumaOnEachCpu.checkModeLocal*"'
 		;;
+	umf_test-memspace_highest_bandwidth)
+		FILTER='--gtest_filter="-*allocLocalMt*"'
+		;;
 	esac
 
 	[ "$FILTER" != "" ] && echo -n "($FILTER) "


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description
This memspace contains memory targets ordered by the highest bandwidth value (targets higher in the ordering are prioritised).
There is also an alternative way to assign nodes to this memspace by setting `UMF_MEMSPACE_HIGHEST_BANDWIDTH` environment variable.

<!--

Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->
### TODO
- [x] Add tests for "highest bandwidth" memspace from `UMF_MEMSPACE_HIGHEST_BANDWIDTH`
- [x] Verify functionality on QEMU runner

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [x] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [x] New tests added, especially if they will fail without my changes
- [x] Extended the README/documentation
- [x] All newly added source files have a license
- [x] All newly added source files are referenced in CMake files
- [x] Logger (with debug/info/... messages) is used
