### PR TITLE
Bump black version

### DIFF
--- a/third_party/requirements.txt
+++ b/third_party/requirements.txt
@@ -2,7 +2,7 @@
 # Formatting the source code
 clang-format==15.0.7
 cmake-format==0.6.13
-black==23.7.0
+black==24.3.0
 # Generating HTML documentation
 pygments==2.15.1
 sphinxcontrib_applehelp==1.0.4


### PR DESCRIPTION
Bump `black` formatter version in our python's `requirements.txt` to omit the vulnerability PYSEC-2024-48.
- [x] verified on my fork, the vulnerability is no longer reported by scorecard