### PR TITLE
Add pid to the umf_ipc_data_t structure

### DIFF
--- a/src/ipc.c
+++ b/src/ipc.c
@@ -16,6 +16,7 @@
 #include "ipc_internal.h"
 #include "memory_pool_internal.h"
 #include "provider/provider_tracking.h"
+#include "utils_common.h"
 #include "utils_log.h"
 
 umf_result_t umfGetIPCHandle(const void *ptr, umf_ipc_handle_t *umfIPCHandle,
@@ -56,6 +57,7 @@ umf_result_t umfGetIPCHandle(const void *ptr, umf_ipc_handle_t *umfIPCHandle,
         return ret;
     }
 
+    ipcData->pid = utils_getpid();
     ipcData->baseSize = allocInfo.baseSize;
     ipcData->offset = (uintptr_t)ptr - (uintptr_t)allocInfo.base;
 

--- a/src/ipc_internal.h
+++ b/src/ipc_internal.h
@@ -21,6 +21,7 @@ extern "C" {
 // providerIpcData is a Flexible Array Member because its size varies
 // depending on the provider.
 typedef struct umf_ipc_data_t {
+    int pid;         // process ID of the process that allocated the memory
     size_t baseSize; // size of base (coarse-grain) allocation
     uint64_t offset;
     char providerIpcData[];

--- a/src/provider/provider_os_memory.c
+++ b/src/provider/provider_os_memory.c
@@ -17,6 +17,7 @@
 #include "base_alloc_global.h"
 #include "critnib.h"
 #include "provider_os_memory_internal.h"
+#include "utils_common.h"
 #include "utils_concurrency.h"
 #include "utils_log.h"
 
@@ -854,7 +855,7 @@ static umf_result_t os_get_ipc_handle(void *provider, const void *ptr,
     }
 
     os_ipc_data_t *os_ipc_data = (os_ipc_data_t *)providerIpcData;
-    os_ipc_data->pid = os_getpid();
+    os_ipc_data->pid = utils_getpid();
     os_ipc_data->fd = os_provider->fd;
     os_ipc_data->fd_offset = (size_t)value - 1;
     os_ipc_data->size = size;
@@ -870,7 +871,8 @@ static umf_result_t os_put_ipc_handle(void *provider, void *providerIpcData) {
     os_memory_provider_t *os_provider = (os_memory_provider_t *)provider;
     os_ipc_data_t *os_ipc_data = (os_ipc_data_t *)providerIpcData;
 
-    if (os_ipc_data->fd != os_provider->fd || os_ipc_data->pid != os_getpid()) {
+    if (os_ipc_data->fd != os_provider->fd ||
+        os_ipc_data->pid != utils_getpid()) {
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
 

--- a/src/provider/provider_os_memory_internal.h
+++ b/src/provider/provider_os_memory_internal.h
@@ -48,8 +48,6 @@ size_t os_get_page_size(void);
 
 void os_strerror(int errnum, char *buf, size_t buflen);
 
-int os_getpid(void);
-
 umf_result_t os_duplicate_fd(int pid, int fd_in, int *fd_out);
 
 umf_result_t os_close_fd(int fd);

--- a/src/provider/provider_os_memory_posix.c
+++ b/src/provider/provider_os_memory_posix.c
@@ -90,8 +90,6 @@ void os_strerror(int errnum, char *buf, size_t buflen) {
     strerror_r(errnum, buf, buflen);
 }
 
-int os_getpid(void) { return getpid(); }
-
 umf_result_t os_duplicate_fd(int pid, int fd_in, int *fd_out) {
 // pidfd_getfd(2) is used to obtain a duplicate of another process's file descriptor.
 // Permission to duplicate another process's file descriptor

--- a/src/provider/provider_os_memory_windows.c
+++ b/src/provider/provider_os_memory_windows.c
@@ -116,8 +116,6 @@ void os_strerror(int errnum, char *buf, size_t buflen) {
     strerror_s(buf, buflen, errnum);
 }
 
-int os_getpid(void) { return GetCurrentProcessId(); }
-
 umf_result_t os_duplicate_fd(int pid, int fd_in, int *fd_out) {
     (void)pid;                             // unused
     (void)fd_in;                           // unused

--- a/src/utils/utils_common.h
+++ b/src/utils/utils_common.h
@@ -71,6 +71,9 @@ size_t util_get_page_size(void);
 // align a pointer and a size
 void util_align_ptr_size(void **ptr, size_t *size, size_t alignment);
 
+// get the current process ID
+int utils_getpid(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/utils/utils_posix_common.c
+++ b/src/utils/utils_posix_common.c
@@ -23,3 +23,5 @@ size_t util_get_page_size(void) {
     util_init_once(&Page_size_is_initialized, _util_get_page_size);
     return Page_size;
 }
+
+int utils_getpid(void) { return getpid(); }

--- a/src/utils/utils_windows_common.c
+++ b/src/utils/utils_windows_common.c
@@ -28,3 +28,4 @@ size_t util_get_page_size(void) {
     util_init_once(&Page_size_is_initialized, _util_get_page_size);
     return Page_size;
 }
+int utils_getpid(void) { return GetCurrentProcessId(); }


### PR DESCRIPTION
Add pid to the umf_ipc_data_t structure

### Description
Add pid to the umf_ipc_data_t structure. It is required to implement IPC cache for the `umfOpenIPCHandle` function on the consumer side.
Also moved `getpid` implementation from the `provider_os_memory` to the `utils_common`.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
