### PR TITLE
Disable umf-provider_os_memory in sanitizers tests

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -68,7 +68,9 @@ jobs:
       working-directory: ${{env.BUILD_DIR}}
       run: > 
         ${{ matrix.compiler.cxx == 'icpx' && '. /opt/intel/oneapi/setvars.sh &&' || ''}}
-        ctest --output-on-failure
+        GTEST_FILTER="-*umfProviderTest.alloc_page64_align_0*" ctest --output-on-failure
+      # TO DO: fix umf-provider_os_memory test for sanitizers
+      # issue 581: https://github.com/oneapi-src/unified-memory-framework/issues/581
 
   windows-build:
     name: cl and clang-cl on Windows


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description
Disable umf-provider_os_memory in sanitizers tests for now due to https://github.com/oneapi-src/unified-memory-framework/issues/581
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly

