### PR TITLE
Add initial expected_message to the logger test

### DIFF
--- a/src/utils/utils_log.c
+++ b/src/utils/utils_log.c
@@ -251,7 +251,8 @@ void util_log_init(void) {
         }
     } else {
         loggerConfig.output = stderr;
-        LOG_ERR("Logging output not set - logging disabled");
+        LOG_ERR("Logging output not set - logging disabled (UMF_LOG = \"%s\")",
+                envVar);
         loggerConfig.output = NULL;
         return;
     }

--- a/test/utils/utils_log.cpp
+++ b/test/utils/utils_log.cpp
@@ -19,8 +19,9 @@ FILE *mock_fopen(const char *filename, const char *mode) {
 }
 
 const std::string MOCK_FN_NAME = "MOCK_FUNCTION_NAME";
-std::string expected_message = "";
-// The "Logging output not set - logging disabled" message is printed to stderr.
+std::string expected_message = "[ERROR UMF] util_log_init: Logging output not "
+                               "set - logging disabled (UMF_LOG = \"\")\n";
+// The expected_message (above) is printed to stderr.
 FILE *expected_stream = stderr;
 int expect_fput_count = 0;
 int fput_count = 0;


### PR DESCRIPTION
### Description

Add initial expected_message to the logger test.

Ref: #552

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
