### PR TITLE
Add memspace "lowest latency"

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,11 @@ Can be retrieved using umfMemspaceHighestCapacityGet.
 Memspace backed by an aggregated list of NUMA nodes identified as highest bandwidth after selecting each available NUMA node as the initiator.
 Querying the bandwidth value requires HMAT support on the platform. Calling `umfMemspaceHighestBandwidthGet()` will return NULL if it's not supported.
 
+#### Lowest latency memspace
+
+Memspace backed by an aggregated list of NUMA nodes identified as lowest latency after selecting each available NUMA node as the initiator.
+Querying the latency value requires HMAT support on the platform. Calling `umfMemspaceLowestLatencyGet()` will return NULL if it's not supported.
+
 ### Proxy library
 
 UMF provides the UMF proxy library (`umf_proxy`) that makes it possible

--- a/include/umf/memspace.h
+++ b/include/umf/memspace.h
@@ -57,12 +57,14 @@ umf_memspace_handle_t umfMemspaceHostAllGet(void);
 umf_memspace_handle_t umfMemspaceHighestCapacityGet(void);
 
 /// \brief Retrieves predefined highest bandwidth memspace.
-/// \return highest bandwidth memspace handle on success or NULL on failure.
+/// \return highest bandwidth memspace handle on success or NULL on
+///         failure (no HMAT support).
 ///
 umf_memspace_handle_t umfMemspaceHighestBandwidthGet(void);
 
 /// \brief Retrieves predefined lowest latency memspace.
-/// \return lowest latency memspace handle on success or NULL on failure.
+/// \return lowest latency memspace handle on success or NULL on
+///         failure (no HMAT support).
 ///
 umf_memspace_handle_t umfMemspaceLowestLatencyGet(void);
 

--- a/include/umf/memspace.h
+++ b/include/umf/memspace.h
@@ -61,6 +61,11 @@ umf_memspace_handle_t umfMemspaceHighestCapacityGet(void);
 ///
 umf_memspace_handle_t umfMemspaceHighestBandwidthGet(void);
 
+/// \brief Retrieves predefined lowest latency memspace.
+/// \return lowest latency memspace handle on success or NULL on failure.
+///
+umf_memspace_handle_t umfMemspaceLowestLatencyGet(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,7 +85,8 @@ set(UMF_SOURCES_COMMON_LINUX_MACOSX
     memspaces/memspace_numa.c
     memspaces/memspace_host_all.c
     memspaces/memspace_highest_capacity.c
-    memspaces/memspace_highest_bandwidth.c)
+    memspaces/memspace_highest_bandwidth.c
+    memspaces/memspace_lowest_latency.c)
 
 set(UMF_SOURCES_LINUX ${UMF_SOURCES_LINUX} ${UMF_SOURCES_COMMON_LINUX_MACOSX}
                       provider/provider_os_memory_linux.c)

