### PR TITLE
[Tests] skip test with improper ptrace value

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -42,6 +42,9 @@ jobs:
     - name: Install Python requirements
       run: python3 -m pip install -r third_party/requirements.txt
 
+    - name: Set ptrace value for IPC test
+      run: bash -c "echo 0 > /proc/sys/kernel/yama/ptrace_scope"
+
     - name: Configure build
       run: >
         cmake
@@ -136,6 +139,9 @@ jobs:
 
     - name: Install libhwloc
       run: .github/scripts/install_hwloc.sh
+
+    - name: Set ptrace value for IPC test
+      run: sudo bash -c "echo 0 > /proc/sys/kernel/yama/ptrace_scope"
 
     - name: Configure build
       run: >

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -58,6 +58,7 @@ jobs:
         -DUMF_BUILD_LIBUMF_POOL_DISJOINT=ON
         -DUMF_BUILD_LIBUMF_POOL_SCALABLE=ON
         -DUMF_BUILD_EXAMPLES=ON
+        -DUMF_TESTS_FAIL_ON_SKIP=ON
 
     - name: Build UMF
       run: cmake --build build -j $(nproc)
@@ -151,6 +152,7 @@ jobs:
         -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
         -DUMF_BUILD_LIBUMF_POOL_DISJOINT=ON
         -DUMF_BUILD_LIBUMF_POOL_SCALABLE=ON
+        -DUMF_TESTS_FAIL_ON_SKIP=ON
 
     - name: Build UMF
       run: cmake --build ${{env.BUILD_DIR}} -j $(nproc)
@@ -235,6 +237,7 @@ jobs:
         -DUMF_BUILD_LIBUMF_POOL_SCALABLE=ON
         -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
         -DUMF_BUILD_LEVEL_ZERO_PROVIDER=${{matrix.level_zero_provider}}
+        -DUMF_TESTS_FAIL_ON_SKIP=ON
 
     - name: Build UMF
       run: cmake --build ${{env.BUILD_DIR}} --config ${{matrix.build_type}} -j $Env:NUMBER_OF_PROCESSORS
@@ -289,6 +292,7 @@ jobs:
         -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
         -DUMF_BUILD_LIBUMF_POOL_SCALABLE=ON
         -DUMF_BUILD_SHARED_LIBRARY=ON
+        -DUMF_TESTS_FAIL_ON_SKIP=ON
 
     - name: Build UMF
       run: cmake --build ${{env.BUILD_DIR}} -j $(sysctl -n hw.logicalcpu)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -74,6 +74,7 @@ jobs:
         -DUMF_BUILD_LIBUMF_POOL_SCALABLE=ON
         -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
         -DUMF_BUILD_LEVEL_ZERO_PROVIDER=ON
+        -DUMF_TESTS_FAIL_ON_SKIP=ON
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config Release -j

--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -57,6 +57,7 @@ jobs:
           -DUMF_BUILD_LIBUMF_POOL_SCALABLE=ON
           -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
           -DUMF_BUILD_LEVEL_ZERO_PROVIDER=ON
+          -DUMF_TESTS_FAIL_ON_SKIP=ON
       
       - name: Configure build for Ubuntu
         if: matrix.os == 'Ubuntu'
@@ -77,6 +78,7 @@ jobs:
           -DUMF_BUILD_LIBUMF_POOL_SCALABLE=ON
           -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
           -DUMF_BUILD_LEVEL_ZERO_PROVIDER=ON
+          -DUMF_TESTS_FAIL_ON_SKIP=ON
 
       - name: Build UMF
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} -j ${{matrix.number_of_processors}}

--- a/.github/workflows/multi_numa.yml
+++ b/.github/workflows/multi_numa.yml
@@ -38,6 +38,7 @@ jobs:
           -DUMF_BUILD_LIBUMF_POOL_DISJOINT=ON
           -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
           -DUMF_BUILD_LIBUMF_POOL_SCALABLE=ON
+          -DUMF_TESTS_FAIL_ON_SKIP=ON
 
       - name: Build UMF
         run: cmake --build ${{github.workspace}}/build -j $(nproc)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,6 +40,7 @@ jobs:
         -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
         -DUMF_BUILD_LEVEL_ZERO_PROVIDER=OFF
         -DUSE_VALGRIND=1
