### PR TITLE
Add size param to the close_ipc_handle API

### DIFF
--- a/include/umf/memory_provider.h
+++ b/include/umf/memory_provider.h
@@ -188,12 +188,13 @@ umfMemoryProviderOpenIPCHandle(umf_memory_provider_handle_t hProvider,
 /// @brief Close an IPC memory handle.
 /// @param hProvider [in] handle to the memory provider.
 /// @param ptr [in] pointer returned by umfMemoryProviderOpenIPCHandle function.
+/// @param size [in] size of the memory address range.
 /// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
 ///         UMF_RESULT_ERROR_INVALID_ARGUMENT if invalid \p hProvider or \p ptr are passed.
 ///         UMF_RESULT_ERROR_NOT_SUPPORTED if IPC functionality is not supported by this provider.
 umf_result_t
 umfMemoryProviderCloseIPCHandle(umf_memory_provider_handle_t hProvider,
-                                void *ptr);
+                                void *ptr, size_t size);
 
 ///
 /// @brief Retrieve name of a given memory \p hProvider.

--- a/include/umf/memory_provider_ops.h
+++ b/include/umf/memory_provider_ops.h
@@ -125,10 +125,11 @@ typedef struct umf_memory_provider_ipc_ops_t {
     /// @brief Closes an IPC memory handle.
     /// @param provider pointer to the memory provider.
     /// @param ptr pointer to the memory retrieved with open_ipc_handle function.
+    /// @param size size of the memory address range.
     /// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
     ///         UMF_RESULT_ERROR_INVALID_ARGUMENT if invalid \p ptr is passed.
     ///         UMF_RESULT_ERROR_NOT_SUPPORTED if IPC functionality is not supported by this provider.
-    umf_result_t (*close_ipc_handle)(void *provider, void *ptr);
+    umf_result_t (*close_ipc_handle)(void *provider, void *ptr, size_t size);
 } umf_memory_provider_ipc_ops_t;
 
 ///

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -113,5 +113,6 @@ umf_result_t umfCloseIPCHandle(void *ptr) {
     // upstream provider but we need tracking one
     umf_memory_provider_handle_t hProvider = allocInfo.pool->provider;
 
-    return umfMemoryProviderCloseIPCHandle(hProvider, allocInfo.base);
+    return umfMemoryProviderCloseIPCHandle(hProvider, allocInfo.base,
+                                           allocInfo.size);
 }

--- a/src/memory_provider.c
+++ b/src/memory_provider.c
@@ -90,9 +90,11 @@ static umf_result_t umfDefaultOpenIPCHandle(void *provider,
     return UMF_RESULT_ERROR_NOT_SUPPORTED;
 }
 