--- a/src/libumf.c
+++ b/src/libumf.c
@@ -34,6 +34,7 @@ void umfTearDown(void) {
         umfMemspaceHostAllDestroy();
         umfMemspaceHighestCapacityDestroy();
         umfMemspaceHighestBandwidthDestroy();
+        umfMemspaceLowestLatencyDestroy();
         umfDestroyTopology();
 #endif
         // make sure TRACKER is not used after being destroyed

--- a/src/libumf.map
+++ b/src/libumf.map
@@ -38,6 +38,7 @@ UMF_1.0 {
         umfMemspaceHighestBandwidthGet;
         umfMemspaceHighestCapacityGet;
         umfMemspaceHostAllGet;
+        umfMemspaceLowestLatencyGet;
         umfOpenIPCHandle;
         umfOsMemoryProviderOps;
         umfPoolAlignedMalloc;

--- a/src/memory_target.c
+++ b/src/memory_target.c
@@ -97,3 +97,15 @@ umfMemoryTargetGetBandwidth(umf_memory_target_handle_t srcMemoryTarget,
     return srcMemoryTarget->ops->get_bandwidth(
         srcMemoryTarget->priv, dstMemoryTarget->priv, bandwidth);
 }
+
+umf_result_t
+umfMemoryTargetGetLatency(umf_memory_target_handle_t srcMemoryTarget,
+                          umf_memory_target_handle_t dstMemoryTarget,
+                          size_t *latency) {
+    if (!srcMemoryTarget || !dstMemoryTarget || !latency) {
+        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
+    return srcMemoryTarget->ops->get_latency(srcMemoryTarget->priv,
+                                             dstMemoryTarget->priv, latency);
+}

--- a/src/memory_target.h
+++ b/src/memory_target.h
@@ -39,6 +39,10 @@ umf_result_t
 umfMemoryTargetGetBandwidth(umf_memory_target_handle_t srcMemoryTarget,
                             umf_memory_target_handle_t dstMemoryTarget,
                             size_t *bandwidth);
+umf_result_t
+umfMemoryTargetGetLatency(umf_memory_target_handle_t srcMemoryTarget,
+                          umf_memory_target_handle_t dstMemoryTarget,
+                          size_t *latency);
 
 #ifdef __cplusplus
 }

--- a/src/memory_target_ops.h
+++ b/src/memory_target_ops.h
@@ -41,6 +41,8 @@ typedef struct umf_memory_target_ops_t {
     umf_result_t (*get_capacity)(void *memoryTarget, size_t *capacity);
     umf_result_t (*get_bandwidth)(void *srcMemoryTarget, void *dstMemoryTarget,
                                   size_t *bandwidth);
+    umf_result_t (*get_latency)(void *srcMemoryTarget, void *dstMemoryTarget,
+                                size_t *latency);
 } umf_memory_target_ops_t;
 
 #ifdef __cplusplus

--- a/src/memspace_internal.h
+++ b/src/memspace_internal.h
@@ -60,6 +60,7 @@ void umfMemspaceDestroy(umf_memspace_handle_t hMemspace);
 void umfMemspaceHostAllDestroy(void);
 void umfMemspaceHighestCapacityDestroy(void);
 void umfMemspaceHighestBandwidthDestroy(void);
+void umfMemspaceLowestLatencyDestroy(void);
 
 #ifdef __cplusplus
 }

--- a/src/memspaces/memspace_lowest_latency.c
+++ b/src/memspaces/memspace_lowest_latency.c
@@ -1,0 +1,103 @@
+/*
+ *
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ */
+
+#include <assert.h>
+#include <ctype.h>
+#include <hwloc.h>
+#include <stdlib.h>
+
+#include "base_alloc_global.h"
+#include "memory_target_numa.h"
+#include "memspace_internal.h"
+#include "memspace_numa.h"
+#include "topology.h"
+#include "utils_common.h"
+#include "utils_concurrency.h"
+#include "utils_log.h"
+
+static umf_result_t getBestLatencyTarget(umf_memory_target_handle_t initiator,
+                                         umf_memory_target_handle_t *nodes,
+                                         size_t numNodes,
+                                         umf_memory_target_handle_t *target) {
+    size_t bestNodeIdx = 0;
+    size_t bestLatency = SIZE_MAX;
+    for (size_t nodeIdx = 0; nodeIdx < numNodes; nodeIdx++) {
+        size_t latency = SIZE_MAX;
+        umf_result_t ret =
+            umfMemoryTargetGetLatency(initiator, nodes[nodeIdx], &latency);
+        if (ret) {
+            return ret;
+        }
+
+        if (latency < bestLatency) {
+            bestNodeIdx = nodeIdx;
+            bestLatency = latency;
+        }
+    }
+
+    *target = nodes[bestNodeIdx];
+
+    return UMF_RESULT_SUCCESS;
+}
+
+static umf_result_t
+umfMemspaceLowestLatencyCreate(umf_memspace_handle_t *hMemspace) {
+    if (!hMemspace) {
+        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
+    umf_memspace_handle_t hostAllMemspace = umfMemspaceHostAllGet();
+    if (!hostAllMemspace) {
+        return UMF_RESULT_ERROR_UNKNOWN;
+    }
+
+    umf_memspace_handle_t lowLatencyMemspace = NULL;
+    umf_result_t ret = umfMemspaceFilter(hostAllMemspace, getBestLatencyTarget,
+                                         &lowLatencyMemspace);
+    if (ret != UMF_RESULT_SUCCESS) {
+        // HWLOC could possibly return an 'EINVAL' error, which in this context
+        // means that the HMAT is unavailable and we can't obtain the
+        // 'latency' value of any NUMA node.
+        return ret;
+    }
+
+    *hMemspace = lowLatencyMemspace;
+    return UMF_RESULT_SUCCESS;
+}
+
+static umf_memspace_handle_t UMF_MEMSPACE_LOWEST_LATENCY = NULL;
+static UTIL_ONCE_FLAG UMF_MEMSPACE_LOWEST_LATENCY_INITIALIZED =
+    UTIL_ONCE_FLAG_INIT;
+
+void umfMemspaceLowestLatencyDestroy(void) {
+    if (UMF_MEMSPACE_LOWEST_LATENCY) {
+        umfMemspaceDestroy(UMF_MEMSPACE_LOWEST_LATENCY);
+        UMF_MEMSPACE_LOWEST_LATENCY = NULL;
+    }
+}
+
+static void umfMemspaceLowestLatencyInit(void) {
+    umf_result_t ret =
+        umfMemspaceLowestLatencyCreate(&UMF_MEMSPACE_LOWEST_LATENCY);
+    if (ret != UMF_RESULT_SUCCESS) {
+        LOG_ERR("Creating the lowest latency memspace failed with a %u error\n",
+                ret);
+        assert(ret == UMF_RESULT_ERROR_NOT_SUPPORTED);
+    }
+
+#if defined(_WIN32) && !defined(UMF_SHARED_LIBRARY)
+    atexit(umfMemspaceLowestLatencyDestroy);
+#endif
+}
+
+umf_memspace_handle_t umfMemspaceLowestLatencyGet(void) {
+    util_init_once(&UMF_MEMSPACE_LOWEST_LATENCY_INITIALIZED,
+                   umfMemspaceLowestLatencyInit);
+    return UMF_MEMSPACE_LOWEST_LATENCY;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -162,22 +162,26 @@ if(LINUX) # OS-specific functions are implemented only for Linux now
     add_umf_test(
         NAME memspace_numa
         SRCS memspaces/memspace_numa.cpp
-        LIBS ${LIBNUMA_LIBRARIES})
+        LIBS ${LIBNUMA_LIBRARIES} ${LIBHWLOC_LIBRARIES})
     add_umf_test(
         NAME provider_os_memory_config
         SRCS provider_os_memory_config.cpp
-        LIBS ${UMF_UTILS_FOR_TEST} ${LIBNUMA_LIBRARIES})
+        LIBS ${UMF_UTILS_FOR_TEST} ${LIBNUMA_LIBRARIES} ${LIBHWLOC_LIBRARIES})
     add_umf_test(
         NAME memspace_host_all
         SRCS memspaces/memspace_host_all.cpp
-        LIBS ${UMF_UTILS_FOR_TEST} ${LIBNUMA_LIBRARIES})
+        LIBS ${UMF_UTILS_FOR_TEST} ${LIBNUMA_LIBRARIES} ${LIBHWLOC_LIBRARIES})
     add_umf_test(
         NAME memspace_highest_capacity
         SRCS memspaces/memspace_highest_capacity.cpp
-        LIBS ${UMF_UTILS_FOR_TEST} ${LIBNUMA_LIBRARIES})
+        LIBS ${UMF_UTILS_FOR_TEST} ${LIBNUMA_LIBRARIES} ${LIBHWLOC_LIBRARIES})
     add_umf_test(
         NAME memspace_highest_bandwidth
         SRCS memspaces/memspace_highest_bandwidth.cpp
+        LIBS ${UMF_UTILS_FOR_TEST} ${LIBNUMA_LIBRARIES} ${LIBHWLOC_LIBRARIES})
+    add_umf_test(
+        NAME memspace_lowest_latency
+        SRCS memspaces/memspace_lowest_latency.cpp
         LIBS ${UMF_UTILS_FOR_TEST} ${LIBNUMA_LIBRARIES} ${LIBHWLOC_LIBRARIES})
     add_umf_test(
         NAME mempolicy

--- a/test/memspaces/memspace_fixtures.hpp
+++ b/test/memspaces/memspace_fixtures.hpp
@@ -1,0 +1,221 @@
+// Copyright (C) 2024 Intel Corporation
+// Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef UMF_MEMSPACE_FIXTURES_HPP
+#define UMF_MEMSPACE_FIXTURES_HPP
+
+#include "base.hpp"
+#include "memspace_helpers.hpp"
+#include "test_helpers.h"
+
+#include <hwloc.h>
+#include <numa.h>
+#include <numaif.h>
+#include <thread>
+#include <umf/memspace.h>
+
+#define SIZE_4K (4096UL)
+#define SIZE_4M (SIZE_4K * 1024UL)
+
+// In HWLOC v2.3.0, the 'hwloc_location_type_e' enum is defined inside an
+// 'hwloc_location' struct. In newer versions, this enum is defined globally.
+// To prevent compile errors in C++ tests related this scope change
+// 'hwloc_location_type_e' has been aliased.
+using hwloc_location_type_alias = decltype(hwloc_location::type);
+
+struct numaNodesTest : ::umf_test::test {
+    void SetUp() override {
+        ::umf_test::test::SetUp();
+
+        if (numa_available() == -1 || numa_all_nodes_ptr == nullptr) {
+            GTEST_FAIL() << "Failed to initialize libnuma";
+        }
+
+        int maxNode = numa_max_node();
+        if (maxNode < 0) {
+            GTEST_FAIL() << "No available numa nodes";
+        }
+
+        for (int i = 0; i <= maxNode; i++) {
+            if (numa_bitmask_isbitset(numa_all_nodes_ptr, i)) {
+                nodeIds.emplace_back(i);
+                maxNodeId = i;
+            }
+        }
+    }
+
+    std::vector<unsigned> nodeIds;
+    unsigned long maxNodeId = 0;
+};
+
+using isQuerySupportedFunc = bool (*)(size_t);
+using memspaceGetFunc = umf_memspace_handle_t (*)();
+using memspaceGetParams = std::tuple<isQuerySupportedFunc, memspaceGetFunc>;
+
+struct memspaceGetTest : ::numaNodesTest,
+                         ::testing::WithParamInterface<memspaceGetParams> {
+    void SetUp() override {
+        ::numaNodesTest::SetUp();
+
+        auto [isQuerySupported, memspaceGet] = this->GetParam();
+
+        if (!isQuerySupported(nodeIds.front())) {
+            GTEST_SKIP();
+        }
+
+        hMemspace = memspaceGet();
+        ASSERT_NE(hMemspace, nullptr);
+    }
+
+    umf_memspace_handle_t hMemspace = nullptr;
+};
+
+struct memspaceProviderTest : ::memspaceGetTest {
+    void SetUp() override {
+        ::memspaceGetTest::SetUp();
+
+        if (::memspaceGetTest::IsSkipped()) {
+            GTEST_SKIP();
+        }
+
+        umf_result_t ret =
+            umfMemoryProviderCreateFromMemspace(hMemspace, nullptr, &hProvider);
+        ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+        ASSERT_NE(hProvider, nullptr);
+    }
+
+    void TearDown() override {
+        ::memspaceGetTest::TearDown();
+
+        if (hProvider) {
+            umfMemoryProviderDestroy(hProvider);
+        }
+    }
+
+    umf_memory_provider_handle_t hProvider = nullptr;
+};
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(memspaceGetTest);
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(memspaceProviderTest);
+
+TEST_P(memspaceGetTest, providerFromMemspace) {
+    umf_memory_provider_handle_t hProvider = nullptr;
+    umf_result_t ret =
+        umfMemoryProviderCreateFromMemspace(hMemspace, nullptr, &hProvider);
+    UT_ASSERTeq(ret, UMF_RESULT_SUCCESS);
+    UT_ASSERTne(hProvider, nullptr);
+
+    umfMemoryProviderDestroy(hProvider);
+}
+
+TEST_P(memspaceProviderTest, allocFree) {
+    void *ptr = nullptr;
+    size_t size = SIZE_4K;
+    size_t alignment = 0;
+
+    umf_result_t ret = umfMemoryProviderAlloc(hProvider, size, alignment, &ptr);
+    UT_ASSERTeq(ret, UMF_RESULT_SUCCESS);
+    UT_ASSERTne(ptr, nullptr);
+
+    // Access the allocation, so that all the pages associated with it are
+    // allocated on some NUMA node.
+    memset(ptr, 0xFF, size);
+
+    ret = umfMemoryProviderFree(hProvider, ptr, size);
+    UT_ASSERTeq(ret, UMF_RESULT_SUCCESS);
+}
+
+static std::vector<int> getAllCpus() {
+    std::vector<int> allCpus;
+    for (int i = 0; i < numa_num_possible_cpus(); ++i) {
+        if (numa_bitmask_isbitset(numa_all_cpus_ptr, i)) {
+            allCpus.push_back(i);
+        }
+    }
+
+    return allCpus;
+}
+
+#define MAX_NODES 512
+
+TEST_P(memspaceProviderTest, allocLocalMt) {
+    auto pinAllocValidate = [&](umf_memory_provider_handle_t hProvider,
+                                int cpu) {
+        hwloc_topology_t topology = NULL;
+        UT_ASSERTeq(hwloc_topology_init(&topology), 0);
+        UT_ASSERTeq(hwloc_topology_load(topology), 0);
+
+        // Pin current thread to the provided CPU.
+        hwloc_cpuset_t pinCpuset = hwloc_bitmap_alloc();
+        UT_ASSERTeq(hwloc_bitmap_set(pinCpuset, cpu), 0);
+        UT_ASSERTeq(
+            hwloc_set_cpubind(topology, pinCpuset, HWLOC_CPUBIND_THREAD), 0);
+
+        // Confirm that the thread is pinned to the provided CPU.
+        hwloc_cpuset_t curCpuset = hwloc_bitmap_alloc();
+        UT_ASSERTeq(
+            hwloc_get_cpubind(topology, curCpuset, HWLOC_CPUBIND_THREAD), 0);
+        UT_ASSERT(hwloc_bitmap_isequal(curCpuset, pinCpuset));
+        hwloc_bitmap_free(curCpuset);
+        hwloc_bitmap_free(pinCpuset);
+
+        // Allocate some memory.
+        const size_t size = SIZE_4K;
+        const size_t alignment = 0;
+        void *ptr = nullptr;
+
+        umf_result_t ret =
+            umfMemoryProviderAlloc(hProvider, size, alignment, &ptr);
+        UT_ASSERTeq(ret, UMF_RESULT_SUCCESS);
+        UT_ASSERTne(ptr, nullptr);
+
+        // Access the allocation, so that all the pages associated with it are
+        // allocated on some NUMA node.
+        memset(ptr, 0xFF, size);
+
+        // Get the NUMA node responsible for this allocation.
+        int mode = -1;
+        std::vector<size_t> boundNodeIds;
+        size_t allocNodeId = SIZE_MAX;
+        getAllocationPolicy(ptr, maxNodeId, mode, boundNodeIds, allocNodeId);
+
+        // Get the CPUs associated with the specified NUMA node.
+        hwloc_obj_t allocNodeObj =
+            hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, allocNodeId);
+
+        unsigned nNodes = MAX_NODES;
+        std::vector<hwloc_obj_t> localNodes(MAX_NODES);
+        hwloc_location loc;
+        loc.location.object = allocNodeObj,
+        loc.type = hwloc_location_type_alias::HWLOC_LOCATION_TYPE_OBJECT;
+        UT_ASSERTeq(hwloc_get_local_numanode_objs(topology, &loc, &nNodes,
+                                                  localNodes.data(), 0),
+                    0);
+        UT_ASSERT(nNodes <= MAX_NODES);
+
+        // Confirm that the allocation from this thread was made to a local
+        // NUMA node.
+        UT_ASSERT(std::any_of(localNodes.begin(), localNodes.end(),
+                              [&allocNodeObj](hwloc_obj_t node) {
+                                  return node == allocNodeObj;
+                              }));
+
+        ret = umfMemoryProviderFree(hProvider, ptr, size);
+        UT_ASSERTeq(ret, UMF_RESULT_SUCCESS);
+
+        hwloc_topology_destroy(topology);
+    };
+
+    const auto cpus = getAllCpus();
+    std::vector<std::thread> threads;
+    for (auto cpu : cpus) {
+        threads.emplace_back(pinAllocValidate, hProvider, cpu);
+    }
+
+    for (auto &thread : threads) {
+        thread.join();
+    }
+}
+
+#endif /* UMF_MEMSPACE_FIXTURES_HPP */