+        -DUMF_TESTS_FAIL_ON_SKIP=ON
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config Debug -j$(nproc)

--- a/.github/workflows/pr_push.yml
+++ b/.github/workflows/pr_push.yml
@@ -63,6 +63,10 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y cmake libjemalloc-dev libhwloc-dev libnuma-dev libtbb-dev
 
+    - name: Set ptrace value for IPC test (on Linux only)
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo bash -c "echo 0 > /proc/sys/kernel/yama/ptrace_scope"
+
     - name: Configure CMake
       run: >
         cmake

--- a/.github/workflows/pr_push.yml
+++ b/.github/workflows/pr_push.yml
@@ -76,6 +76,7 @@ jobs:
         -DUMF_BUILD_TESTS=${{matrix.build_tests}}
         -DUMF_BUILD_EXAMPLES=ON
         -DUMF_BUILD_LEVEL_ZERO_PROVIDER=ON
+        -DUMF_TESTS_FAIL_ON_SKIP=ON
         ${{matrix.extra_build_options}}
 
     - name: Build

--- a/.github/workflows/proxy_lib.yml
+++ b/.github/workflows/proxy_lib.yml
@@ -42,6 +42,7 @@ jobs:
           -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
           -DUMF_BUILD_LIBUMF_POOL_DISJOINT=ON
           -DUMF_BUILD_LIBUMF_POOL_SCALABLE=ON
+          -DUMF_TESTS_FAIL_ON_SKIP=ON
           -DUMF_PROXY_LIB_BASED_ON_POOL=${{matrix.proxy_lib_pool}}
 
       - name: Build UMF

--- a/.github/workflows/proxy_lib.yml
+++ b/.github/workflows/proxy_lib.yml
@@ -27,6 +27,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake libhwloc-dev libjemalloc-dev libtbb-dev
 
+      - name: Set ptrace value for IPC test
+        run: sudo bash -c "echo 0 > /proc/sys/kernel/yama/ptrace_scope"
+
       - name: Configure build
         run: >
           cmake

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -52,6 +52,7 @@ jobs:
         -DUSE_UBSAN=${{matrix.sanitizers.ubsan}}
         -DUSE_TSAN=${{matrix.sanitizers.tsan}}
         -DUMF_BUILD_EXAMPLES=ON
+        -DUMF_TESTS_FAIL_ON_SKIP=ON
 
     - name: Build UMF
       run: cmake --build ${{env.BUILD_DIR}} -j $(nproc)
@@ -96,6 +97,7 @@ jobs:
         -DUSE_UBSAN=${{matrix.sanitizers.ubsan}}
         -DUSE_TSAN=${{matrix.sanitizers.tsan}}
         -DUMF_BUILD_EXAMPLES=ON
+        -DUMF_TESTS_FAIL_ON_SKIP=ON
 
     - name: Build UMF
       run: cmake --build ${{env.BUILD_DIR}} -j $(nproc)
@@ -157,6 +159,7 @@ jobs:
         -DUSE_ASAN=${{matrix.sanitizers.asan}}
         -DUMF_BUILD_EXAMPLES=ON
         -DUMF_BUILD_LEVEL_ZERO_PROVIDER=OFF
+        -DUMF_TESTS_FAIL_ON_SKIP=ON
 
     - name: Build UMF
       run: cmake --build ${{env.BUILD_DIR}} --config Debug -j $Env:NUMBER_OF_PROCESSORS

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -34,6 +34,9 @@ jobs:
         apt-get update
         apt-get install -y cmake libnuma-dev libjemalloc-dev libtbb-dev libhwloc-dev sudo
 
+    - name: Set ptrace value for IPC test
+      run: bash -c "echo 0 > /proc/sys/kernel/yama/ptrace_scope"
+
     - name: Configure build
       run: >
         cmake
@@ -78,6 +81,9 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y clang cmake libhwloc-dev libnuma-dev libjemalloc-dev libtbb-dev
+
+    - name: Set ptrace value for IPC test
+      run: sudo bash -c "echo 0 > /proc/sys/kernel/yama/ptrace_scope"
 
     - name: Configure build
       run: >

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -35,6 +35,7 @@ jobs:
         -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
         -DUMF_BUILD_LEVEL_ZERO_PROVIDER=OFF
         -DUSE_VALGRIND=1
