### PR TITLE
Set versions in CMake

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -6,6 +6,10 @@ on: workflow_call
 permissions:
   contents: read
 
+env:
+  # for installation testing - it should match with version set in CMake
+  UMF_VERSION: 0.1.0
+
 jobs:
   icx-build:
     # TODO: we could merge ICX build with gcc/clang (using our dockers) Issue: #259
@@ -34,7 +38,10 @@ jobs:
     - name: Install apt packages
       run: |
         apt-get update
-        apt-get install -y libnuma-dev libjemalloc-dev libtbb-dev libhwloc-dev sudo
+        apt-get install -y libnuma-dev libjemalloc-dev libtbb-dev libhwloc-dev python3-pip sudo
+
+    - name: Install Python requirements
+      run: python3 -m pip install -r third_party/requirements.txt
 
     - name: Configure build
       run: >
@@ -71,6 +78,7 @@ jobs:
         --disjoint-pool
         --jemalloc-pool
         --scalable-pool
+        --umf-version ${{env.UMF_VERSION}}
         ${{ matrix.shared_library == 'ON' && '--shared-library' || ''}}
 
   ubuntu-build:
@@ -170,6 +178,7 @@ jobs:
         --disjoint-pool
         --jemalloc-pool
         --scalable-pool
+        --umf-version ${{env.UMF_VERSION}}
         ${{ matrix.shared_library == 'ON' && '--shared-library' || '' }}
 
   windows-build:
@@ -258,6 +267,7 @@ jobs:
         --disjoint-pool
         --jemalloc-pool
         --scalable-pool
+        --umf-version ${{env.UMF_VERSION}}
         ${{ matrix.shared_library == 'ON' && '--shared-library' || ''}}
 
   macos-build:
@@ -304,7 +314,8 @@ jobs:
         --build-dir ${{env.BUILD_DIR}}
         --install-dir ${{env.INSTL_DIR}}
         --build-type ${{env.BUILD_TYPE}}
-        --shared-library
         --disjoint-pool
         --jemalloc-pool
         --scalable-pool
+        --umf-version ${{env.UMF_VERSION}}
+        --shared-library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,22 @@ project(
     VERSION 0.1.0
     LANGUAGES C)
 
+# needed when UMF is used as an external project
+set(UMF_CMAKE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+list(APPEND CMAKE_MODULE_PATH "${UMF_CMAKE_SOURCE_DIR}/cmake")
+include(helpers)
+
+# CMAKE_PROJECT_VERSION[_MAJOR|_MINOR|_PATCH] variables are set via 'project'
+# command. They cannot contain any "pre-release" part, though. We use custom
+# "UMF_SRC_VERSION" to store more accurate (source) version - this var should be
+# used, e.g., for creating packages.
+set_source_version()
+message(
+    STATUS
+        "UMF version: ${CMAKE_PROJECT_VERSION} (source version: ${UMF_SRC_VERSION})"
+)
+
 # Build Options
 option(UMF_BUILD_SHARED_LIBRARY "Build UMF as shared library" OFF)
 option(UMF_BUILD_LEVEL_ZERO_PROVIDER "Build Level Zero memory provider" ON)
@@ -108,12 +124,6 @@ include(CTest)
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 find_package(PkgConfig)
-
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-include(helpers)
-
-# needed when UMF is used as an external project
-set(UMF_CMAKE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,8 +115,10 @@ if(UMF_BUILD_SHARED_LIBRARY)
     set(UMF_PRIVATE_COMPILE_DEFINITIONS ${UMF_PRIVATE_COMPILE_DEFINITIONS}
                                         "UMF_SHARED_LIBRARY")
     set_target_properties(
-        umf PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_UMF_OUTPUT_DIRECTORY}
-                       VERSION ${CMAKE_PROJECT_VERSION})
+        umf
+        PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_UMF_OUTPUT_DIRECTORY}
+                   VERSION ${CMAKE_PROJECT_VERSION}
+                   SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR})
 else()
     add_umf_library(
         NAME umf

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,8 +114,9 @@ if(UMF_BUILD_SHARED_LIBRARY)
         WINDOWS_DEF_FILE ${CMAKE_CURRENT_SOURCE_DIR}/libumf.def)
     set(UMF_PRIVATE_COMPILE_DEFINITIONS ${UMF_PRIVATE_COMPILE_DEFINITIONS}
                                         "UMF_SHARED_LIBRARY")
-    set_target_properties(umf PROPERTIES RUNTIME_OUTPUT_DIRECTORY
-                                         ${CMAKE_UMF_OUTPUT_DIRECTORY})
+    set_target_properties(
+        umf PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_UMF_OUTPUT_DIRECTORY}
+                       VERSION ${CMAKE_PROJECT_VERSION})
 else()
     add_umf_library(
         NAME umf

--- a/src/proxy_lib/CMakeLists.txt
+++ b/src/proxy_lib/CMakeLists.txt
@@ -27,6 +27,8 @@ add_umf_library(
     LIBS ${PROXY_LIBS}
     LINUX_MAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/proxy_lib.map
     WINDOWS_DEF_FILE ${CMAKE_CURRENT_SOURCE_DIR}/proxy_lib.def)
+set_target_properties(umf_proxy PROPERTIES SOVERSION
+                                           ${CMAKE_PROJECT_VERSION_MAJOR})
 
 add_library(${PROJECT_NAME}::proxy ALIAS umf_proxy)
 

--- a/third_party/requirements.txt
+++ b/third_party/requirements.txt
@@ -3,6 +3,8 @@
 clang-format==15.0.7
 cmake-format==0.6.13
 black==24.3.0
+# Tests
+packaging==24.0
 # Generating HTML documentation
 pygments==2.15.1
 sphinxcontrib_applehelp==1.0.4


### PR DESCRIPTION
### Description
Use (and print) version set via `project` command, and additionally set "SRCVERSION" which will be more precise (based on git tags, if we have any).

Version change is actually a minor update, the more important part is the SOVERSION, which is now set for `libumf` and `libumf_proxy` shared libraries.

// After installation it looks like this, now:

![image](https://github.com/oneapi-src/unified-memory-framework/assets/29728779/4a008faa-366a-4bdf-9c08-e49f8e81dc22)
