### PR TITLE
Link the init_teardown test with libdl

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -287,7 +287,10 @@ endif()
 if(LINUX
    AND UMF_BUILD_SHARED_LIBRARY
    AND UMF_POOL_SCALABLE_ENABLED)
-    add_umf_test(NAME init_teardown SRCS test_init_teardown.c)
+    add_umf_test(
+        NAME init_teardown
+        SRCS test_init_teardown.c
+        LIBS dl)
     # append LD_LIBRARY_PATH to the libumf
     set_property(
         TEST umf-init_teardown


### PR DESCRIPTION
### Description

Link the init_teardown test with libdl explicitly
for systems with glibc < 2.34.

The init_teardown test uses dlopen(), dlsym() and dlclose().

Fixes: #543

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
