### PR TITLE
[CI] bump toolset version in sanitizer job on Win

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -119,7 +119,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-    # Use '14.38.33130' MSVC toolset when compiling UMF with ASan.
+    # Use the latest MSVC toolset available, when compiling UMF with ASan.
     # Running binaries compiled with older toolsets results in a
     # 'STATUS_DLL_INIT_FAILED' error despite being linked with ASan from
     # the same toolset as the compiler being used.
@@ -129,7 +129,7 @@ jobs:
       uses: TheMrMilchmann/setup-msvc-dev@48edcef51a12c80d7e62ace57aae1417795e511c # v3.0.0
       with:
         arch: x64
-        toolset: 14.38.33130
+        toolset: '14.39.33519'
 
     - name: Initialize vcpkg
       uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5


### PR DESCRIPTION
Use the latest version available in the GHA Win image.

- [x] All tests pass locally
- [x] CI workflows execute properly