### PR TITLE
Suppress unused param warning from hwloc.h

### DIFF
--- a/src/umf_hwloc.h
+++ b/src/umf_hwloc.h
@@ -12,7 +12,17 @@
 #pragma warning(disable : 4100)
 #endif // _MSC_VER
 
+// disable warning "unused parameter" thrown in hwloc.h
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif // defined(__GNUC__) || defined(__clang__)
+
 #include <hwloc.h>
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif // defined(__GNUC__) || defined(__clang__)
 
 #if defined(_MSC_VER)
 #pragma warning(pop)


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->
UMF source code imports HWLOC headers that trigger unused parameter warnings, which are treated as errors. The UMF CI might not have caught this issue, but the UR CI did, possibly due to different HWLOC versions.

Logs: https://github.com/oneapi-src/unified-runtime/actions/runs/9701110619/job/26798893141?pr=1430

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->