### PR TITLE
[CI] Bump MSVC version to more generic one

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -95,7 +95,7 @@ jobs:
       uses: TheMrMilchmann/setup-msvc-dev@48edcef51a12c80d7e62ace57aae1417795e511c # v3.0.0
       with:
         arch: x64
-        toolset: '14.39.33519'
+        toolset: '14'
 
     - name: Initialize vcpkg
       uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5


### PR DESCRIPTION
Apparently, the more generic version works properly (even though it uses precisely the same version, as before).

- [x] All tests pass locally
- [x] CI workflows execute properly