### PR TITLE
Add a virtual destructor to the provider_base_t class

### DIFF
--- a/test/common/provider.hpp
+++ b/test/common/provider.hpp
@@ -94,6 +94,7 @@ typedef struct provider_base_t {
                                   [[maybe_unused]] size_t size) noexcept {
         return UMF_RESULT_ERROR_UNKNOWN;
     }
+    virtual ~provider_base_t() = default;
 } provider_base_t;
 
 umf_memory_provider_ops_t BASE_PROVIDER_OPS =


### PR DESCRIPTION
### Description

Add a virtual destructor to the provider_base_t class.
It fixes the Coverity issue no. 460541.

### Checklist
- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
