### PR TITLE
Revert: Temporarily disable Windows 2022 Release CI builds

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -159,24 +159,21 @@ jobs:
         level_zero_provider: ['ON']
         include:
           - os: 'windows-2022'
-            build_type: Debug
+            build_type: Release
             compiler: {c: clang-cl, cxx: clang-cl}
             shared_library: 'ON'
             level_zero_provider: 'ON'
             toolset: "-T ClangCL"
           - os: 'windows-2022'
-            build_type: Debug
+            build_type: Release
             compiler: {c: cl, cxx: cl}
             shared_library: 'ON'
             level_zero_provider: 'ON'
           - os: 'windows-2022'
-            build_type: Debug
+            build_type: Release
             compiler: {c: cl, cxx: cl}
             shared_library: 'ON'
             level_zero_provider: 'OFF'
-        exclude:
-          - os: 'windows-2022'
-            build_type: Release
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -14,7 +14,7 @@ jobs:
       VCPKG_PATH: "${{github.workspace}}/build/vcpkg/packages/hwloc_x64-windows;${{github.workspace}}/build/vcpkg/packages/tbb_x64-windows;${{github.workspace}}/build/vcpkg/packages/jemalloc_x64-windows"
     strategy:
       matrix:
-        os: ['ubuntu-latest']
+        os: ['ubuntu-latest', 'windows-latest']
         include: 
           # Windows doesn't recognize 'CMAKE_BUILD_TYPE', it uses '--config' param in build command to determine the build type
           - os: ubuntu-latest

--- a/.github/workflows/pr_push.yml
+++ b/.github/workflows/pr_push.yml
@@ -103,16 +103,16 @@ jobs:
         ${{matrix.extra_build_options}}
 
     - name: Build
-      run: cmake --build ${{github.workspace}}/build --config Debug -j
+      run: cmake --build ${{github.workspace}}/build --config Release -j
 
     - name: Run examples
       working-directory: ${{github.workspace}}/build
-      run: ctest --output-on-failure --test-dir examples -C Debug
+      run: ctest --output-on-failure --test-dir examples -C Release
 
     - name: Run tests
       if: matrix.build_tests == 'ON'
       working-directory: ${{github.workspace}}/build
-      run: ctest --output-on-failure --test-dir test -C Debug
+      run: ctest --output-on-failure --test-dir test -C Release
 
   CodeStyle:
     name: Coding style


### PR DESCRIPTION
### Description

Revert: Temporarily disable Windows 2022 Release CI builds

This PR reverts https://github.com/oneapi-src/unified-memory-framework/pull/535

Ref: #535 

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
