### PR TITLE
Use utils_getpid() and utils_gettid() in util_log_internal()

### DIFF
--- a/src/utils/utils_common.h
+++ b/src/utils/utils_common.h
@@ -74,6 +74,9 @@ void util_align_ptr_size(void **ptr, size_t *size, size_t alignment);
 // get the current process ID
 int utils_getpid(void);
 
+// get the current thread ID
+int utils_gettid(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/utils/utils_log.c
+++ b/src/utils/utils_log.c
@@ -72,18 +72,8 @@ static void util_log_internal(util_log_level_t level, int perror,
         return;
     }
 
-#if defined(_WIN32)
-    DWORD pid = GetCurrentProcessId();
-    DWORD tid = GetCurrentThreadId();
-#elif defined(__APPLE__)
-    pid_t pid = getpid();
-    uint64_t tid64;
-    pthread_threadid_np(NULL, &tid64);
-    pid_t tid = (pid_t)tid64;
-#else
-    pid_t pid = getpid();
-    pid_t tid = gettid();
-#endif
+    int pid = utils_getpid();
+    int tid = utils_gettid();
 
     char buffer[LOG_MAX];
     char *b_pos = buffer;

--- a/src/utils/utils_posix_common.c
+++ b/src/utils/utils_posix_common.c
@@ -25,3 +25,16 @@ size_t util_get_page_size(void) {
 }
 
 int utils_getpid(void) { return getpid(); }
+
+int utils_gettid(void) {
+#ifdef __APPLE__
+    uint64_t tid64;
+    pthread_threadid_np(NULL, &tid64);
+    return (int)tid64;
+#else
+    // Some older OSes does not have
+    // the gettid() function implemented,
+    // so let's use the syscall instead:
+    return syscall(SYS_gettid);
+#endif
+}

--- a/src/utils/utils_windows_common.c
+++ b/src/utils/utils_windows_common.c
@@ -10,6 +10,7 @@
 #include <windows.h>
 
 #include <processenv.h>
+#include <processthreadsapi.h>
 
 #include "utils_concurrency.h"
 
@@ -28,4 +29,7 @@ size_t util_get_page_size(void) {
     util_init_once(&Page_size_is_initialized, _util_get_page_size);
     return Page_size;
 }
+
 int utils_getpid(void) { return GetCurrentProcessId(); }
+
+int utils_gettid(void) { return GetCurrentThreadId(); }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -93,14 +93,18 @@ add_umf_test(NAME memoryProvider SRCS memoryProviderAPI.cpp)
 if(UMF_BUILD_SHARED_LIBRARY)
     # if build as shared library, utils symbols won't be visible in tests
     set(UMF_UTILS_FOR_TEST umf_utils)
+    if(LINUX OR MACOSX)
+        set(UMF_UTILS_SOURCES
+            ../src/utils/utils_common.c ../src/utils/utils_posix_common.c
+            ../src/utils/utils_posix_concurrency.c)
+    elseif(WINDOWS)
+        set(UMF_UTILS_SOURCES
+            ../src/utils/utils_common.c ../src/utils/utils_windows_common.c
+            ../src/utils/utils_windows_concurrency.c)
+    endif()
 endif()
 
-if(UMF_BUILD_SHARED_LIBRARY)
-    add_umf_test(NAME logger SRCS utils/utils_log.cpp
-                                  ../src/utils/utils_common.c)
-else()
-    add_umf_test(NAME logger SRCS utils/utils_log.cpp)
-endif()
+add_umf_test(NAME logger SRCS utils/utils_log.cpp ${UMF_UTILS_SOURCES})
 
 add_umf_test(
     NAME utils_common


### PR DESCRIPTION
### Description

Use `syscall(SYS_gettid)` instead of `gettid()`,
because `gettid()` can be undefined in older OSes.

`gettid()` is undefined in CI OSes of OpenMP.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
