### PR TITLE
Remove unnecessary semicolons

### DIFF
--- a/include/umf/proxy_lib_new_delete.h
+++ b/include/umf/proxy_lib_new_delete.h
@@ -68,8 +68,8 @@ static inline void *internal_aligned_alloc(size_t alignment, size_t size) {
 #define decl_new_nothrow(n) [[nodiscard]]
 #endif // defined(_MSC_VER) && defined(_Ret_notnull_) && defined(_Post_writable_byte_size_)
 
-void operator delete(void *p) noexcept { free(p); };
-void operator delete[](void *p) noexcept { free(p); };
+void operator delete(void *p) noexcept { free(p); }
+void operator delete[](void *p) noexcept { free(p); }
 
 void operator delete(void *p, const std::nothrow_t &) noexcept { free(p); }
 void operator delete[](void *p, const std::nothrow_t &) noexcept { free(p); }
@@ -96,11 +96,11 @@ decl_new_nothrow(n) void *operator new[](std::size_t n,
 void operator delete(void *p, std::size_t n) noexcept {
     (void)(n);
     free(p);
-};
+}
 void operator delete[](void *p, std::size_t n) noexcept {
     (void)(n);
     free(p);
-};
+}
 #endif // (__cplusplus >= 201402L || _MSC_VER >= 1916)
 
 #if (__cplusplus > 201402L || defined(__cpp_aligned_new))
@@ -116,12 +116,12 @@ void operator delete(void *p, std::size_t n, std::align_val_t al) noexcept {
     (void)(n);
     (void)(al);
     free(p);
-};
+}
 void operator delete[](void *p, std::size_t n, std::align_val_t al) noexcept {
     (void)(n);
     (void)(al);
     free(p);
-};
+}
 void operator delete(void *p, std::align_val_t al,
                      const std::nothrow_t &) noexcept {
     (void)(al);


### PR DESCRIPTION

### Description
Remove unnecessary semicolons in the `proxy_lib_new_delete.h` file.
The compiler reported these as errors when I tried to build UMF on Ubuntu 20.04. I have no ideas why it was not catch by our CI.

### Checklist

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [ ] CI workflows execute properly
