### PR TITLE
Run the simplest CMake CI build also on Ubuntu 20.04

### DIFF
--- a/.github/workflows/pr_push.yml
+++ b/.github/workflows/pr_push.yml
@@ -42,8 +42,14 @@ jobs:
             build_tests: 'OFF'
             extra_build_options: '-DCMAKE_BUILD_TYPE=Release -DUMF_BUILD_BENCHMARKS=ON'
             simple_cmake: 'OFF'
-          # simplest CMake
+          # simplest CMake on ubuntu-latest
           - os: ubuntu-latest
+            disjoint: 'OFF'
+            build_tests: 'ON'
+            extra_build_options: '-DCMAKE_BUILD_TYPE=Release'
+            simple_cmake: 'ON'
+          # simplest CMake ubuntu-20.04
+          - os: ubuntu-20.04
             disjoint: 'OFF'
             build_tests: 'ON'
             extra_build_options: '-DCMAKE_BUILD_TYPE=Release'
@@ -67,14 +73,21 @@ jobs:
       run: vcpkg install
       shell: pwsh # Specifies PowerShell as the shell for running the script.
 
-    - name: Install apt packages
+    - name: Install apt packages (ubuntu-latest)
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update
         sudo apt-get install -y cmake libjemalloc-dev libhwloc-dev libnuma-dev libtbb-dev
 
+    - name: Install apt packages (ubuntu-20.04)
+      if: matrix.os == 'ubuntu-20.04'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake libjemalloc-dev libnuma-dev libtbb-dev
+        .github/scripts/install_hwloc.sh # install hwloc-2.3.0 instead of hwloc-2.1.0 present in the OS package
+
     - name: Set ptrace value for IPC test (on Linux only)
-      if: matrix.os == 'ubuntu-latest'
+      if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-20.04' }}
       run: sudo bash -c "echo 0 > /proc/sys/kernel/yama/ptrace_scope"
 
     - name: Configure CMake


### PR DESCRIPTION
### Description

Run the simplest CMake CI build also on Ubuntu 20.04
in order to test glibc < 2.34.

Ref: #543

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