--- a/test/memspaces/memspace_helpers.hpp
+++ b/test/memspaces/memspace_helpers.hpp
@@ -17,31 +17,6 @@
 #define SIZE_4K (4096UL)
 #define SIZE_4M (SIZE_4K * 1024UL)
 
-struct numaNodesTest : ::umf_test::test {
-    void SetUp() override {
-        ::umf_test::test::SetUp();
-
-        if (numa_available() == -1 || numa_all_nodes_ptr == nullptr) {
-            GTEST_FAIL() << "Failed to initialize libnuma";
-        }
-
-        int maxNode = numa_max_node();
-        if (maxNode < 0) {
-            GTEST_FAIL() << "No available numa nodes";
-        }
-
-        for (int i = 0; i <= maxNode; i++) {
-            if (numa_bitmask_isbitset(numa_all_nodes_ptr, i)) {
-                nodeIds.emplace_back(i);
-                maxNodeId = i;
-            }
-        }
-    }
-
-    std::vector<unsigned> nodeIds;
-    unsigned long maxNodeId = 0;
-};
-
 ///
 /// @brief Retrieves the memory policy information for \p ptr.
 /// @param ptr allocation pointer.

--- a/test/memspaces/memspace_highest_capacity.cpp
+++ b/test/memspaces/memspace_highest_capacity.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "memory_target_numa.h"
+#include "memspace_fixtures.hpp"
 #include "memspace_helpers.hpp"
 #include "memspace_internal.h"
 #include "numa_helpers.h"

