### PR TITLE
Fix: os_free(NULL) should return UMF_RESULT_SUCCESS

### DIFF
--- a/src/provider/provider_os_memory.c
+++ b/src/provider/provider_os_memory.c
@@ -560,8 +560,12 @@ err_unmap:
 }
 
 static umf_result_t os_free(void *provider, void *ptr, size_t size) {
-    if (provider == NULL || ptr == NULL) {
+    if (provider == NULL) {
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (ptr == NULL) {
+        return UMF_RESULT_SUCCESS;
     }
 
     os_memory_provider_t *os_provider = (os_memory_provider_t *)provider;

--- a/test/provider_os_memory.cpp
+++ b/test/provider_os_memory.cpp
@@ -268,12 +268,12 @@ TEST_P(umfProviderTest, free_size_0_ptr_not_null) {
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
 }
 
-// other negative tests
-
 TEST_P(umfProviderTest, free_NULL) {
     umf_result_t umf_result = umfMemoryProviderFree(provider.get(), nullptr, 0);
-    ASSERT_EQ(umf_result, UMF_RESULT_ERROR_INVALID_ARGUMENT);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
 }
+
+// other negative tests
 
 TEST_P(umfProviderTest, free_INVALID_POINTER_SIZE_GT_0) {
     umf_result_t umf_result =


### PR DESCRIPTION
### Description

Fix: `os_free(NULL)` should return `UMF_RESULT_SUCCESS` instead of `UMF_RESULT_ERROR_INVALID_ARGUMENT`.

### Checklist
- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
