### PR TITLE
cleanup include ze_api.h

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -52,9 +52,8 @@ if(UMF_BUILD_GPU_EXAMPLES
         LIBS disjoint_pool ze_loader umf)
 
     target_include_directories(
-        ${EXAMPLE_NAME}
-        PRIVATE ${LEVEL_ZERO_INCLUDE_DIRS} ${UMF_CMAKE_SOURCE_DIR}/src/utils
-                ${UMF_CMAKE_SOURCE_DIR}/include)
+        ${EXAMPLE_NAME} PRIVATE ${UMF_CMAKE_SOURCE_DIR}/src/utils
+                                ${UMF_CMAKE_SOURCE_DIR}/include)
 
     target_link_directories(${EXAMPLE_NAME} PRIVATE ${LIBHWLOC_LIBRARY_DIRS})
 

--- a/examples/basic/utils_level_zero.h
+++ b/examples/basic/utils_level_zero.h
@@ -10,6 +10,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+// To use the Level Zero API, the Level Zero SDK has to be installed
+// on the system
 #ifdef _WIN32
 #include <ze_api.h>
 #else

--- a/src/provider/provider_level_zero.c
+++ b/src/provider/provider_level_zero.c
@@ -10,9 +10,6 @@
 #include <stddef.h>
 #include <string.h>
 
-// Level Zero API
-#include <ze_api.h>
-
 #include <umf.h>
 #include <umf/memory_provider_ops.h>
 #include <umf/providers/provider_level_zero.h>
@@ -24,6 +21,7 @@
 #include "utils_load_library.h"
 #include "utils_log.h"
 #include "utils_sanitizers.h"
+#include "ze_api.h"
 
 typedef struct ze_memory_provider_t {
     ze_context_handle_t context;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -185,6 +185,8 @@ if(UMF_BUILD_GPU_TESTS AND UMF_BUILD_LEVEL_ZERO_PROVIDER)
         NAME provider_level_zero
         SRCS providers/provider_level_zero.cpp
         LIBS ${UMF_UTILS_FOR_TEST} ze_loader)
+    target_include_directories(umf_test-provider_level_zero
+                               PRIVATE ${LEVEL_ZERO_INCLUDE_DIRS})
 
     add_umf_test(
         NAME provider_level_zero_dlopen
@@ -192,6 +194,8 @@ if(UMF_BUILD_GPU_TESTS AND UMF_BUILD_LEVEL_ZERO_PROVIDER)
         LIBS ${UMF_UTILS_FOR_TEST})
     target_compile_definitions(umf_test-provider_level_zero_dlopen
                                PUBLIC USE_DLOPEN=1)
+    target_include_directories(umf_test-provider_level_zero_dlopen
+                               PRIVATE ${LEVEL_ZERO_INCLUDE_DIRS})
 endif()
 
 if(UMF_BUILD_SHARED_LIBRARY)

--- a/test/providers/provider_level_zero.cpp
+++ b/test/providers/provider_level_zero.cpp
@@ -5,16 +5,16 @@
 #ifdef _WIN32
 //workaround for std::numeric_limits on windows
 #define NOMINMAX
-#include <ze_api.h>
-#else
-#include <level_zero/ze_api.h>
 #endif
-#include "ipcFixtures.hpp"
-#include "pool.hpp"
-#include "umf/providers/provider_level_zero.h"
-#include "utils_load_library.h"
 
 #include <mutex>
+
+#include <umf/providers/provider_level_zero.h>
+
+#include "ipcFixtures.hpp"
+#include "pool.hpp"
+#include "utils_load_library.h"
+#include "ze_api.h"
 
 using umf_test::test;
 using namespace umf_test;


### PR DESCRIPTION

### Description

ze_api.h should be always:
* included from the deps (build/_deps/level-zero-loader-***) for all internal code including tests
* included from the system paths in the examples

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