-static umf_result_t umfDefaultCloseIPCHandle(void *provider, void *ptr) {
+static umf_result_t umfDefaultCloseIPCHandle(void *provider, void *ptr,
+                                             size_t size) {
     (void)provider;
     (void)ptr;
+    (void)size;
     return UMF_RESULT_ERROR_NOT_SUPPORTED;
 }
 
@@ -356,6 +358,7 @@ umfMemoryProviderOpenIPCHandle(umf_memory_provider_handle_t hProvider,
 
 umf_result_t
 umfMemoryProviderCloseIPCHandle(umf_memory_provider_handle_t hProvider,
-                                void *ptr) {
-    return hProvider->ops.ipc.close_ipc_handle(hProvider->provider_priv, ptr);
+                                void *ptr, size_t size) {
+    return hProvider->ops.ipc.close_ipc_handle(hProvider->provider_priv, ptr,
+                                               size);
 }

--- a/src/provider/provider_level_zero.c
+++ b/src/provider/provider_level_zero.c
@@ -366,10 +366,11 @@ static umf_result_t ze_memory_provider_open_ipc_handle(void *provider,
     return UMF_RESULT_SUCCESS;
 }
 
-static umf_result_t ze_memory_provider_close_ipc_handle(void *provider,
-                                                        void *ptr) {
+static umf_result_t
+ze_memory_provider_close_ipc_handle(void *provider, void *ptr, size_t size) {
     ASSERT(provider != NULL);
     ASSERT(ptr != NULL);
+    (void)size;
     ze_result_t ze_result;
     struct ze_memory_provider_t *ze_provider =
         (struct ze_memory_provider_t *)provider;

--- a/src/provider/provider_tracking.c
+++ b/src/provider/provider_tracking.c
@@ -598,14 +598,15 @@ static umf_result_t trackingOpenIpcHandle(void *provider, void *providerIpcData,
     size_t bufferSize = getDataSizeFromIpcHandle(providerIpcData);
     ret = umfMemoryTrackerAdd(p->hTracker, p->pool, *ptr, bufferSize);
     if (ret != UMF_RESULT_SUCCESS) {
-        if (umfMemoryProviderCloseIPCHandle(p->hUpstream, *ptr)) {
+        if (umfMemoryProviderCloseIPCHandle(p->hUpstream, *ptr, bufferSize)) {
             // TODO: LOG
         }
     }
     return ret;
 }
 
-static umf_result_t trackingCloseIpcHandle(void *provider, void *ptr) {
+static umf_result_t trackingCloseIpcHandle(void *provider, void *ptr,
+                                           size_t size) {
     umf_tracking_memory_provider_t *p =
         (umf_tracking_memory_provider_t *)provider;
 
@@ -621,7 +622,7 @@ static umf_result_t trackingCloseIpcHandle(void *provider, void *ptr) {
             LOG_ERR("tracking free: umfMemoryTrackerRemove failed");
         }
     }
-    return umfMemoryProviderCloseIPCHandle(p->hUpstream, ptr);
+    return umfMemoryProviderCloseIPCHandle(p->hUpstream, ptr, size);
 }
 
 umf_memory_provider_ops_t UMF_TRACKING_MEMORY_PROVIDER_OPS = {

--- a/test/common/provider.hpp
+++ b/test/common/provider.hpp
@@ -90,7 +90,8 @@ typedef struct provider_base_t {
                                  [[maybe_unused]] void **ptr) noexcept {
         return UMF_RESULT_ERROR_UNKNOWN;
     }
-    umf_result_t close_ipc_handle([[maybe_unused]] void *ptr) noexcept {
+    umf_result_t close_ipc_handle([[maybe_unused]] void *ptr,
+                                  [[maybe_unused]] size_t size) noexcept {
         return UMF_RESULT_ERROR_UNKNOWN;
     }
 } provider_base_t;

--- a/test/common/provider_null.c
+++ b/test/common/provider_null.c
@@ -122,9 +122,10 @@ static umf_result_t nullOpenIpcHandle(void *provider, void *ipcHandle,
     return UMF_RESULT_SUCCESS;
 }
 
-static umf_result_t nullCloseIpcHandle(void *provider, void *ptr) {
+static umf_result_t nullCloseIpcHandle(void *provider, void *ptr, size_t size) {
     (void)provider;
     (void)ptr;
+    (void)size;
     return UMF_RESULT_SUCCESS;
 }
 

--- a/test/common/provider_trace.c
+++ b/test/common/provider_trace.c
@@ -165,13 +165,14 @@ static umf_result_t traceOpenIpcHandle(void *provider, void *ipcHandle,
                                           ipcHandle, ptr);
 }
 
-static umf_result_t traceCloseIpcHandle(void *provider, void *ptr) {
+static umf_result_t traceCloseIpcHandle(void *provider, void *ptr,
+                                        size_t size) {
     umf_provider_trace_params_priv_t *traceProvider =
         (umf_provider_trace_params_priv_t *)provider;
 
     traceProvider->trace("close_ipc_handle");
     return umfMemoryProviderCloseIPCHandle(traceProvider->hUpstreamProvider,
-                                           ptr);
+                                           ptr, size);
 }
 
 umf_memory_provider_ops_t UMF_TRACE_PROVIDER_OPS = {

--- a/test/ipcAPI.cpp
+++ b/test/ipcAPI.cpp
@@ -111,7 +111,8 @@ struct provider_mock_ipc : public umf_test::provider_base_t {
 
         return UMF_RESULT_SUCCESS;
     }
-    enum umf_result_t close_ipc_handle(void *ptr) noexcept {
+    enum umf_result_t close_ipc_handle(void *ptr, size_t size) noexcept {
+        (void)size;
         ++stat->closeCount;
         std::free(ptr);
         return UMF_RESULT_SUCCESS;


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description
Add size param to the close_ipc_handle API

It is needed by https://github.com/oneapi-src/unified-memory-framework/pull/429

Ref: #429 

### Checklist

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [ ] CI workflows execute properly
