### PR TITLE
Remove assert from tracking provider

### DIFF
--- a/src/provider/provider_tracking.c
+++ b/src/provider/provider_tracking.c
@@ -405,7 +405,6 @@ static void check_if_tracker_is_empty(umf_memory_tracker_handle_t hTracker,
                         "left)",
                         n_items);
             }
-            assert(n_items == 0);
         }
     }
 }


### PR DESCRIPTION
This assert would be triggered every time a memory is leaked by the application. Currently this happens in certain SYCL tests.
Ref: https://github.com/intel/llvm/actions/runs/9024914892/job/24800360426?pr=13343
<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
