### PR TITLE
Add init/teardown functions: umfInit() and umfTearDown()

### DIFF
--- a/include/umf.h
+++ b/include/umf.h
@@ -15,4 +15,17 @@
 #include <umf/mempolicy.h>
 #include <umf/memspace.h>
 
+///
+/// @brief  Increment the usage reference counter and initialize the global state of libumf
+///         if the usage reference counter was equal to 0.
+///         It must be called just after dlopen() and it is not required in other scenarios.
+/// @return 0 on success or -1 on failure.
+int umfInit(void);
+
+///
+/// @brief Decrement the usage reference counter and destroy the global state of libumf
+///        if the usage reference counter is equal to 0.
+///        It must be called just before dlclose() and it is not required in other scenarios.
+void umfTearDown(void);
+
 #endif /* UMF_UNIFIED_MEMORY_FRAMEWORK_H */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,7 @@ set(BA_SOURCES
 
 set(UMF_SOURCES
     ${BA_SOURCES}
+    libumf.c
     ipc.c
     memory_pool.c
     memory_provider.c

--- a/src/base_alloc/base_alloc_global.c
+++ b/src/base_alloc/base_alloc_global.c
@@ -10,6 +10,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "base_alloc.h"
 #include "base_alloc_global.h"
@@ -45,6 +46,10 @@ void umf_ba_destroy_global(void) {
             BASE_ALLOC.ac[i] = NULL;
         }
     }
