### PR TITLE
check for null dereference in trackingOpenIpcHandle

### DIFF
--- a/src/provider/provider_tracking.c
+++ b/src/provider/provider_tracking.c
@@ -586,17 +586,23 @@ static umf_result_t trackingOpenIpcHandle(void *provider, void *providerIpcData,
         (umf_tracking_memory_provider_t *)provider;
     umf_result_t ret = UMF_RESULT_SUCCESS;
 
+    if (p->hUpstream == NULL) {
+        LOG_ERR("tracking open ipc handle failed: no upstream provider");
+        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
     ret = umfMemoryProviderOpenIPCHandle(p->hUpstream, providerIpcData, ptr);
     if (ret != UMF_RESULT_SUCCESS) {
         return ret;
     }
     size_t bufferSize = getDataSizeFromIpcHandle(providerIpcData);
     ret = umfMemoryTrackerAdd(p->hTracker, p->pool, *ptr, bufferSize);
-    if (ret != UMF_RESULT_SUCCESS && p->hUpstream) {
+    if (ret != UMF_RESULT_SUCCESS) {
         if (umfMemoryProviderCloseIPCHandle(p->hUpstream, *ptr)) {
-            // TODO: LOG
+            LOG_ERR("failed to close IPC handle");
         }
     }
+
     return ret;
 }
 


### PR DESCRIPTION


### Description

Check for null dereference in trackingOpenIpcHandle - this is a fix for coverity issue https://scan3.scan.coverity.com/#/project-view/65229/15141?selectedIssue=453142

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
- [x] Logger (with debug/info/... messages) is used