--- a/test/memspaces/memspace_host_all.cpp
+++ b/test/memspaces/memspace_host_all.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "memory_target_numa.h"
+#include "memspace_fixtures.hpp"
 #include "memspace_helpers.hpp"
 #include "memspace_internal.h"
 #include "numa_helpers.h"

--- a/test/memspaces/memspace_lowest_latency.cpp
+++ b/test/memspaces/memspace_lowest_latency.cpp
@@ -10,7 +10,7 @@
 #include <hwloc.h>
 #include <umf/memspace.h>
 
-static bool canQueryBandwidth(size_t nodeId) {
+static bool canQueryLatency(size_t nodeId) {
     hwloc_topology_t topology = nullptr;
     int ret = hwloc_topology_init(&topology);
     UT_ASSERTeq(ret, 0);
@@ -27,8 +27,8 @@ static bool canQueryBandwidth(size_t nodeId) {
     initiator.type = hwloc_location_type_alias::HWLOC_LOCATION_TYPE_CPUSET;
 
     hwloc_uint64_t value = 0;
-    ret = hwloc_memattr_get_value(topology, HWLOC_MEMATTR_ID_BANDWIDTH,
-                                  numaNode, &initiator, 0, &value);
+    ret = hwloc_memattr_get_value(topology, HWLOC_MEMATTR_ID_LATENCY, numaNode,
+                                  &initiator, 0, &value);
 
     hwloc_topology_destroy(topology);
     return (ret == 0);
@@ -36,11 +36,9 @@ static bool canQueryBandwidth(size_t nodeId) {
 
 INSTANTIATE_TEST_SUITE_P(memspaceLowestLatencyTest, memspaceGetTest,
                          ::testing::Values(memspaceGetParams{
-                             canQueryBandwidth,
-                             umfMemspaceHighestBandwidthGet}));
+                             canQueryLatency, umfMemspaceLowestLatencyGet}));
 
 INSTANTIATE_TEST_SUITE_P(memspaceLowestLatencyProviderTest,
                          memspaceProviderTest,
                          ::testing::Values(memspaceGetParams{
-                             canQueryBandwidth,
-                             umfMemspaceHighestBandwidthGet}));
+                             canQueryLatency, umfMemspaceLowestLatencyGet}));

