### PR TITLE
[CMake] include helpers module via full path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ project(
 set(UMF_CMAKE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 list(APPEND CMAKE_MODULE_PATH "${UMF_CMAKE_SOURCE_DIR}/cmake")
-include(helpers)
+include(${UMF_CMAKE_SOURCE_DIR}/cmake/helpers.cmake)
 
 # CMAKE_PROJECT_VERSION[_MAJOR|_MINOR|_PATCH] variables are set via 'project'
 # command. They cannot contain any "pre-release" part, though. We use custom


### PR DESCRIPTION
the name of helpers file is not very unique, it's safer to incldue this module via its full path.

Fixes https://github.com/oneapi-src/unified-memory-framework/issues/480

### Checklist
- [x] Code compiles without errors locally
- [x] CI workflows execute properly