+        -DUMF_TESTS_FAIL_ON_SKIP=ON
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config Debug -j$(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,8 @@ option(UMF_DEVELOPER_MODE "Enable developer checks, treats warnings as errors"
 option(UMF_FORMAT_CODE_STYLE
        "Add clang, cmake, and black -format-check and -format-apply targets"
        OFF)
+# Only a part of skips is treated as a failure now. TODO: extend to all tests
+option(UMF_TESTS_FAIL_ON_SKIP "Treat skips in tests as fail" OFF)
 option(USE_ASAN "Enable AddressSanitizer checks" OFF)
 option(USE_UBSAN "Enable UndefinedBehaviorSanitizer checks" OFF)
 option(USE_TSAN "Enable ThreadSanitizer checks" OFF)
@@ -58,6 +60,16 @@ set(UMF_PROXY_LIB_BASED_ON_POOL
           "A UMF pool the proxy library is based on (SCALABLE or JEMALLOC)")
 set_property(CACHE UMF_PROXY_LIB_BASED_ON_POOL
              PROPERTY STRINGS ${KNOWN_PROXY_LIB_POOLS})
+
+if(UMF_BUILD_TESTS
+   AND DEFINED ENV{CI}
+   AND NOT UMF_TESTS_FAIL_ON_SKIP)
+    message(
+        FATAL_ERROR
+            "Env variable 'CI' is set, tests are enabled, but UMF_TESTS_FAIL_ON_SKIP is not. "
+            "Please set UMF_TESTS_FAIL_ON_SKIP to ON in all CI workflows running tests."
+    )
+endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     set(LINUX TRUE)

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ List of options provided by CMake:
 | UMF_BUILD_GPU_EXAMPLES | Build UMF GPU examples | ON/OFF | OFF |
 | UMF_DEVELOPER_MODE | Treat warnings as errors and enables additional checks | ON/OFF | OFF |
 | UMF_FORMAT_CODE_STYLE | Add clang, cmake, and black -format-check and -format-apply targets to make | ON/OFF | OFF |
+| UMF_TESTS_FAIL_ON_SKIP | Treat skips in tests as fail | ON/OFF | OFF |
 | USE_ASAN | Enable AddressSanitizer checks | ON/OFF | OFF |
 | USE_UBSAN | Enable UndefinedBehaviorSanitizer checks | ON/OFF | OFF |
 | USE_TSAN | Enable ThreadSanitizer checks | ON/OFF | OFF |

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -137,10 +137,10 @@ if(LINUX AND UMF_BUILD_LIBUMF_POOL_SCALABLE)
         COMMAND ${BASE_NAME}.sh
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-    set_tests_properties(
-        ${EXAMPLE_NAME} PROPERTIES
-        SKIP_RETURN_CODE 125
-        LABELS "example")
+    set_tests_properties(${EXAMPLE_NAME} PROPERTIES LABELS "example")
+    if(NOT UMF_TESTS_FAIL_ON_SKIP)
+        set_tests_properties(${EXAMPLE_NAME} PROPERTIES SKIP_RETURN_CODE 125)
+    endif()
 else()
     message(
         STATUS

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -137,7 +137,10 @@ if(LINUX AND UMF_BUILD_LIBUMF_POOL_SCALABLE)
         COMMAND ${BASE_NAME}.sh
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-    set_tests_properties(${EXAMPLE_NAME} PROPERTIES LABELS "example")
+    set_tests_properties(
+        ${EXAMPLE_NAME} PROPERTIES
+        SKIP_RETURN_CODE 125
+        LABELS "example")
 else()
     message(
         STATUS

--- a/examples/basic/ipc_shm_ipcapi.sh
+++ b/examples/basic/ipc_shm_ipcapi.sh
@@ -20,19 +20,8 @@ VAL=0
 if [ -f $PTRACE_SCOPE_FILE ]; then
 	PTRACE_SCOPE_VAL=$(cat $PTRACE_SCOPE_FILE)
 	if [ $PTRACE_SCOPE_VAL -ne $VAL ]; then
-		# check if sudo requires password
-		if ! timeout --kill-after=5s 3s sudo date; then
-			echo "ERROR: sudo requires password - cannot set ptrace_scope to 0"
-			exit 1
-		fi
-		echo "Setting ptrace_scope to 0 (classic ptrace permissions) ..."
-		echo "$ sudo bash -c \"echo $VAL > $PTRACE_SCOPE_FILE\""
-		sudo bash -c "echo $VAL > $PTRACE_SCOPE_FILE"
-	fi
-	PTRACE_SCOPE_VAL=$(cat $PTRACE_SCOPE_FILE)
-	if [ $PTRACE_SCOPE_VAL -ne $VAL ]; then
-		echo "SKIP: setting ptrace_scope to 0 (classic ptrace permissions) FAILED - skipping the test"
-		exit 0
+		echo "SKIP: ptrace_scope is not set to 0 (classic ptrace permissions) - skipping the test"
+		exit 125 # skip code defined in CMakeLists.txt
 	fi
 fi
 

--- a/scripts/qemu/run-build.sh
+++ b/scripts/qemu/run-build.sh
@@ -12,6 +12,9 @@ branch=$2
 echo password | sudo -Sk apt update
 echo password | sudo -Sk apt install -y git cmake gcc g++ numactl libnuma-dev libhwloc-dev libjemalloc-dev libtbb-dev pkg-config valgrind hwloc
 
+# Set ptrace value for IPC test
+echo password | sudo bash -c "echo 0 > /proc/sys/kernel/yama/ptrace_scope"
+
 numactl -H
 
 git clone $repo umf

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -257,6 +257,7 @@ if(LINUX)
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
     set_tests_properties(${TEST_NAME} PROPERTIES LABELS "umf")
+    set_tests_properties(${TEST_NAME} PROPERTIES SKIP_RETURN_CODE 125)
 else()
     message(
         STATUS "IPC shared memory test is supported on Linux only - skipping")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -257,7 +257,9 @@ if(LINUX)
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
     set_tests_properties(${TEST_NAME} PROPERTIES LABELS "umf")
-    set_tests_properties(${TEST_NAME} PROPERTIES SKIP_RETURN_CODE 125)
+    if(NOT UMF_TESTS_FAIL_ON_SKIP)
+        set_tests_properties(${TEST_NAME} PROPERTIES SKIP_RETURN_CODE 125)
+    endif()
 else()
     message(
         STATUS "IPC shared memory test is supported on Linux only - skipping")

--- a/test/ipc_os_prov.sh
+++ b/test/ipc_os_prov.sh
@@ -20,19 +20,8 @@ VAL=0
 if [ -f $PTRACE_SCOPE_FILE ]; then
 	PTRACE_SCOPE_VAL=$(cat $PTRACE_SCOPE_FILE)
 	if [ $PTRACE_SCOPE_VAL -ne $VAL ]; then
-		# check if sudo requires password
-		if ! timeout --kill-after=5s 3s sudo date; then
-			echo "ERROR: sudo requires password - cannot set ptrace_scope to 0"
-			exit 1
-		fi
-		echo "Setting ptrace_scope to 0 (classic ptrace permissions) ..."
-		echo "$ sudo bash -c \"echo $VAL > $PTRACE_SCOPE_FILE\""
-		sudo bash -c "echo $VAL > $PTRACE_SCOPE_FILE"
-	fi
-	PTRACE_SCOPE_VAL=$(cat $PTRACE_SCOPE_FILE)
-	if [ $PTRACE_SCOPE_VAL -ne $VAL ]; then
-		echo "SKIP: setting ptrace_scope to 0 (classic ptrace permissions) FAILED - skipping the test"
-		exit 0
+		echo "SKIP: ptrace_scope is not set to 0 (classic ptrace permissions) - skipping the test"
+		exit 125 # skip code defined in CMakeLists.txt
 	fi
 fi
 


### PR DESCRIPTION
Add skipping of IPC test, which require a specific value of ptrace (set in the system). Enable it in the CI in all workflows.

Fixes: #488 