### PR TITLE
Remove assert from umf_ba_destroy

### DIFF
--- a/src/base_alloc/base_alloc.c
+++ b/src/base_alloc/base_alloc.c
@@ -291,7 +291,6 @@ void umf_ba_destroy(umf_ba_pool_t *pool) {
     if (pool->metadata.n_allocs) {
         LOG_ERR("umf_ba_destroy(): pool->metadata.n_allocs = %zu",
                 pool->metadata.n_allocs);
-        assert(pool->metadata.n_allocs == 0);
     }
 #endif /* NDEBUG */
 

--- a/src/base_alloc/base_alloc_linear.c
+++ b/src/base_alloc/base_alloc_linear.c
@@ -252,7 +252,6 @@ void umf_ba_linear_destroy(umf_ba_linear_pool_t *pool) {
     if (pool->metadata.global_n_allocs) {
         LOG_ERR("umf_ba_linear_destroy(): global_n_allocs = %zu",
                 pool->metadata.global_n_allocs);
-        assert(pool->metadata.global_n_allocs == 0);
     }
 #endif /* NDEBUG */
 


### PR DESCRIPTION
This assert would be triggered every time a memory pool or memory provider is leaked. Assert should not be used to verify the correctness of a user code but only to make sure the state of UMF is correct.  Also, in certain cases, leaking a pool/provider might be done on purpose.

<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
