### PR TITLE
Dependabot configuration changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,8 @@ updates:
     directory: "/third_party" # Location of package manifests
     schedule:
       interval: "daily"
-    # Run only required security updates
-    open-pull-requests-limit: 0
+    groups:
+      pip-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
Since there is no repo traffic related to dependabot, I'm trying another approach: grouped version updates.