--- a/test/memspaces/memspace_numa.cpp
+++ b/test/memspaces/memspace_numa.cpp
@@ -4,6 +4,7 @@
 
 #include "memspaces/memspace_numa.h"
 #include "base.hpp"
+#include "memspace_fixtures.hpp"
 #include "memspace_helpers.hpp"
 #include "memspace_internal.h"
 

--- a/test/test_valgrind.sh
+++ b/test/test_valgrind.sh
@@ -103,6 +103,9 @@ for test in $(ls -1 umf_test-*); do
 	umf_test-memspace_highest_bandwidth)
 		FILTER='--gtest_filter="-*allocLocalMt*"'
 		;;
+	umf_test-memspace_lowest_latency)
+		FILTER='--gtest_filter="-*allocLocalMt*"'
+		;;
 	esac
 
 	[ "$FILTER" != "" ] && echo -n "($FILTER) "


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->
This memspace is analogous to the 'highest bandwidth' memspace in its composition, but it focuses on the NUMA nodes with best latency.
### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->
Contains changes from https://github.com/oneapi-src/unified-memory-framework/pull/408.
### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [x] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [x] New tests added, especially if they will fail without my changes
- [x] Extended the README/documentation
- [x] All newly added source files have a license
- [x] All newly added source files are referenced in CMake files
- [x] Logger (with debug/info/... messages) is used
