### PR TITLE
add umf split mode to os_memory_provider

### DIFF
--- a/src/provider/provider_os_memory_internal.h
+++ b/src/provider/provider_os_memory_internal.h
@@ -41,6 +41,7 @@ typedef struct os_memory_provider_t {
     critnib *fd_offset_map;
 
     // NUMA config
+    umf_numa_mode_t mode;
     hwloc_bitmap_t *nodeset;
     unsigned nodeset_len;
     char *nodeset_str_buf;
@@ -49,6 +50,14 @@ typedef struct os_memory_provider_t {
 
     size_t part_size;
     size_t alloc_sum; // sum of all allocations - used for manual interleaving
+
+    struct {
+        unsigned weight;
+        hwloc_bitmap_t target;
+    } *partitions;
+    unsigned partitions_len;
+    size_t partitions_weight_sum;
+
     hwloc_topology_t topo;
 } os_memory_provider_t;
 

--- a/test/provider_os_memory.cpp
+++ b/test/provider_os_memory.cpp
@@ -178,6 +178,32 @@ TEST_F(test, create_WRONG_NUMA_MODE_INTERLEAVE) {
     ASSERT_EQ(ret, UMF_RESULT_ERROR_INVALID_ARGUMENT);
 }
 
+TEST_F(test, create_WRONG_NUMA_MODE_SPLIT) {
+    auto ret = create_os_provider_with_mode(UMF_NUMA_MODE_SPLIT, nullptr, 0);
+    ASSERT_EQ(ret, UMF_RESULT_ERROR_INVALID_ARGUMENT);
+}
+
+TEST_F(test, create_ZERO_WEIGHT_PARTITION) {
+    umf_numa_split_partition_t p = {0, 0};
+    umf_result_t umf_result;
+    umf_memory_provider_handle_t os_memory_provider = nullptr;
+    umf_os_memory_provider_params_t os_memory_provider_params =
+        umfOsMemoryProviderParamsDefault();
+
+    os_memory_provider_params.numa_mode = UMF_NUMA_MODE_SPLIT;
+    os_memory_provider_params.numa_list = &valid_list;
+    os_memory_provider_params.numa_list_len = valid_list_len;
+    os_memory_provider_params.partitions = &p;
+    os_memory_provider_params.partitions_len = 1;
+
+    umf_result = umfMemoryProviderCreate(umfOsMemoryProviderOps(),
+                                         &os_memory_provider_params,
+                                         &os_memory_provider);
+
+    EXPECT_EQ(os_memory_provider, nullptr);
+    ASSERT_EQ(umf_result, UMF_RESULT_ERROR_INVALID_ARGUMENT);
+}
+
 // positive tests using test_alloc_free_success
 
 auto defaultParams = umfOsMemoryProviderParamsDefault();


### PR DESCRIPTION
split mode splits each allocation based on user provided partitions,
across multiple numa nodes. If no partition defined then each
allocation is split evenly, across all numa available.

Signed-off-by: Łukasz Plewa <lukasz.plewa@intel.com>