### PR TITLE
Make sure the received string is NULL-terminated

### DIFF
--- a/examples/basic/ipc_shm_ipcapi_producer.c
+++ b/examples/basic/ipc_shm_ipcapi_producer.c
@@ -180,7 +180,7 @@ int main(int argc, char *argv[]) {
     memset(recv_buffer, 0, sizeof(recv_buffer));
 
     // receive the consumer's response
-    len = recv(producer_socket, recv_buffer, sizeof(recv_buffer), 0);
+    len = recv(producer_socket, recv_buffer, sizeof(recv_buffer) - 1, 0);
     if (len < 0) {
         fprintf(
             stderr,

--- a/test/ipc_os_prov_producer.c
+++ b/test/ipc_os_prov_producer.c
@@ -205,8 +205,8 @@ int main(int argc, char *argv[]) {
     memset(consumer_message, 0, sizeof(consumer_message));
 
     // receive the consumer's response
-    if (recv(producer_socket, consumer_message, sizeof(consumer_message), 0) <
-        0) {
+    if (recv(producer_socket, consumer_message, sizeof(consumer_message) - 1,
+             0) < 0) {
         fprintf(
             stderr,
             "[producer] ERROR: error while receiving the consumer's message\n");


### PR DESCRIPTION
### Description

Make sure the received string is NULL-terminated.
It fixes the Coverity issue no. 460614.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
