### PR TITLE
Enable tests of proxy library on Windows Debug

### DIFF
--- a/.cmake-format
+++ b/.cmake-format
@@ -26,8 +26,7 @@ with section("parse"):
       'kwargs': {
         'NAME': '*', 
         'SRCS': '*', 
-        'LIBS': '*',
-        'CFGS': '*'}},
+        'LIBS': '*'}},
     'add_umf_library': {
       "pargs": 0,
       "flags": [],

--- a/README.md
+++ b/README.md
@@ -199,6 +199,26 @@ using umfMemspaceHostAllGet.
 Memspace backed by all available NUMA nodes discovered on the platform sorted by capacity.
 Can be retrieved using umfMemspaceHighestCapacityGet.
 
+### Proxy library
+
+UMF provides the UMF proxy library (`umf_proxy`) that makes it possible
+to override the default allocator in other programs in both Linux and Windows.
+
+#### Linux
+
+In case of Linux it can be done without any code changes using the `LD_PRELOAD` environment variable:
+
+```sh
+$ LD_PRELOAD=/usr/lib/libumf_proxy.so myprogram
+```
+
+#### Windows
+
+In case of Windows it requires:
+1) explicitly linking your program dynamically with the `umf_proxy.dll` library
+2) (C++ code only) including `proxy_lib_new_delete.h` in a single(!) source file in your project
+   to override also the `new`/`delete` operations.
+
 ## Contributions
 
 All contributions to the UMF project are most welcome! Before submitting

--- a/include/umf/proxy_lib_new_delete.h
+++ b/include/umf/proxy_lib_new_delete.h
@@ -1,0 +1,153 @@
+/* ----------------------------------------------------------------------------
+Copyright (c) 2018-2020 Microsoft Research, Daan Leijen
+Copyright (C) 2024 Intel Corporation
+
+This is free software; you can redistribute it and/or modify it under the
+terms of the MIT license:
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-----------------------------------------------------------------------------*/
+
+#ifndef UMF_PROXY_LIB_NEW_DELETE_H
+#define UMF_PROXY_LIB_NEW_DELETE_H
+
+// ----------------------------------------------------------------------------
+// This header provides convenient overrides for the new and
+// delete operations in C++.
+//
+// This header should be included in only one source file!
+//
+// On Windows, or when linking dynamically with UMF, these
+// can be more performant than the standard new-delete operations.
+// See <https://en.cppreference.com/w/cpp/memory/new/operator_new>
+// ---------------------------------------------------------------------------
+
+#if defined(__cplusplus)
+#include <new>
+
+#ifndef _WIN32
+#include <stdlib.h>
+#endif // _WIN32
+
+static inline void *internal_aligned_alloc(size_t alignment, size_t size) {
+#ifdef _WIN32
+    return _aligned_malloc(size, alignment);
+#else
+    return aligned_alloc(alignment, size);
+#endif // _WIN32
+}
+
+#if defined(_MSC_VER) && defined(_Ret_notnull_) &&                             \
+    defined(_Post_writable_byte_size_)
+// stay consistent with VCRT definitions
+#define decl_new(n) [[nodiscard]] _Ret_notnull_ _Post_writable_byte_size_(n)
+#define decl_new_nothrow(n)                                                    \
+    [[nodiscard]] _Ret_maybenull_ _Success_(return != NULL)                    \
+        _Post_writable_byte_size_(n)
+#else
+#define decl_new(n) [[nodiscard]]
+#define decl_new_nothrow(n) [[nodiscard]]
+#endif // defined(_MSC_VER) && defined(_Ret_notnull_) && defined(_Post_writable_byte_size_)
+
+void operator delete(void *p) noexcept { free(p); };
+void operator delete[](void *p) noexcept { free(p); };
+
+void operator delete(void *p, const std::nothrow_t &) noexcept { free(p); }
+void operator delete[](void *p, const std::nothrow_t &) noexcept { free(p); }
+
+decl_new(n) void *operator new(std::size_t n) noexcept(false) {
+    return malloc(n);
+}
+decl_new(n) void *operator new[](std::size_t n) noexcept(false) {
+    return malloc(n);
+}
+
+decl_new_nothrow(n) void *operator new(std::size_t n,
+                                       const std::nothrow_t &tag) noexcept {
+    (void)(tag);
+    return malloc(n);
+}
+decl_new_nothrow(n) void *operator new[](std::size_t n,
+                                         const std::nothrow_t &tag) noexcept {
+    (void)(tag);
+    return malloc(n);
+}
+
+#if (__cplusplus >= 201402L || _MSC_VER >= 1916)
+void operator delete(void *p, std::size_t n) noexcept {
+    (void)(n);
+    free(p);
+};
+void operator delete[](void *p, std::size_t n) noexcept {
+    (void)(n);
+    free(p);
+};
+#endif // (__cplusplus >= 201402L || _MSC_VER >= 1916)
+
+#if (__cplusplus > 201402L || defined(__cpp_aligned_new))
+void operator delete(void *p, std::align_val_t al) noexcept {
+    (void)(al);
+    free(p);
+}
+void operator delete[](void *p, std::align_val_t al) noexcept {
+    (void)(al);
+    free(p);
+}
+void operator delete(void *p, std::size_t n, std::align_val_t al) noexcept {
+    (void)(n);
+    (void)(al);
+    free(p);
+};
+void operator delete[](void *p, std::size_t n, std::align_val_t al) noexcept {
+    (void)(n);
+    (void)(al);
+    free(p);
+};
+void operator delete(void *p, std::align_val_t al,
+                     const std::nothrow_t &) noexcept {
+    (void)(al);
+    free(p);
+}
+void operator delete[](void *p, std::align_val_t al,
+                       const std::nothrow_t &) noexcept {
+    (void)(al);
+    free(p);
+}
+
+void *operator new(std::size_t n, std::align_val_t al) noexcept(false) {
+    return internal_aligned_alloc(static_cast<size_t>(al), n);
+}
+void *operator new[](std::size_t n, std::align_val_t al) noexcept(false) {
+    return internal_aligned_alloc(static_cast<size_t>(al), n);
+}
+void *operator new(std::size_t n, std::align_val_t al,
+                   const std::nothrow_t &) noexcept {
+    return internal_aligned_alloc(static_cast<size_t>(al), n);
+}
+void *operator new[](std::size_t n, std::align_val_t al,
+                     const std::nothrow_t &) noexcept {
+    return internal_aligned_alloc(static_cast<size_t>(al), n);
+}
+#endif // (__cplusplus > 201402L || defined(__cpp_aligned_new))
+#endif // defined(__cplusplus)
+
+#endif // UMF_PROXY_LIB_NEW_DELETE_H

