### PR TITLE
Handle default kernel behavior for CPU access to all NUMA nodes

### DIFF
--- a/test/memspaces/memspace_host_all.cpp
+++ b/test/memspaces/memspace_host_all.cpp
@@ -2,17 +2,19 @@
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <numa.h>
+#include <numaif.h>
+#include <sys/mman.h>
+#include <unordered_set>
+
+#include <umf/memspace.h>
+
 #include "memory_target_numa.h"
 #include "memspace_helpers.hpp"
 #include "memspace_internal.h"
 #include "numa_helpers.h"
 #include "test_helpers.h"
 #include "utils_sanitizers.h"
-
-#include <numa.h>
-#include <numaif.h>
-#include <umf/memspace.h>
-#include <unordered_set>
 
 using umf_test::test;
 
@@ -87,6 +89,69 @@ TEST_F(memspaceHostAllProviderTest, allocFree) {
     UT_ASSERTeq(ret, UMF_RESULT_SUCCESS);
 }
 
+TEST_F(memspaceHostAllProviderTest, hostAllDefaults) {
+    // This testcase checks if the allocations made using the provider with
+    // default parameters based on default memspace (HostAll) uses the fast,
+    // default kernel path (no mbind).
+
+    umf_memspace_handle_t hMemspace = umfMemspaceHostAllGet();
+    UT_ASSERTne(hMemspace, nullptr);
+
+    umf_memory_provider_handle_t hProvider = nullptr;
+    umf_result_t ret = umfMemoryProviderCreateFromMemspace(
+        umfMemspaceHostAllGet(), NULL, &hProvider);
+    ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+    ASSERT_NE(hProvider, nullptr);
+
+    // Create single allocation using the provider.
+    void *ptr1 = nullptr;
+    size_t size = SIZE_4K;
+    size_t alignment = 0;
+
+    ret = umfMemoryProviderAlloc(hProvider, size, alignment, &ptr1);
+    UT_ASSERTeq(ret, UMF_RESULT_SUCCESS);
+    UT_ASSERTne(ptr1, nullptr);
+    memset(ptr1, 0xFF, size);
+
+    // Create single allocation using mmap
+    void *ptr2 = mmap(nullptr, size, PROT_READ | PROT_WRITE,
+                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    UT_ASSERTne(ptr2, nullptr);
+    memset(ptr2, 0xFF, size);
+
+    // Compare UMF and kernel default allocation policy
+    struct bitmask *nodemask1 = numa_allocate_nodemask();
+    struct bitmask *nodemask2 = numa_allocate_nodemask();
+    int memMode1 = -1, memMode2 = -1;
+
+    int ret2 = get_mempolicy(&memMode1, nodemask1->maskp, nodemask1->size, ptr1,
+                             MPOL_F_ADDR);
+    UT_ASSERTeq(ret2, 0);
+    ret2 = get_mempolicy(&memMode2, nodemask2->maskp, nodemask2->size, ptr2,
+                         MPOL_F_ADDR);
+    UT_ASSERTeq(ret2, 0);
+    UT_ASSERTeq(memMode1, memMode2);
+    UT_ASSERTeq(nodemask1->size, nodemask2->size);
+    UT_ASSERTeq(numa_bitmask_equal(nodemask1, nodemask2), 1);
+
+    int nodeId1 = -1, nodeId2 = -1;
+    ret2 = get_mempolicy(&nodeId1, nullptr, 0, ptr1, MPOL_F_ADDR | MPOL_F_NODE);
+    UT_ASSERTeq(ret2, 0);
+    ret2 = get_mempolicy(&nodeId2, nullptr, 0, ptr2, MPOL_F_ADDR | MPOL_F_NODE);
+    UT_ASSERTeq(ret2, 0);
+    UT_ASSERTeq(nodeId1, nodeId2);
+
+    numa_free_nodemask(nodemask2);
+    numa_free_nodemask(nodemask1);
+
+    ret2 = munmap(ptr2, size);
+    UT_ASSERTeq(ret2, 0);
+
+    ret = umfMemoryProviderFree(hProvider, ptr1, size);
+    UT_ASSERTeq(ret, UMF_RESULT_SUCCESS);
+    umfMemoryProviderDestroy(hProvider);
+}
+
 TEST_F(memspaceHostAllProviderTest, allocsSpreadAcrossAllNumaNodes) {
     // This testcase is unsuitable for TSan.
 #ifdef __SANITIZE_THREAD__
@@ -140,17 +205,11 @@ TEST_F(memspaceHostAllProviderTest, allocsSpreadAcrossAllNumaNodes) {
         size_t allocNodeId = SIZE_MAX;
         getAllocationPolicy(ptr, maxNodeId, mode, boundNodeIds, allocNodeId);
 
-        // 'BIND' mode specifies that the memory is bound to a set of NUMA nodes.
-        // In case of 'HOST ALL' memspace, those set of nodes should be all
-        // available nodes.
-        UT_ASSERTeq(mode, MPOL_BIND);
-
-        // Confirm that the memory is bound to all the nodes from 'HOST ALL'
-        // memspace.
-        for (auto &id : nodeIds) {
-            auto it = std::find(boundNodeIds.begin(), boundNodeIds.end(), id);
-            UT_ASSERT(it != boundNodeIds.end());
-        }
+        // In case of 'HOST ALL' memspace, the default set of nodes (that
+        // contains all available nodes) is used but get_mempolicy() would
+        // return an empty set of nodes.
+        UT_ASSERTeq(mode, MPOL_DEFAULT);
+        UT_ASSERTeq(boundNodeIds.size(), 0);
 
         // Confirm that the memory is allocated on one of the nodes in
         // 'HOST ALL' memspace.


### PR DESCRIPTION

### Description

For the default CPU memspace (MemspaceHostAll) with all NUMA nodes, we should follow the default kernel behavior, and we shouldn't call any kind of mbind() that could negatively impact the performance

### Checklist

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
- [x] New tests added, especially if they will fail without my changes
