### PR TITLE
Print UMF source version in util_log_init() if it is defined

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,7 +76,7 @@ set(UMF_SOURCES_WINDOWS libumf_windows.c)
 # Compile definitions for UMF library.
 #
 # TODO: Cleanup the compile definitions across all the CMake files
-set(UMF_PRIVATE_COMPILE_DEFINITIONS "")
+set(UMF_PRIVATE_COMPILE_DEFINITIONS "-DUMF_SRC_VERSION=${UMF_SRC_VERSION}")
 
 set(UMF_SOURCES_COMMON_LINUX_MACOSX
     provider/provider_os_memory.c

--- a/src/utils/utils_log.c
+++ b/src/utils/utils_log.c
@@ -293,10 +293,19 @@ void util_log_init(void) {
         loggerConfig.flushLevel = LOG_FATAL;
     }
 
+#ifdef UMF_SRC_VERSION
+// convert a define to a C string
+#define STR_(X) #X
+#define STR(X) STR_(X)
+#define STR_UMF_SRC_VERSION "src version: " STR(UMF_SRC_VERSION) ", "
+#else /* !UMF_SRC_VERSION */
+#define STR_UMF_SRC_VERSION ""
+#endif /* !UMF_SRC_VERSION */
+
     int umf_ver = umfGetCurrentVersion();
     LOG_INFO(
-        "Logger enabled (umf_version: %i.%i, level: %s, flush: %s, pid: %s, "
-        "timestamp: %s)",
+        "Logger enabled (umf version: %i.%i, " STR_UMF_SRC_VERSION
+        "level: %s, flush: %s, pid: %s, timestamp: %s)",
         UMF_MAJOR_VERSION(umf_ver), UMF_MINOR_VERSION(umf_ver),
         level_to_str(loggerConfig.level), level_to_str(loggerConfig.flushLevel),
         bool_to_str(loggerConfig.pid), bool_to_str(loggerConfig.timestamp));


### PR DESCRIPTION
### Description

Add `UMF_SRC_VERSION` to `UMF_PRIVATE_COMPILE_DEFINITIONS`.
Print UMF source version (`UMF_SRC_VERSION`) in `util_log_init()` if it is defined.

It looks like:
```
[PID:21521  TID:21521  INFO  UMF] util_log_init: Logger enabled (umf version: 0.9, src version: 0.1.0.git.d1e2930, level: DEBUG, flush: DEBUG, pid: yes, timestamp: no)
```

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
