### PR TITLE
Enable gcov

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ option(USE_UBSAN "Enable UndefinedBehaviorSanitizer checks" OFF)
 option(USE_TSAN "Enable ThreadSanitizer checks" OFF)
 option(USE_MSAN "Enable MemorySanitizer checks" OFF)
 option(USE_VALGRIND "Enable Valgrind instrumentation" OFF)
+option(USE_GCOV "Enable gcov support" OFF)
 
 # set UMF_PROXY_LIB_BASED_ON_POOL to one of: SCALABLE or JEMALLOC
 set(KNOWN_PROXY_LIB_POOLS SCALABLE JEMALLOC)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@
     - [Extending public API](#extending-public-api)
     - [License](#license)
     - [Adding new dependency](#adding-new-dependency)
+- [Code coverage](#code-coverage)
 
 Below you'll find instructions on how to contribute to UMF, either with code changes
 or issues. All contributions are most welcome!
@@ -201,4 +202,21 @@ New dependency: dependency_name
 
 license: SPDX license tag
 origin: https://dependency_origin.com
+```
+
+## Code coverage
+
+After adding a new functionality add tests and check coverage before and after the change.
+To do this, enable coverage instrumentation by turning on the USE_GCOV flag in CMake.
+Coverage instrumentation feature is supported only by GCC and Clang.
+An example flow might look like the following:
+
+```bash
+$ cmake -B build -DUSE_GCOV=1 -DCMAKE_BUILD_TYPE=Debug
+$ cmake --build build -j
+$ cd build
+$ ctest
+$ apt install lcov
+$ lcov --capture --directory . --output-file coverage.info
+$ genhtml -o html_report coverage.info
 ```

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ List of options provided by CMake:
 | USE_TSAN | Enable ThreadSanitizer checks | ON/OFF | OFF |
 | USE_MSAN | Enable MemorySanitizer checks | ON/OFF | OFF |
 | USE_VALGRIND | Enable Valgrind instrumentation | ON/OFF | OFF |
+| USE_GCOV | Enable gcov support (Linux only) | ON/OFF | OFF |
 
 ## Architecture: memory pools and providers
 

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -104,6 +104,12 @@ function(add_umf_target_compile_options name)
                 ${name} PRIVATE -Werror -fno-omit-frame-pointer
                                 -fstack-protector-strong)
         endif()
+        if(USE_GCOV)
+            if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+                message(FATAL_ERROR "To use gcov, the build type must be Debug")
+            endif()
+            target_compile_options(${name} PRIVATE --coverage)
+        endif()
     elseif(MSVC)
         target_compile_options(
             ${name}
@@ -121,6 +127,13 @@ function(add_umf_target_link_options name)
     if(NOT MSVC)
         if(NOT APPLE)
             target_link_options(${name} PRIVATE "LINKER:-z,relro,-z,now")
+            if(USE_GCOV)
+                if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+                    message(
+                        FATAL_ERROR "To use gcov, the build type must be Debug")
+                endif()
+                target_link_options(${name} PRIVATE --coverage)
+            endif()
         endif()
     elseif(MSVC)
         target_link_options(


### PR DESCRIPTION
### Description
This pull request introduces support for gcov, a test coverage program that developers can use to assess the effectiveness of their test suites. The changes include:

- An additional CMake option USE_GCOV to enable gcov support, which is turned off by default.
- Modifications to CMakeLists.txt and cmake/helpers.cmake to ensure that the correct compile and link options are set when USE_GCOV is enabled. It also includes a check to ensure that gcov is only used with Debug builds.
- Updates to CONTRIBUTING.md to guide contributors on how to use gcov to check code coverage for new functionality, including a sample workflow for generating a coverage report.
- Documentation in README.md has been updated to include the new USE_GCOV option in the list of CMake options.

With these changes, contributors can now enable gcov support in their debug builds to generate coverage reports, helping to maintain and improve the quality of the test suite.
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [x] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [x] Added/extended example(s) to cover this functionality
- [x] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
