### PR TITLE
Replace enum umf_result_t with the umf_result_t type

### DIFF
--- a/benchmark/ubench.c
+++ b/benchmark/ubench.c
@@ -120,7 +120,7 @@ static umf_os_memory_provider_params_t UMF_OS_MEMORY_PROVIDER_PARAMS = {
 static void *w_umfMemoryProviderAlloc(void *provider, size_t size,
                                       size_t alignment) {
     void *ptr = NULL;
-    enum umf_result_t umf_result;
+    umf_result_t umf_result;
     umf_memory_provider_handle_t hProvider =
         (umf_memory_provider_handle_t)provider;
     umf_result = umfMemoryProviderAlloc(hProvider, size, alignment, &ptr);
@@ -133,7 +133,7 @@ static void *w_umfMemoryProviderAlloc(void *provider, size_t size,
 }
 
 static void w_umfMemoryProviderFree(void *provider, void *ptr, size_t size) {
-    enum umf_result_t umf_result;
+    umf_result_t umf_result;
     umf_memory_provider_handle_t hProvider =
         (umf_memory_provider_handle_t)provider;
     umf_result = umfMemoryProviderFree(hProvider, ptr, size);
@@ -146,7 +146,7 @@ static void w_umfMemoryProviderFree(void *provider, void *ptr, size_t size) {
 UBENCH_EX(simple, os_memory_provider) {
     alloc_t *array = alloc_array(N_ITERATIONS);
 
-    enum umf_result_t umf_result;
+    umf_result_t umf_result;
     umf_memory_provider_handle_t os_memory_provider = NULL;
     umf_result = umfMemoryProviderCreate(umfOsMemoryProviderOps(),
                                          &UMF_OS_MEMORY_PROVIDER_PARAMS,
@@ -176,7 +176,7 @@ static void *w_umfPoolMalloc(void *provider, size_t size, size_t alignment) {
 
 static void w_umfPoolFree(void *provider, void *ptr, size_t size) {
     (void)size; // unused
-    enum umf_result_t umf_result;
+    umf_result_t umf_result;
     umf_memory_pool_handle_t hPool = (umf_memory_pool_handle_t)provider;
     umf_result = umfPoolFree(hPool, ptr);
     if (umf_result != UMF_RESULT_SUCCESS) {
@@ -190,7 +190,7 @@ static void w_umfPoolFree(void *provider, void *ptr, size_t size) {
 UBENCH_EX(simple, proxy_pool_with_os_memory_provider) {
     alloc_t *array = alloc_array(N_ITERATIONS);
 
-    enum umf_result_t umf_result;
+    umf_result_t umf_result;
     umf_memory_provider_handle_t os_memory_provider = NULL;
     umf_result = umfMemoryProviderCreate(umfOsMemoryProviderOps(),
                                          &UMF_OS_MEMORY_PROVIDER_PARAMS,
@@ -227,7 +227,7 @@ UBENCH_EX(simple, proxy_pool_with_os_memory_provider) {
 UBENCH_EX(simple, disjoint_pool_with_os_memory_provider) {
     alloc_t *array = alloc_array(N_ITERATIONS);
 
-    enum umf_result_t umf_result;
+    umf_result_t umf_result;
     umf_memory_provider_handle_t os_memory_provider = NULL;
     umf_result = umfMemoryProviderCreate(umfOsMemoryProviderOps(),
                                          &UMF_OS_MEMORY_PROVIDER_PARAMS,
@@ -272,7 +272,7 @@ UBENCH_EX(simple, disjoint_pool_with_os_memory_provider) {
 UBENCH_EX(simple, jemalloc_pool_with_os_memory_provider) {
     alloc_t *array = alloc_array(N_ITERATIONS);
 
-    enum umf_result_t umf_result;
+    umf_result_t umf_result;
     umf_memory_provider_handle_t os_memory_provider = NULL;
     umf_result = umfMemoryProviderCreate(umfOsMemoryProviderOps(),
                                          &UMF_OS_MEMORY_PROVIDER_PARAMS,
@@ -310,7 +310,7 @@ UBENCH_EX(simple, jemalloc_pool_with_os_memory_provider) {
 UBENCH_EX(simple, scalable_pool_with_os_memory_provider) {
     alloc_t *array = alloc_array(N_ITERATIONS);
 
-    enum umf_result_t umf_result;
+    umf_result_t umf_result;
     umf_memory_provider_handle_t os_memory_provider = NULL;
     umf_result = umfMemoryProviderCreate(umfOsMemoryProviderOps(),
                                          &UMF_OS_MEMORY_PROVIDER_PARAMS,

--- a/src/memspace.c
+++ b/src/memspace.c
@@ -110,8 +110,8 @@ void umfMemspaceDestroy(umf_memspace_handle_t memspace) {
     umf_ba_global_free(memspace);
 }
 
-enum umf_result_t umfMemspaceClone(umf_memspace_handle_t hMemspace,
-                                   umf_memspace_handle_t *outHandle) {
+umf_result_t umfMemspaceClone(umf_memspace_handle_t hMemspace,
+                              umf_memspace_handle_t *outHandle) {
     if (!hMemspace || !outHandle) {
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
@@ -171,7 +171,7 @@ static int propertyCmp(const void *a, const void *b) {
     }
 }
 
-enum umf_result_t
+umf_result_t
 umfMemspaceSortDesc(umf_memspace_handle_t hMemspace,
                     umf_result_t (*getProperty)(umf_memory_target_handle_t node,
                                                 uint64_t *property)) {

--- a/src/memspace_internal.h
+++ b/src/memspace_internal.h
@@ -27,8 +27,8 @@ struct umf_memspace_t {
 ///
 /// \brief Clones memspace
 ///
-enum umf_result_t umfMemspaceClone(umf_memspace_handle_t hMemspace,
-                                   umf_memspace_handle_t *outHandle);
+umf_result_t umfMemspaceClone(umf_memspace_handle_t hMemspace,
+                              umf_memspace_handle_t *outHandle);
 
 typedef umf_result_t (*umfGetPropertyFn)(umf_memory_target_handle_t,
                                          uint64_t *);
@@ -36,8 +36,8 @@ typedef umf_result_t (*umfGetPropertyFn)(umf_memory_target_handle_t,
 ///
 /// \brief Sorts memspace by getProperty() in descending order
 ///
-enum umf_result_t umfMemspaceSortDesc(umf_memspace_handle_t hMemspace,
-                                      umfGetPropertyFn getProperty);
+umf_result_t umfMemspaceSortDesc(umf_memspace_handle_t hMemspace,
+                                 umfGetPropertyFn getProperty);
 
 ///
 /// \brief Destroys memspace

--- a/src/memspaces/memspace_numa.c
+++ b/src/memspaces/memspace_numa.c
@@ -14,14 +14,13 @@
 #include "base_alloc_global.h"
 #include "memspace_numa.h"
 
-enum umf_result_t
-umfMemspaceCreateFromNumaArray(unsigned *nodeIds, size_t numIds,
-                               umf_memspace_handle_t *hMemspace) {
+umf_result_t umfMemspaceCreateFromNumaArray(unsigned *nodeIds, size_t numIds,
+                                            umf_memspace_handle_t *hMemspace) {
     if (!nodeIds || numIds == 0 || !hMemspace) {
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
 
-    enum umf_result_t ret = UMF_RESULT_SUCCESS;
+    umf_result_t ret = UMF_RESULT_SUCCESS;
     umf_memspace_handle_t memspace =
         umf_ba_global_alloc(sizeof(struct umf_memspace_t));
     if (!memspace) {

--- a/src/provider/provider_level_zero.c
+++ b/src/provider/provider_level_zero.c
@@ -92,7 +92,7 @@ static void init_ze_global_state(void) {
     }
 }
 
-enum umf_result_t ze_memory_provider_initialize(void *params, void **provider) {
+umf_result_t ze_memory_provider_initialize(void *params, void **provider) {
     if (provider == NULL || params == NULL) {
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
@@ -128,9 +128,9 @@ void ze_memory_provider_finalize(void *provider) {
     umf_ba_global_free(provider);
 }
 
-static enum umf_result_t ze_memory_provider_alloc(void *provider, size_t size,
-                                                  size_t alignment,
-                                                  void **resultPtr) {
+static umf_result_t ze_memory_provider_alloc(void *provider, size_t size,
+                                             size_t alignment,
+                                             void **resultPtr) {
     assert(provider);
     assert(resultPtr);
 
@@ -185,8 +185,8 @@ static enum umf_result_t ze_memory_provider_alloc(void *provider, size_t size,
                : UMF_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC;
 }
 
-static enum umf_result_t ze_memory_provider_free(void *provider, void *ptr,
-                                                 size_t bytes) {
+static umf_result_t ze_memory_provider_free(void *provider, void *ptr,
+                                            size_t bytes) {
     (void)bytes;
 
     assert(provider);
@@ -210,9 +210,9 @@ void ze_memory_provider_get_last_native_error(void *provider,
     *pError = 0;
 }
 
-static enum umf_result_t
-ze_memory_provider_get_min_page_size(void *provider, void *ptr,
-                                     size_t *pageSize) {
+static umf_result_t ze_memory_provider_get_min_page_size(void *provider,
+                                                         void *ptr,
+                                                         size_t *pageSize) {
     (void)provider;
     (void)ptr;
 
@@ -241,7 +241,7 @@ static umf_result_t ze_memory_provider_purge_force(void *provider, void *ptr,
     return UMF_RESULT_ERROR_NOT_SUPPORTED;
 }
 
-static enum umf_result_t
+static umf_result_t
 ze_memory_provider_get_recommended_page_size(void *provider, size_t size,
                                              size_t *pageSize) {
     (void)provider;
@@ -257,10 +257,10 @@ const char *ze_memory_provider_get_name(void *provider) {
     return "LEVEL_ZERO";
 }
 
-static enum umf_result_t ze_memory_provider_allocation_merge(void *hProvider,
-                                                             void *lowPtr,
-                                                             void *highPtr,
-                                                             size_t totalSize) {
+static umf_result_t ze_memory_provider_allocation_merge(void *hProvider,
+                                                        void *lowPtr,
+                                                        void *highPtr,
+                                                        size_t totalSize) {
     (void)hProvider;
     (void)lowPtr;
     (void)highPtr;

--- a/src/proxy_lib/proxy_lib.c
+++ b/src/proxy_lib/proxy_lib.c
@@ -109,7 +109,7 @@ static __TLS int was_called_from_umfPool = 0;
 void proxy_lib_create_common(void) {
     umf_os_memory_provider_params_t os_params =
         umfOsMemoryProviderParamsDefault();
-    enum umf_result_t umf_result;
+    umf_result_t umf_result;
 
 #ifndef _WIN32
     if (util_env_var_has_str("UMF_PROXY", "page.disposition=shared")) {

--- a/test/ipcAPI.cpp
+++ b/test/ipcAPI.cpp
@@ -28,7 +28,7 @@ struct provider_mock_ipc : public umf_test::provider_base_t {
     allocations_mutex_type alloc_mutex;
     allocations_map_type allocations;
 
-    enum umf_result_t alloc(size_t size, size_t align, void **ptr) noexcept {
+    umf_result_t alloc(size_t size, size_t align, void **ptr) noexcept {
         auto ret = helper_prov.alloc(size, align, ptr);
         if (ret == UMF_RESULT_SUCCESS) {
             allocations_write_lock_type lock(alloc_mutex);
@@ -38,7 +38,7 @@ struct provider_mock_ipc : public umf_test::provider_base_t {
         }
         return ret;
     }
-    enum umf_result_t free(void *ptr, size_t size) noexcept {
+    umf_result_t free(void *ptr, size_t size) noexcept {
         allocations_write_lock_type lock(alloc_mutex);
         allocations.erase(ptr);
         lock.unlock();
@@ -46,12 +46,12 @@ struct provider_mock_ipc : public umf_test::provider_base_t {
         return ret;
     }
     const char *get_name() noexcept { return "mock_ipc"; }
-    enum umf_result_t get_ipc_handle_size(size_t *size) noexcept {
+    umf_result_t get_ipc_handle_size(size_t *size) noexcept {
         *size = sizeof(provider_ipc_data_t);
         return UMF_RESULT_SUCCESS;
     }
-    enum umf_result_t get_ipc_handle(const void *ptr, size_t size,
-                                     void *providerIpcData) noexcept {
+    umf_result_t get_ipc_handle(const void *ptr, size_t size,
+                                void *providerIpcData) noexcept {
         provider_ipc_data_t *ipcData =
             static_cast<provider_ipc_data_t *>(providerIpcData);
         // we do not need lock for allocations map here, because we just read
@@ -69,12 +69,11 @@ struct provider_mock_ipc : public umf_test::provider_base_t {
         ipcData->size = size; // size of the base allocation
         return UMF_RESULT_SUCCESS;
     }
-    enum umf_result_t put_ipc_handle(void *providerIpcData) noexcept {
+    umf_result_t put_ipc_handle(void *providerIpcData) noexcept {
         (void)providerIpcData;
         return UMF_RESULT_SUCCESS;
     }
-    enum umf_result_t open_ipc_handle(void *providerIpcData,
-                                      void **ptr) noexcept {
+    umf_result_t open_ipc_handle(void *providerIpcData, void **ptr) noexcept {
         provider_ipc_data_t *ipcData =
             static_cast<provider_ipc_data_t *>(providerIpcData);
 
@@ -99,7 +98,7 @@ struct provider_mock_ipc : public umf_test::provider_base_t {
 
         return UMF_RESULT_SUCCESS;
     }
-    enum umf_result_t close_ipc_handle(void *ptr, size_t size) noexcept {
+    umf_result_t close_ipc_handle(void *ptr, size_t size) noexcept {
         (void)size;
         std::free(ptr);
         return UMF_RESULT_SUCCESS;

--- a/test/memspaces/memspace_helpers.hpp
+++ b/test/memspaces/memspace_helpers.hpp
@@ -44,7 +44,7 @@ struct memspaceNumaTest : ::numaNodesTest {
     void SetUp() override {
         ::numaNodesTest::SetUp();
 
-        enum umf_result_t ret = umfMemspaceCreateFromNumaArray(
+        umf_result_t ret = umfMemspaceCreateFromNumaArray(
             nodeIds.data(), nodeIds.size(), &hMemspace);
         ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
         ASSERT_NE(hMemspace, nullptr);

--- a/test/memspaces/memspace_host_all.cpp
+++ b/test/memspaces/memspace_host_all.cpp
@@ -34,7 +34,7 @@ TEST_F(numaNodesTest, memspaceGet) {
 
 TEST_F(memspaceHostAllTest, providerFromHostAllMemspace) {
     umf_memory_provider_handle_t hProvider = nullptr;
-    enum umf_result_t ret =
+    umf_result_t ret =
         umfMemoryProviderCreateFromMemspace(hMemspace, nullptr, &hProvider);
     UT_ASSERTeq(ret, UMF_RESULT_SUCCESS);
     UT_ASSERTne(hProvider, nullptr);
@@ -47,8 +47,7 @@ TEST_F(memspaceHostAllProviderTest, allocFree) {
     size_t size = SIZE_4K;
     size_t alignment = 0;
 
-    enum umf_result_t ret =
-        umfMemoryProviderAlloc(hProvider, size, alignment, &ptr);
+    umf_result_t ret = umfMemoryProviderAlloc(hProvider, size, alignment, &ptr);
     UT_ASSERTeq(ret, UMF_RESULT_SUCCESS);
     UT_ASSERTne(ptr, nullptr);
 

--- a/test/memspaces/memspace_numa.cpp
+++ b/test/memspaces/memspace_numa.cpp
@@ -11,7 +11,7 @@
 
 TEST_F(numaNodesTest, createDestroy) {
     umf_memspace_handle_t hMemspace = nullptr;
-    enum umf_result_t ret = umfMemspaceCreateFromNumaArray(
+    umf_result_t ret = umfMemspaceCreateFromNumaArray(
         nodeIds.data(), nodeIds.size(), &hMemspace);
     ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
     ASSERT_NE(hMemspace, nullptr);
@@ -21,28 +21,28 @@ TEST_F(numaNodesTest, createDestroy) {
 
 TEST_F(numaNodesTest, createInvalidNullArray) {
     umf_memspace_handle_t hMemspace = nullptr;
-    enum umf_result_t ret = umfMemspaceCreateFromNumaArray(NULL, 0, &hMemspace);
+    umf_result_t ret = umfMemspaceCreateFromNumaArray(NULL, 0, &hMemspace);
     ASSERT_EQ(ret, UMF_RESULT_ERROR_INVALID_ARGUMENT);
     ASSERT_EQ(hMemspace, nullptr);
 }
 
 TEST_F(numaNodesTest, createInvalidZeroSize) {
     umf_memspace_handle_t hMemspace = nullptr;
-    enum umf_result_t ret =
+    umf_result_t ret =
         umfMemspaceCreateFromNumaArray(nodeIds.data(), 0, &hMemspace);
     ASSERT_EQ(ret, UMF_RESULT_ERROR_INVALID_ARGUMENT);
     ASSERT_EQ(hMemspace, nullptr);
 }
 
 TEST_F(numaNodesTest, createInvalidNullHandle) {
-    enum umf_result_t ret =
+    umf_result_t ret =
         umfMemspaceCreateFromNumaArray(nodeIds.data(), nodeIds.size(), nullptr);
     ASSERT_EQ(ret, UMF_RESULT_ERROR_INVALID_ARGUMENT);
 }
 
 TEST_F(memspaceNumaTest, providerFromNumaMemspace) {
     umf_memory_provider_handle_t hProvider = nullptr;
-    enum umf_result_t ret =
+    umf_result_t ret =
         umfMemoryProviderCreateFromMemspace(hMemspace, nullptr, &hProvider);
     ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
     ASSERT_NE(hProvider, nullptr);
@@ -55,8 +55,7 @@ TEST_F(memspaceNumaProviderTest, allocFree) {
     size_t size = SIZE_4K;
     size_t alignment = 0;
 
-    enum umf_result_t ret =
-        umfMemoryProviderAlloc(hProvider, size, alignment, &ptr);
+    umf_result_t ret = umfMemoryProviderAlloc(hProvider, size, alignment, &ptr);
     ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
     ASSERT_NE(ptr, nullptr);
 


### PR DESCRIPTION
### Description

Replace `enum umf_result_t` with the `umf_result_t` type.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