--- a/src/proxy_lib/proxy_lib.def
+++ b/src/proxy_lib/proxy_lib.def
@@ -9,8 +9,15 @@ EXPORTS
 	DllMain
 	aligned_alloc
 	calloc
-	_free_dbg
 	free
 	malloc
 	_msize
 	realloc
+	_aligned_malloc
+	_aligned_realloc
+	_aligned_recalloc
+	_aligned_msize
+	_aligned_free
+	_aligned_offset_malloc
+	_aligned_offset_realloc
+	_aligned_offset_recalloc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -240,6 +240,8 @@ if(UMF_PROXY_LIB_ENABLED AND UMF_BUILD_SHARED_LIBRARY)
         SRCS memoryPoolAPI.cpp malloc_compliance_tests.cpp
         LIBS umf_proxy
         CFGS ${CONFIGS})
+    target_compile_definitions(umf_test-proxy_lib_memoryPool
+                               PUBLIC UMF_PROXY_LIB_ENABLED=1)
 endif()
 
 if(UMF_ENABLE_POOL_TRACKING)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,7 +30,7 @@ function(add_umf_test)
     # * SRCS - source files
     # * LIBS - libraries to be linked with
     set(oneValueArgs NAME)
-    set(multiValueArgs SRCS LIBS CFGS)
+    set(multiValueArgs SRCS LIBS)
     cmake_parse_arguments(
         ARG
         ""
@@ -73,7 +73,6 @@ function(add_umf_test)
     add_test(
         NAME ${TEST_NAME}
         COMMAND ${TEST_TARGET_NAME}
-        CONFIGURATIONS ${ARG_CFGS}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
     set_tests_properties(${TEST_NAME} PROPERTIES LABELS "umf")
@@ -224,22 +223,16 @@ add_umf_test(
 
 # tests for the proxy library
 if(UMF_PROXY_LIB_ENABLED AND UMF_BUILD_SHARED_LIBRARY)
-    # The CFGS variable can be removed when the issue of running the proxy
-    # library on Windows with Debug configuration is fixed.
-    if(WINDOWS)
-        set(CONFIGS Release RelWithDebInfo MinSizeRel)
-    endif()
     add_umf_test(
         NAME proxy_lib_basic
         SRCS test_proxy_lib.cpp
-        LIBS umf_proxy
-        CFGS ${CONFIGS})
+        LIBS umf_proxy)
+
     # the memoryPool test run with the proxy library
     add_umf_test(
         NAME proxy_lib_memoryPool
         SRCS memoryPoolAPI.cpp malloc_compliance_tests.cpp
-        LIBS umf_proxy
-        CFGS ${CONFIGS})
+        LIBS umf_proxy)
     target_compile_definitions(umf_test-proxy_lib_memoryPool
                                PUBLIC UMF_PROXY_LIB_ENABLED=1)
 endif()

--- a/test/memoryPoolAPI.cpp
+++ b/test/memoryPoolAPI.cpp
@@ -14,6 +14,10 @@
 #include <umf/memory_provider.h>
 #include <umf/pools/pool_proxy.h>
 
+#ifdef UMF_PROXY_LIB_ENABLED
+#include <umf/proxy_lib_new_delete.h>
+#endif
+
 #include <array>
 #include <string>
 #include <thread>

--- a/test/test_proxy_lib.cpp
+++ b/test/test_proxy_lib.cpp
@@ -11,6 +11,8 @@
 #include <malloc.h>
 #endif
 
+#include <umf/proxy_lib_new_delete.h>
+
 #include "base.hpp"
 #include "test_helpers.h"
 


### PR DESCRIPTION
### Description

1) Add `_aligned_malloc()` and `_aligned_free()` to Windows proxy library.
    `_aligned_malloc()` is a Windows variant of Linux `aligned_alloc()`

2) Add proxy_lib_new_delete.h

    This header provides convenient overrides for the new and delete
    operations in C++. It should be included in only one source file.

    See: https://github.com/microsoft/mimalloc/tree/8f7d1e9a41bb0182166aac6a8d4d8b00f60ed032?tab=readme-ov-file#override_on_windows
    Fixes: #350

3) Revert "Disable proxy lib tests on Windows Debug"

    This reverts commit 92fa419d007a29c308739ffc7d8f3a2b608058ea.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
