### PR TITLE
load DLLs only from safe load list

### DIFF
--- a/.github/scripts/check_dll_flags.ps1
+++ b/.github/scripts/check_dll_flags.ps1
@@ -1,0 +1,42 @@
+# Copyright (C) 2023-2024 Intel Corporation
+# Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Invoke-CmdScript runs a command script and updates the current environment 
+# with any flag changes set by the script.
+function Invoke-CmdScript {
+  param(
+    [String] $scriptName
+  )
+  $cmdLine = """$scriptName"" $args & set"
+  & $Env:SystemRoot\system32\cmd.exe /c $cmdLine |
+  select-string '^([^=]*)=(.*)$' | foreach-object {
+    $varName = $_.Matches[0].Groups[1].Value
+    $varValue = $_.Matches[0].Groups[2].Value
+    set-item Env:$varName $varValue
+  }
+}
+
+# Get the path to vcvarsall.bat
+$vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" `
+  -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+  -property installationPath
+$vsPath = "$vsPath\VC\Auxiliary\Build"
+$vcvarsall = "${vsPath}\vcvarsall.bat"
+echo "Visual Studio path: $vsPath"
+echo "vcvarsall.bat path: $vcvarsall"
+
+# Call vcvarsall.bat so we can run MSVC commands
+echo "Setting up MSVC environment..."
+Invoke-CmdScript "$vcvarsall" x86
+
+# Get umf.dll configuration flags and check if DEPENDENTLOADFLAG is set to 0x2000
+$flags = & "${env:VCToolsInstallDir}\bin\Hostx64\x64\dumpbin.exe" /LOADCONFIG "$args"
+if (($flags | Where-Object { $_ -match '(\d+).*Dependent' } | ForEach-Object { $matches[1] } ) -eq "2000") { 
+  echo "The DEPENDENTLOADFLAG is correctly set to 0x2000."
+  exit 0
+} else {
+  echo "The DEPENDENTLOADFLAG is not correctly set"
+  echo "$flags"
+  exit 1
+}

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -148,7 +148,7 @@ jobs:
     name: Windows
     env:
       VCPKG_PATH: "${{github.workspace}}/build/vcpkg/packages/hwloc_x64-windows;${{github.workspace}}/build/vcpkg/packages/tbb_x64-windows;${{github.workspace}}/build/vcpkg/packages/jemalloc_x64-windows"
-      BUILD_DIR : "${{github.workspace}}/build/${{matrix.build_type}}"
+      BUILD_DIR : "${{github.workspace}}/build/"
       INSTL_DIR : "${{github.workspace}}/../install-dir"
     strategy:
       matrix:
@@ -227,11 +227,21 @@ jobs:
         --proxy
         --umf-version ${{env.UMF_VERSION}}
         ${{ matrix.shared_library == 'ON' && '--shared-library' || ''}}
+        
+    - name: check /DEPENDENTLOADFLAG in umf.dll
+      if: ${{matrix.shared_library == 'ON' && matrix.compiler.cxx == 'cl'}}
+      run: ${{github.workspace}}/.github/scripts/check_dll_flags.ps1 ${{github.workspace}}/build/bin/${{matrix.build_type}}/umf.dll
+      shell: pwsh
+
+    - name: check /DEPENDENTLOADFLAG in umf_proxy.dll
+      if: ${{matrix.compiler.cxx == 'cl'}}
+      run: ${{github.workspace}}/.github/scripts/check_dll_flags.ps1 ${{github.workspace}}/build/src/proxy_lib/${{matrix.build_type}}/umf_proxy.dll
+      shell: pwsh
 
   windows-dynamic_build_hwloc:
     name: "Windows dynamic UMF + static hwloc"
     env:
-      BUILD_DIR : "${{github.workspace}}/build/${{matrix.build_type}}"
+      BUILD_DIR : "${{github.workspace}}/build"
     strategy:
       matrix:
         build_type: [Release]
@@ -263,10 +273,16 @@ jobs:
       working-directory: ${{env.BUILD_DIR}}
       run: ctest -C ${{matrix.build_type}} --output-on-failure --test-dir test
 
+      # we check umf.dll only here - note that the proxy library is disabled in
+      # this configuration
+    - name: check /DEPENDENTLOADFLAG in umf.dll
+      run: ${{github.workspace}}/.github/scripts/check_dll_flags.ps1 ${{github.workspace}}/build/bin/${{matrix.build_type}}/umf.dll
+      shell: pwsh
+
   windows-static_build_hwloc:
     name: "Windows static UMF + static hwloc"
     env:
-      BUILD_DIR : "${{github.workspace}}/build/${{matrix.build_type}}"
+      BUILD_DIR : "${{github.workspace}}/build"
     strategy:
       matrix:
         build_type: [Release]

--- a/.github/workflows/pr_push.yml
+++ b/.github/workflows/pr_push.yml
@@ -104,6 +104,7 @@ jobs:
         -DUMF_BUILD_EXAMPLES=ON
         -DUMF_BUILD_LEVEL_ZERO_PROVIDER=ON
         -DUMF_TESTS_FAIL_ON_SKIP=ON
+        -DUMF_BUILD_SHARED_LIBRARY=ON
         ${{matrix.extra_build_options}}
 
     - name: Configure CMake (simple)
@@ -126,6 +127,16 @@ jobs:
       if: matrix.build_tests == 'ON'
       working-directory: ${{github.workspace}}/build
       run: ctest --output-on-failure --test-dir test -C Release
+
+    - name: check /DEPENDENTLOADFLAG (Windows only)
+      if: matrix.os == 'windows-latest'
+      run: ${{github.workspace}}/.github/scripts/check_dll_flags.ps1 ${{github.workspace}}/build/bin/Release/umf.dll
+      shell: pwsh
+
+    - name: check /DEPENDENTLOADFLAG in umf_proxy.dll
+      if: matrix.os == 'windows-latest'
+      run: ${{github.workspace}}/.github/scripts/check_dll_flags.ps1 ${{github.workspace}}/build/src/proxy_lib/Release/umf_proxy.dll
+      shell: pwsh
 
   CodeStyle:
     name: Coding style

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -158,6 +158,8 @@ function(add_umf_target_link_options name)
             PRIVATE
             /DYNAMICBASE
             /HIGHENTROPYVA
+            $<$<C_COMPILER_ID:MSVC>:/DEPENDENTLOADFLAG:0x2000>
+            $<$<CXX_COMPILER_ID:MSVC>:/DEPENDENTLOADFLAG:0x2000>
             /NXCOMPAT)
     endif()
 endfunction()


### PR DESCRIPTION
Set /DEPENDENTLOADFLAG to 2000 (LOAD_LIBRARY_SAFE_CURRENT_DIRS) in Windows umf.dll builds (MSVC only). 
With this flag, loading a DLL for execution from the current directory is only allowed if it is under a directory in the Safe load list.

In addition, there is a new test written in Power Shell that uses dumpbin.exe to check that this flag is set correctly.

Detailed information about the flag can be found at: https://learn.microsoft.com/en-us/cpp/build/reference/dependentloadflag?view=msvc-170
and: https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexa

- [x] requires #534 

