### PR TITLE
Print out the UMV version in util_log_init()

### DIFF
--- a/src/utils/utils_log.c
+++ b/src/utils/utils_log.c
@@ -26,6 +26,8 @@
 #include <string.h>
 #include <time.h>
 
+#include "umf.h"
+
 #include "utils_assert.h"
 #include "utils_common.h"
 #include "utils_log.h"
@@ -290,8 +292,11 @@ void util_log_init(void) {
         loggerConfig.flushLevel = LOG_FATAL;
     }
 
+    int umf_ver = umfGetCurrentVersion();
     LOG_INFO(
-        "Logger enabled (level: %s, flush: %s, pid: %s, timestamp: %s)",
+        "Logger enabled (umf_version: %i.%i, level: %s, flush: %s, pid: %s, "
+        "timestamp: %s)",
+        UMF_MAJOR_VERSION(umf_ver), UMF_MINOR_VERSION(umf_ver),
         level_to_str(loggerConfig.level), level_to_str(loggerConfig.flushLevel),
         bool_to_str(loggerConfig.pid), bool_to_str(loggerConfig.timestamp));
 }

--- a/test/utils/utils_log.cpp
+++ b/test/utils/utils_log.cpp
@@ -20,7 +20,8 @@ FILE *mock_fopen(const char *filename, const char *mode) {
 
 const std::string MOCK_FN_NAME = "MOCK_FUNCTION_NAME";
 std::string expected_message = "";
-FILE *expected_stream;
+// The "Logging output not set - logging disabled" message is printed to stderr.
+FILE *expected_stream = stderr;
 int expect_fput_count = 0;
 int fput_count = 0;
 


### PR DESCRIPTION
### Description

Print out the UMV version in `util_log_init()`.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
