### PR TITLE
Do not ignore error in os free when size == 0

### DIFF
--- a/src/provider/provider_os_memory.c
+++ b/src/provider/provider_os_memory.c
@@ -659,8 +659,7 @@ static umf_result_t os_free(void *provider, void *ptr, size_t size) {
 
     errno = 0;
     int ret = os_munmap(ptr, size);
-    // ignore error when size == 0
-    if (ret && (size > 0)) {
+    if (ret) {
         os_store_last_native_error(UMF_OS_RESULT_ERROR_FREE_FAILED, errno);
         LOG_PERR("memory deallocation failed");
 

--- a/test/provider_os_memory.cpp
+++ b/test/provider_os_memory.cpp
@@ -265,7 +265,7 @@ TEST_P(umfProviderTest, get_name) {
 TEST_P(umfProviderTest, free_size_0_ptr_not_null) {
     umf_result_t umf_result =
         umfMemoryProviderFree(provider.get(), INVALID_PTR, 0);
-    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_EQ(umf_result, UMF_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC);
 }
 
 TEST_P(umfProviderTest, free_NULL) {


### PR DESCRIPTION
### Description

Do not ignore error in os free when size == 0.
This is a continuation of #482.

Ref: #482

Requires to be merged:
- [x] #487 
- [x] #490 

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
