### PR TITLE
Do not run umfPoolDestroy() nor umfMemoryProviderDestroy() if umf has already been destroyed

### DIFF
--- a/src/base_alloc/base_alloc_global.c
+++ b/src/base_alloc/base_alloc_global.c
@@ -47,6 +47,8 @@ void umf_ba_destroy_global(void) {
     }
 }
 
+int umf_ba_is_destroyed(void) { return (BASE_ALLOC.ac[0] == NULL); }
+
 static void umf_ba_create_global(void) {
     for (int i = 0; i < NUM_ALLOCATION_CLASSES; i++) {
         // allocation classes need to be powers of 2

--- a/src/base_alloc/base_alloc_global.h
+++ b/src/base_alloc/base_alloc_global.h
@@ -19,6 +19,7 @@ void umf_ba_global_free(void *ptr);
 void umf_ba_destroy_global(void);
 size_t umf_ba_global_malloc_usable_size(void *ptr);
 void *umf_ba_global_aligned_alloc(size_t size, size_t alignment);
+int umf_ba_is_destroyed(void);
 
 #ifdef __cplusplus
 }

--- a/src/libumf.h
+++ b/src/libumf.h
@@ -17,6 +17,8 @@ extern "C" {
 // initializes runtime state needed by the library (needed mostly for static libaries on windows)
 void libumfInit(void);
 
+int umf_is_destroyed(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libumf_linux.c
+++ b/src/libumf_linux.c
@@ -33,6 +33,8 @@ void __attribute__((destructor)) umfDestroy(void) {
     umfDestroyTopology();
 }
 
+int umf_is_destroyed(void) { return (TRACKER == NULL); }
+
 void libumfInit(void) {
     // do nothing, additional initialization not needed
 }

--- a/src/libumf_windows.c
+++ b/src/libumf_windows.c
@@ -23,8 +23,11 @@ static void umfCreate(void) {
 
 static void umfDestroy(void) {
     umfMemoryTrackerDestroy(TRACKER);
+    TRACKER = NULL;
     umf_ba_destroy_global();
 }
+
+int umf_is_destroyed(void) { return (TRACKER == NULL); }
 
 #if defined(UMF_SHARED_LIBRARY)
 BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {

--- a/src/memory_pool.c
+++ b/src/memory_pool.c
@@ -71,6 +71,10 @@ err_provider_create:
 }
 
 void umfPoolDestroy(umf_memory_pool_handle_t hPool) {
+    if (umf_is_destroyed() || umf_ba_is_destroyed()) {
+        return;
+    }
+
     hPool->ops.finalize(hPool->pool_priv);
     if (hPool->flags & UMF_POOL_CREATE_FLAG_OWN_PROVIDER) {
         // Destroy associated memory provider.

--- a/src/memory_provider.c
+++ b/src/memory_provider.c
@@ -195,6 +195,10 @@ umf_result_t umfMemoryProviderCreate(const umf_memory_provider_ops_t *ops,
 }
 
 void umfMemoryProviderDestroy(umf_memory_provider_handle_t hProvider) {
+    if (umf_is_destroyed() || umf_ba_is_destroyed()) {
+        return;
+    }
+
     hProvider->ops.finalize(hProvider->provider_priv);
     umf_ba_global_free(hProvider);
 }


### PR DESCRIPTION
### Description

Add `umf_ba_is_destroyed()` and `umf_is_destroyed()`.

Do not run `umfPoolDestroy()` nor `umfMemoryProviderDestroy()` if umf has already been destroyed.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
