### PR TITLE
Move memcopy() to a separate source file

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -311,13 +311,15 @@ if(LINUX)
         ipc_os_prov_consumer
         SRCS
         ipc_os_prov_consumer.c
-        common/ipc_common.c)
+        common/ipc_common.c
+        common/ipc_os_prov_common.c)
     build_umf_test(
         NAME
         ipc_os_prov_producer
         SRCS
         ipc_os_prov_producer.c
-        common/ipc_common.c)
+        common/ipc_common.c
+        common/ipc_os_prov_common.c)
     add_umf_ipc_test(TEST ipc_os_prov_anon_fd)
     add_umf_ipc_test(TEST ipc_os_prov_shm)
 else()

--- a/test/common/ipc_common.c
+++ b/test/common/ipc_common.c
@@ -473,8 +473,3 @@ err_umfMemoryProviderDestroy:
 
     return ret;
 }
-
-void memcopy(void *dst, const void *src, size_t size, void *context) {
-    (void)context;
-    memcpy(dst, src, size);
-}

--- a/test/common/ipc_common.h
+++ b/test/common/ipc_common.h
@@ -8,8 +8,6 @@
 #ifndef IPC_COMMON_H
 #define IPC_COMMON_H
 
-#include <stdlib.h>
-
 #include <umf/memory_provider.h>
 
 // pointer to the function that returns void and accept two int values
@@ -25,7 +23,5 @@ int run_producer(int port, umf_memory_provider_ops_t *provider_ops,
 int run_consumer(int port, umf_memory_provider_ops_t *provider_ops,
                  void *provider_params, memcopy_callback_t memcopy_callback,
                  void *memcopy_ctx);
-
-void memcopy(void *dst, const void *src, size_t size, void *context);
 
 #endif // IPC_COMMON_H

--- a/test/common/ipc_os_prov_common.c
+++ b/test/common/ipc_os_prov_common.c
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#include <string.h>
+
+#include "ipc_os_prov_common.h"
+
+void memcopy(void *dst, const void *src, size_t size, void *context) {
+    (void)context;
+    memcpy(dst, src, size);
+}

--- a/test/common/ipc_os_prov_common.h
+++ b/test/common/ipc_os_prov_common.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#ifndef IPC_OS_PROV_COMMON_H
+#define IPC_OS_PROV_COMMON_H
+
+#include <stdlib.h>
+
+void memcopy(void *dst, const void *src, size_t size, void *context);
+
+#endif // IPC_OS_PROV_COMMON_H

--- a/test/ipc_os_prov_consumer.c
+++ b/test/ipc_os_prov_consumer.c
@@ -11,6 +11,7 @@
 #include <umf/providers/provider_os_memory.h>
 
 #include "ipc_common.h"
+#include "ipc_os_prov_common.h"
 
 int main(int argc, char *argv[]) {
     if (argc < 2) {

--- a/test/ipc_os_prov_producer.c
+++ b/test/ipc_os_prov_producer.c
@@ -11,6 +11,7 @@
 #include <umf/providers/provider_os_memory.h>
 
 #include "ipc_common.h"
+#include "ipc_os_prov_common.h"
 
 int main(int argc, char *argv[]) {
     if (argc < 2) {


### PR DESCRIPTION
### Description

Move `memcopy()` to a separate source file.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
