### PR TITLE
Temporarily disable Windows 2022 Release CI builds

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -159,21 +159,24 @@ jobs:
         level_zero_provider: ['ON']
         include:
           - os: 'windows-2022'
-            build_type: Release
+            build_type: Debug
             compiler: {c: clang-cl, cxx: clang-cl}
             shared_library: 'ON'
             level_zero_provider: 'ON'
             toolset: "-T ClangCL"
           - os: 'windows-2022'
-            build_type: Release
+            build_type: Debug
             compiler: {c: cl, cxx: cl}
             shared_library: 'ON'
             level_zero_provider: 'ON'
           - os: 'windows-2022'
-            build_type: Release
+            build_type: Debug
             compiler: {c: cl, cxx: cl}
             shared_library: 'ON'
             level_zero_provider: 'OFF'
+        exclude:
+          - os: 'windows-2022'
+            build_type: Release
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -14,7 +14,7 @@ jobs:
       VCPKG_PATH: "${{github.workspace}}/build/vcpkg/packages/hwloc_x64-windows;${{github.workspace}}/build/vcpkg/packages/tbb_x64-windows;${{github.workspace}}/build/vcpkg/packages/jemalloc_x64-windows"
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'windows-latest']
+        os: ['ubuntu-latest']
         include: 
           # Windows doesn't recognize 'CMAKE_BUILD_TYPE', it uses '--config' param in build command to determine the build type
           - os: ubuntu-latest

--- a/.github/workflows/pr_push.yml
+++ b/.github/workflows/pr_push.yml
@@ -103,16 +103,16 @@ jobs:
         ${{matrix.extra_build_options}}
 
     - name: Build
-      run: cmake --build ${{github.workspace}}/build --config Release -j
+      run: cmake --build ${{github.workspace}}/build --config Debug -j
 
     - name: Run examples
       working-directory: ${{github.workspace}}/build
-      run: ctest --output-on-failure --test-dir examples -C Release
+      run: ctest --output-on-failure --test-dir examples -C Debug
 
     - name: Run tests
       if: matrix.build_tests == 'ON'
       working-directory: ${{github.workspace}}/build
-      run: ctest --output-on-failure --test-dir test -C Release
+      run: ctest --output-on-failure --test-dir test -C Debug
 
   CodeStyle:
     name: Coding style


### PR DESCRIPTION
### Description

Temporarily disable Windows 2022 Release CI builds (or replace them with Debug builds)
because they started failing for unknown reason.

Revert this commit when Windows 2022 CI machines are fixed.

### Checklist
- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
