### PR TITLE
Make os_translate_mem_protection_flags return umf_result_t

### DIFF
--- a/src/provider/provider_os_memory_internal.h
+++ b/src/provider/provider_os_memory_internal.h
@@ -20,10 +20,13 @@ typedef enum umf_purge_advise_t {
     UMF_PURGE_FORCE,
 } umf_purge_advise_t;
 
-int os_translate_flags(unsigned in_flags, unsigned max,
-                       int (*translate_flag)(unsigned));
+umf_result_t os_translate_flags(unsigned in_flags, unsigned max,
+                                umf_result_t (*translate_flag)(unsigned,
+                                                               unsigned *),
+                                unsigned *out_flags);
 
-int os_translate_mem_protection_flags(unsigned protection);
+umf_result_t os_translate_mem_protection_flags(unsigned in_protection,
+                                               unsigned *out_protection);
 
 void *os_mmap(void *hint_addr, size_t length, int prot);
 

--- a/src/provider/provider_os_memory_linux.c
+++ b/src/provider/provider_os_memory_linux.c
@@ -13,25 +13,31 @@
 #include "provider_os_memory_internal.h"
 #include <umf/providers/provider_os_memory.h>
 
-static int os_translate_mem_protection_one_flag(unsigned protection) {
-    switch (protection) {
+umf_result_t os_translate_mem_protection_one_flag(unsigned in_protection,
+                                                  unsigned *out_protection) {
+    switch (in_protection) {
     case UMF_PROTECTION_NONE:
-        return PROT_NONE;
+        *out_protection = PROT_NONE;
+        return UMF_RESULT_SUCCESS;
     case UMF_PROTECTION_READ:
-        return PROT_READ;
+        *out_protection = PROT_READ;
+        return UMF_RESULT_SUCCESS;
     case UMF_PROTECTION_WRITE:
-        return PROT_WRITE;
+        *out_protection = PROT_WRITE;
+        return UMF_RESULT_SUCCESS;
     case UMF_PROTECTION_EXEC:
-        return PROT_EXEC;
+        *out_protection = PROT_EXEC;
+        return UMF_RESULT_SUCCESS;
     }
-    assert(0);
-    return -1;
+    return UMF_RESULT_ERROR_INVALID_ARGUMENT;
 }
 
-int os_translate_mem_protection_flags(unsigned protection_flags) {
+umf_result_t os_translate_mem_protection_flags(unsigned in_protection,
+                                               unsigned *out_protection) {
     // translate protection - combination of 'umf_mem_protection_flags_t' flags
-    return os_translate_flags(protection_flags, UMF_PROTECTION_MAX,
-                              os_translate_mem_protection_one_flag);
+    return os_translate_flags(in_protection, UMF_PROTECTION_MAX,
+                              os_translate_mem_protection_one_flag,
+                              out_protection);
 }
 
 static int os_translate_purge_advise(umf_purge_advise_t advise) {

--- a/src/provider/provider_os_memory_windows.c
+++ b/src/provider/provider_os_memory_windows.c
@@ -20,30 +20,38 @@
 static UTIL_ONCE_FLAG Page_size_is_initialized = UTIL_ONCE_FLAG_INIT;
 static size_t Page_size;
 
-int os_translate_mem_protection_flags(unsigned protection) {
-    switch (protection) {
+umf_result_t os_translate_mem_protection_flags(unsigned in_protection,
+                                               unsigned *out_protection) {
+    switch (in_protection) {
     case UMF_PROTECTION_NONE:
-        return PAGE_NOACCESS;
+        *out_protection = PAGE_NOACCESS;
+        return UMF_RESULT_SUCCESS;
     case UMF_PROTECTION_EXEC:
-        return PAGE_EXECUTE;
+        *out_protection = PAGE_EXECUTE;
+        return UMF_RESULT_SUCCESS;
     case (UMF_PROTECTION_EXEC | UMF_PROTECTION_READ):
-        return PAGE_EXECUTE_READ;
+        *out_protection = PAGE_EXECUTE_READ;
+        return UMF_RESULT_SUCCESS;
     case (UMF_PROTECTION_EXEC | UMF_PROTECTION_READ | UMF_PROTECTION_WRITE):
-        return PAGE_EXECUTE_READWRITE;
+        *out_protection = PAGE_EXECUTE_READWRITE;
+        return UMF_RESULT_SUCCESS;
     case (UMF_PROTECTION_EXEC | UMF_PROTECTION_WRITE):
-        return PAGE_EXECUTE_WRITECOPY;
+        *out_protection = PAGE_EXECUTE_WRITECOPY;
+        return UMF_RESULT_SUCCESS;
     case UMF_PROTECTION_READ:
-        return PAGE_READONLY;
+        *out_protection = PAGE_READONLY;
+        return UMF_RESULT_SUCCESS;
     case (UMF_PROTECTION_READ | UMF_PROTECTION_WRITE):
-        return PAGE_READWRITE;
+        *out_protection = PAGE_READWRITE;
+        return UMF_RESULT_SUCCESS;
     case UMF_PROTECTION_WRITE:
-        return PAGE_WRITECOPY;
+        *out_protection = PAGE_WRITECOPY;
+        return UMF_RESULT_SUCCESS;
     }
     LOG_ERR("os_translate_mem_protection_flags(): unsupported protection flag: "
             "%u",
-            protection);
-    assert(0);
-    return -1;
+            in_protection);
+    return UMF_RESULT_ERROR_INVALID_ARGUMENT;
 }
 
 void *os_mmap(void *hint_addr, size_t length, int prot) {


### PR DESCRIPTION
### Description

Make `os_translate_mem_protection_flags`, `os_translate_flags` and `os_translate_mem_protection_one_flag` return umf_result_t.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
