### PR TITLE
Do not use c_str() beyond its scope

### DIFF
--- a/test/utils/utils_log.cpp
+++ b/test/utils/utils_log.cpp
@@ -476,6 +476,7 @@ TEST_F(test, plog_long_error) {
 #endif
     strerror_ret_static = 0;
     helper_test_plog(LOG_DEBUG, "%s", "example log");
+    strerr = NULL; // do not use tmp.c_str() beyond its scope
 }
 
 TEST_F(test, log_pmacros) {


### PR DESCRIPTION
### Description

Do not use c_str() beyond its scope.
It fixes the Coverity issue [#449676](https://scan3.scan.coverity.com/#/project-view/66197/15141?selectedIssue=449676)

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