+
+    // portable version of "ba_is_initialized = UTIL_ONCE_FLAG_INIT;"
+    static UTIL_ONCE_FLAG is_initialized = UTIL_ONCE_FLAG_INIT;
+    memcpy(&ba_is_initialized, &is_initialized, sizeof(ba_is_initialized));
 }
 
 static void umf_ba_create_global(void) {

--- a/src/base_alloc/base_alloc_global.c
+++ b/src/base_alloc/base_alloc_global.c
@@ -67,10 +67,6 @@ static void umf_ba_create_global(void) {
 
     size_t smallestSize = BASE_ALLOC.ac_sizes[0];
     BASE_ALLOC.smallest_ac_size_log2 = log2Utils(smallestSize);
-
-#if defined(_WIN32) && !defined(UMF_SHARED_LIBRARY)
-    atexit(umf_ba_destroy_global);
-#endif
 }
 
 // returns index of the allocation class for a given size

--- a/src/base_alloc/base_alloc_linux.c
+++ b/src/base_alloc/base_alloc_linux.c
@@ -18,14 +18,6 @@
 static UTIL_ONCE_FLAG Page_size_is_initialized = UTIL_ONCE_FLAG_INIT;
 static size_t Page_size;
 
-// The highest possible priority (101) is used, because the constructor should be called
-// as the first one and the destructor as the last one in order to avoid use-after-free.
-void __attribute__((constructor(101))) umf_ba_constructor(void) {}
-
-void __attribute__((destructor(101))) umf_ba_destructor(void) {
-    umf_ba_destroy_global();
-}
-
 void *ba_os_alloc(size_t size) {
     return mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS,
                 -1, 0);

--- a/src/libumf.c
+++ b/src/libumf.c
@@ -1,0 +1,46 @@
+/*
+ *
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ */
+
+#include <stddef.h>
+
+#include "base_alloc_global.h"
+#include "memspace_internal.h"
+#include "provider_tracking.h"
+#include "topology.h"
+#include "utils_log.h"
+
+umf_memory_tracker_handle_t TRACKER = NULL;
+
+static unsigned long long umfRefCount = 0;
+
+int umfInit(void) {
+    if (util_fetch_and_add64(&umfRefCount, 1) == 0) {
+        util_log_init();
+        TRACKER = umfMemoryTrackerCreate();
+    }
+
+    return (TRACKER) ? 0 : -1;
+}
+
+void umfTearDown(void) {
+    if (util_fetch_and_add64(&umfRefCount, -1) == 1) {
+#ifndef _WIN32
+        umfMemspaceHostAllDestroy();
+        umfMemspaceHighestCapacityDestroy();
+        umfMemspaceHighestBandwidthDestroy();
+        umfDestroyTopology();
+#endif
+        // make sure TRACKER is not used after being destroyed
+        umf_memory_tracker_handle_t t = TRACKER;
+        TRACKER = NULL;
+        umfMemoryTrackerDestroy(t);
+
+        umf_ba_destroy_global();
+    }
+}

--- a/src/libumf.def.in
+++ b/src/libumf.def.in
@@ -10,6 +10,8 @@ VERSION 1.0
 
 EXPORTS
     DllMain
+    umfInit
+    umfTearDown
     umfCloseIPCHandle
     umfFree
     umfGetIPCHandle

--- a/src/libumf.map
+++ b/src/libumf.map
@@ -4,6 +4,8 @@
 
 UMF_1.0 {
     global:
+        umfInit;
+        umfTearDown;
         umfCloseIPCHandle;
         umfFree;
         umfGetIPCHandle;

--- a/src/libumf_linux.c
+++ b/src/libumf_linux.c
@@ -7,31 +7,11 @@
  *
  */
 
-#include <stddef.h>
+#include <umf.h>
 
-#include "base_alloc_global.h"
-#include "memspace_internal.h"
-#include "provider_tracking.h"
-#include "topology.h"
-#include "utils_log.h"
+void __attribute__((constructor)) umfCreate(void) { (void)umfInit(); }
 
-umf_memory_tracker_handle_t TRACKER = NULL;
-
-void __attribute__((constructor)) umfCreate(void) {
-    util_log_init();
-    TRACKER = umfMemoryTrackerCreate();
-}
-
-void __attribute__((destructor)) umfDestroy(void) {
-    umf_memory_tracker_handle_t t = TRACKER;
-    // make sure TRACKER is not used after being destroyed
-    TRACKER = NULL;
-    umfMemoryTrackerDestroy(t);
-    umfMemspaceHostAllDestroy();
-    umfMemspaceHighestCapacityDestroy();
-    umfMemspaceHighestBandwidthDestroy();
-    umfDestroyTopology();
-}
+void __attribute__((destructor)) umfDestroy(void) { umfTearDown(); }
 
 void libumfInit(void) {
     // do nothing, additional initialization not needed

--- a/src/memspaces/memspace_highest_bandwidth.c
+++ b/src/memspaces/memspace_highest_bandwidth.c
@@ -78,6 +78,11 @@ void umfMemspaceHighestBandwidthDestroy(void) {
     if (UMF_MEMSPACE_HIGHEST_BANDWIDTH) {
         umfMemspaceDestroy(UMF_MEMSPACE_HIGHEST_BANDWIDTH);
         UMF_MEMSPACE_HIGHEST_BANDWIDTH = NULL;
+
+        // portable version of "UMF_MEMSPACE_HBW_INITIALIZED = UTIL_ONCE_FLAG_INIT;"
+        static UTIL_ONCE_FLAG is_initialized = UTIL_ONCE_FLAG_INIT;
+        memcpy(&UMF_MEMSPACE_HBW_INITIALIZED, &is_initialized,
+               sizeof(UMF_MEMSPACE_HBW_INITIALIZED));
     }
 }
 

--- a/src/memspaces/memspace_highest_bandwidth.c
+++ b/src/memspaces/memspace_highest_bandwidth.c
@@ -95,10 +95,6 @@ static void umfMemspaceHighestBandwidthInit(void) {
             ret);
         assert(ret == UMF_RESULT_ERROR_NOT_SUPPORTED);
     }
-
-#if defined(_WIN32) && !defined(UMF_SHARED_LIBRARY)
-    atexit(umfMemspaceHighestBandwidthDestroy);
-#endif
 }
 
 umf_memspace_handle_t umfMemspaceHighestBandwidthGet(void) {

--- a/src/memspaces/memspace_highest_capacity.c
+++ b/src/memspaces/memspace_highest_capacity.c
@@ -54,6 +54,11 @@ void umfMemspaceHighestCapacityDestroy(void) {
     if (UMF_MEMSPACE_HIGHEST_CAPACITY) {
         umfMemspaceDestroy(UMF_MEMSPACE_HIGHEST_CAPACITY);
         UMF_MEMSPACE_HIGHEST_CAPACITY = NULL;
+
+        // portable version of "UMF_MEMSPACE_HIGHEST_CAPACITY_INITIALIZED = UTIL_ONCE_FLAG_INIT;"
+        static UTIL_ONCE_FLAG is_initialized = UTIL_ONCE_FLAG_INIT;
+        memcpy(&UMF_MEMSPACE_HIGHEST_CAPACITY_INITIALIZED, &is_initialized,
+               sizeof(UMF_MEMSPACE_HIGHEST_CAPACITY_INITIALIZED));
     }
 }
 

--- a/src/memspaces/memspace_highest_capacity.c
+++ b/src/memspaces/memspace_highest_capacity.c
@@ -67,10 +67,6 @@ static void umfMemspaceHighestCapacityInit(void) {
         umfMemspaceHighestCapacityCreate(&UMF_MEMSPACE_HIGHEST_CAPACITY);
     assert(ret == UMF_RESULT_SUCCESS);
     (void)ret;
-
-#if defined(_WIN32) && !defined(UMF_SHARED_LIBRARY)
-    atexit(umfMemspaceHostAllDestroy);
-#endif
 }
 
 umf_memspace_handle_t umfMemspaceHighestCapacityGet(void) {

--- a/src/memspaces/memspace_host_all.c
+++ b/src/memspaces/memspace_host_all.c
@@ -73,6 +73,11 @@ void umfMemspaceHostAllDestroy(void) {
     if (UMF_MEMSPACE_HOST_ALL) {
         umfMemspaceDestroy(UMF_MEMSPACE_HOST_ALL);
         UMF_MEMSPACE_HOST_ALL = NULL;
+
+        // portable version of "UMF_MEMSPACE_HOST_ALL_INITIALIZED = UTIL_ONCE_FLAG_INIT;"
+        static UTIL_ONCE_FLAG is_initialized = UTIL_ONCE_FLAG_INIT;
+        memcpy(&UMF_MEMSPACE_HOST_ALL_INITIALIZED, &is_initialized,
+               sizeof(UMF_MEMSPACE_HOST_ALL_INITIALIZED));
     }
 }
 

--- a/src/provider/provider_level_zero.c
+++ b/src/provider/provider_level_zero.c
@@ -124,6 +124,10 @@ void ze_memory_provider_finalize(void *provider) {
 
     util_init_once(&ze_is_initialized, init_ze_global_state);
     umf_ba_global_free(provider);
+
+    // portable version of "ze_is_initialized = UTIL_ONCE_FLAG_INIT;"
+    static UTIL_ONCE_FLAG is_initialized = UTIL_ONCE_FLAG_INIT;
+    memcpy(&ze_is_initialized, &is_initialized, sizeof(ze_is_initialized));
 }
 
 static umf_result_t ze_memory_provider_alloc(void *provider, size_t size,

--- a/src/topology.c
+++ b/src/topology.c
@@ -39,10 +39,6 @@ static void umfCreateTopology(void) {
         hwloc_topology_destroy(topology);
         topology = NULL;
     }
-
-#if defined(_WIN32) && !defined(UMF_SHARED_LIBRARY)
-    atexit(umfDestroyTopology);
-#endif
 }
 
 hwloc_topology_t umfGetTopology(void) {

--- a/src/topology.c
+++ b/src/topology.c
@@ -19,6 +19,11 @@ static UTIL_ONCE_FLAG topology_initialized = UTIL_ONCE_FLAG_INIT;
 void umfDestroyTopology(void) {
     if (topology) {
         hwloc_topology_destroy(topology);
+
+        // portable version of "topology_initialized = UTIL_ONCE_FLAG_INIT;"
+        static UTIL_ONCE_FLAG is_initialized = UTIL_ONCE_FLAG_INIT;
+        memcpy(&topology_initialized, &is_initialized,
+               sizeof(topology_initialized));
     }
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -279,3 +279,14 @@ else()
     message(
         STATUS "IPC shared memory test is supported on Linux only - skipping")
 endif()
+
+if(LINUX
+   AND UMF_BUILD_SHARED_LIBRARY
+   AND UMF_POOL_SCALABLE_ENABLED)
+    add_umf_test(NAME init_teardown SRCS test_init_teardown.c)
+    # append LD_LIBRARY_PATH to the libumf
+    set_property(
+        TEST umf-init_teardown
+        PROPERTY ENVIRONMENT_MODIFICATION
+                 "LD_LIBRARY_PATH=path_list_append:${CMAKE_BINARY_DIR}/lib")
+endif()

--- a/test/test_init_teardown.c
+++ b/test/test_init_teardown.c
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+*/
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#define SIZE_ALLOC 4096
+
+typedef int (*umfMemoryProviderCreateFromMemspace_t)(void *hMemspace,
+                                                     void *hPolicy,
+                                                     void **hPool);
+typedef int (*umfPoolCreate_t)(void *ops, void *provider, void *params,
+                               uint32_t flags, void **hPool);
+typedef void (*umfDestroy_t)(void *handle);
+typedef void (*umfVoidVoid_t)(void);
+typedef void *(*umfGetPtr_t)(void);
+
+static umfVoidVoid_t umfTearDown;
+static umfDestroy_t umfMemoryProviderDestroy;
+static umfDestroy_t umfPoolDestroy;
+static const char *umf_lib_name;
+static void *h_umf;
+static void *umf_provider_default;
+static void *umf_pool_default;
+static void *umf_default;
+
+// UMF alloc
+static void *(*umf_alloc)(void *pool, size_t size);
+
+// UMF free
+static void (*umf_free)(void *pool, void *ptr);
+
+static void load_symbol(void *handle, const char *name, void **dest) {
+    void *symbol = dlsym(handle, name);
+    if (symbol == NULL) {
+        fprintf(stderr, "umf_load: symbol %s NOT found\n", name);
+        *dest = NULL;
+        return;
+    }
+
+    fprintf(stderr, "umf_load: symbol found: %s\n", name);
+
+    *dest = symbol;
+}
+
+static int umf_load(int n_init_teardown) {
+    umfMemoryProviderCreateFromMemspace_t umfMemoryProviderCreateFromMemspace;
+    umfGetPtr_t umfMemspaceHostAllGet; // the default memspace
+    umfGetPtr_t umfScalablePoolOps;
+    umfPoolCreate_t umfPoolCreate;
+    umfVoidVoid_t umfInit;
+    void *memspaceHostAll;
+    int ret;
+
+    umf_lib_name = "libumf.so";
+    h_umf = dlopen(umf_lib_name, RTLD_LAZY);
+    if (h_umf == NULL) {
+        fprintf(stderr, "umf_load: UMF library not found (%s)\n", umf_lib_name);
+        return -1;
+    }
+
+    load_symbol(h_umf, "umfInit", (void **)&umfInit);
+    if (umfInit == NULL) {
+        goto err_dlclose;
+    }
+
+    load_symbol(h_umf, "umfTearDown", (void **)&umfTearDown);
+    if (umfTearDown == NULL) {
+        goto err_dlclose;
+    }
+
+    // Initialize libumf (increment the reference counter of users).
+    // Normally this should be done exactly once.
+    for (int i = 0; i < n_init_teardown; i++) {
+        (*umfInit)();
+    }
+
+    load_symbol(h_umf, "umfMemoryProviderCreateFromMemspace",
+                (void **)&umfMemoryProviderCreateFromMemspace);
+    if (umfMemoryProviderCreateFromMemspace == NULL) {
+        goto err_dlclose;
+    }
+
+    load_symbol(h_umf, "umfMemoryProviderDestroy",
+                (void **)&umfMemoryProviderDestroy);
+    if (umfMemoryProviderDestroy == NULL) {
+        goto err_dlclose;
+    }
+
+    load_symbol(h_umf, "umfPoolCreate", (void **)&umfPoolCreate);
+    if (umfPoolCreate == NULL) {
+        goto err_dlclose;
+    }
+
+    load_symbol(h_umf, "umfPoolDestroy", (void **)&umfPoolDestroy);
+    if (umfPoolDestroy == NULL) {
+        goto err_dlclose;
+    }
+
+    load_symbol(h_umf, "umfPoolMalloc", (void **)&umf_alloc);
+    if (umf_alloc == NULL) {
+        goto err_dlclose;
+    }
+
+    load_symbol(h_umf, "umfPoolFree", (void **)&umf_free);
+    if (umf_free == NULL) {
+        goto err_dlclose;
+    }
+
+    load_symbol(h_umf, "umfScalablePoolOps", (void **)&umfScalablePoolOps);
+    if (umfScalablePoolOps == NULL) {
+        goto err_dlclose;
+    }
+
+    load_symbol(h_umf, "umfMemspaceHostAllGet",
+                (void **)&umfMemspaceHostAllGet);
+    if (umfMemspaceHostAllGet == NULL) {
+        goto err_dlclose;
+    }
+
+    memspaceHostAll = (*umfMemspaceHostAllGet)();
+    if (memspaceHostAll == NULL) {
+        fprintf(stderr, "umf_load: cannot get the memspaceHostAll memspace\n");
+        goto err_dlclose;
+    }
+    fprintf(stderr, "umf_load: got memspace: memspaceHostAll\n");
+
+    ret = (*umfMemoryProviderCreateFromMemspace)(memspaceHostAll, NULL,
+                                                 &umf_provider_default);
+    if (ret || umf_provider_default == NULL) {
+        fprintf(stderr, "umf_load: error creating the default provider: %i\n",
+                ret);
+        goto err_dlclose;
+    }
+    fprintf(stderr, "umf_load: the default provider created from memspace\n");
+
+    umf_default = NULL;
+    ret = (*umfPoolCreate)((*umfScalablePoolOps)(), umf_provider_default, NULL,
+                           0, &umf_pool_default);
+    if (ret || umf_pool_default == NULL) {
+        fprintf(stderr, "umf_load: error creating the default pool: %i\n", ret);
+        goto err_destroy_provider;
+    }
+    fprintf(stderr,
+            "umf_load: the default pool created from the All Nodes provider\n");
+
+    umf_default = umf_pool_default; // umf pool using the default memspace
+
+    fprintf(stderr, "umf_load: umf initialized\n");
+
+    return 0;
+
+err_destroy_provider:
+    (*umfMemoryProviderDestroy)(umf_provider_default);
+err_dlclose:
+    dlclose(h_umf);
+
+    return -1;
+}
+
+static void umf_unload(int n_init_teardown) {
+    umf_default = NULL;
+
+    fprintf(stderr, "umf_unload: finalizing UMF ...\n");
+
+    (*umfPoolDestroy)(umf_pool_default);
+    fprintf(stderr, "umf_unload: the default umf memory pool destroyed\n");
+
+    (*umfMemoryProviderDestroy)(umf_provider_default);
+    fprintf(stderr, "umf_unload: the default umf memory provider destroyed\n");
+
+    // Deinitialize libumf (decrement the reference counter of users).
+    // Normally this should be done exactly once.
+    for (int i = 0; i < n_init_teardown; i++) {
+        fprintf(stderr, "umf_unload: calling umfTearDown() ...\n");
+        (*umfTearDown)();
+    }
+
+    fprintf(stderr, "umf_unload: closing umf library ...\n");
+    dlclose(h_umf);
+    fprintf(stderr, "umf_unload: umf library closed\n");
+}
+
+static int run_test(int n_init_teardown, int wrong_dtor_order) {
+
+    if (wrong_dtor_order) {
+        fprintf(stderr, "\n\n*** Running test with INCORRECT order of "
+                        "destructors ***\n\n\n");
+    } else {
+        fprintf(
+            stderr,
+            "\n\n*** Running test with CORRECT order of destructors ***\n\n\n");
+    }
+
+    if (umf_load(n_init_teardown)) {
+        return -1;
+    }
+
+    assert(umf_default);
+    void *ptr = (*umf_alloc)(umf_default, SIZE_ALLOC);
+    (*umf_free)(umf_default, ptr);
+
+    // simulate incorrect order of destructors (an additional, unwanted destructor call)
+    if (wrong_dtor_order) {
+        fprintf(stderr,
+                "*** Simulating incorrect order of destructors !!! ***\n");
+        (*umfTearDown)();
+    }
+
+    umf_unload(n_init_teardown);
+
+    return 0;
+}
+
+#define CORRECT_ORDER_OF_DESTRUCTORS 0
+#define INCORRECT_ORDER_OF_DESTRUCTORS 1
+
+int main(void) {
+    if (run_test(1, CORRECT_ORDER_OF_DESTRUCTORS)) {
+        return -1;
+    }
+
+    if (run_test(1, INCORRECT_ORDER_OF_DESTRUCTORS)) {
+        return -1;
+    }
+
+    if (run_test(10, CORRECT_ORDER_OF_DESTRUCTORS)) {
+        return -1;
+    }
+
+    if (run_test(10, INCORRECT_ORDER_OF_DESTRUCTORS)) {
+        return -1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
### Description

Add init/teardown functions: `umfInit()` and `umfTearDown()`:

- `umfInit()` increments the usage reference counter and initializes the global state of libumf if the usage reference counter was equal 0. Returns 0 on success or -1 on failure.

- `umfTearDown()` decrements the usage reference counter and destroys the global state of libumf if the usage reference counter is equal 0.

Fixes: #514

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
