### PR TITLE
Add umfGetCurrentVersion() to UMF API

### DIFF
--- a/include/umf.h
+++ b/include/umf.h
@@ -32,6 +32,10 @@ int umfInit(void);
 ///        It must be called just before dlclose() and it is not required in other scenarios.
 void umfTearDown(void);
 
+///
+/// @brief Get the current version of the UMF headers defined by UMF_VERSION_CURRENT.
+int umfGetCurrentVersion(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libumf.c
+++ b/src/libumf.c
@@ -45,3 +45,5 @@ void umfTearDown(void) {
         umf_ba_destroy_global();
     }
 }
+
+int umfGetCurrentVersion(void) { return UMF_VERSION_CURRENT; }

--- a/src/libumf.def.in
+++ b/src/libumf.def.in
@@ -12,6 +12,7 @@ EXPORTS
     DllMain
     umfInit
     umfTearDown
+    umfGetCurrentVersion
     umfCloseIPCHandle
     umfFree
     umfGetIPCHandle

--- a/src/libumf.map
+++ b/src/libumf.map
@@ -6,6 +6,7 @@ UMF_1.0 {
     global:
         umfInit;
         umfTearDown;
+        umfGetCurrentVersion;
         umfCloseIPCHandle;
         umfFree;
         umfGetIPCHandle;


### PR DESCRIPTION
### Description

Add `umfGetCurrentVersion()` to UMF API that gets the current version of the UMF headers defined by `UMF_VERSION_CURRENT`.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
