### PR TITLE
optimize qemu workflow

### DIFF
--- a/.github/workflows/pr_push.yml
+++ b/.github/workflows/pr_push.yml
@@ -200,6 +200,9 @@ jobs:
   Sanitizers:
     needs: [Spellcheck, FastBuild, CodeStyle]
     uses: ./.github/workflows/sanitizers.yml
+  Qemu:
+    needs: [Spellcheck, FastBuild, CodeStyle]
+    uses: ./.github/workflows/qemu.yml
   Benchmarks:
     needs: [Build]
     uses: ./.github/workflows/benchmarks.yml
@@ -209,9 +212,6 @@ jobs:
   GPU:
     needs: [Build]
     uses: ./.github/workflows/gpu.yml
-  Qemu:
-    needs: [Build]
-    uses: ./.github/workflows/qemu.yml
   Valgrind:
     needs: [Build]
     uses: ./.github/workflows/valgrind.yml

--- a/.github/workflows/qemu.yml
+++ b/.github/workflows/qemu.yml
@@ -4,7 +4,7 @@ name: Qemu
 on: workflow_call
 
 env:
-  CI_BRANCH : "${{ github.head_ref || github.ref_name }}"
+  CI_BRANCH: "${{ github.head_ref || github.ref_name }}"
 
 permissions:
   contents: read
@@ -13,19 +13,6 @@ jobs:
   qemu-build:
     name: Qemu
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        config: [{name: 'default', hmat: 'on'},
-                 { name: 'sock_2_var1', hmat: 'off'},
-                 { name: 'sock_2_var1_hmat', hmat: 'on'},
-                 { name: 'sock_2_var2', hmat: 'off'},
-                 { name: 'sock_2_var2_hmat', hmat: 'on'},
-                 { name: 'sock_2_var3', hmat: 'off'},
-                 { name: 'sock_2_var3_hmat', hmat: 'on'},
-                 { name: 'sock_4_var1', hmat: 'off'},
-                 { name: 'sock_4_var1_hmat', hmat: 'on'},
-                 { name: 'sock_4_var2', hmat: 'off'},
-                 { name: 'sock_4_var2_hmat', hmat: 'on'}]
 
     steps:
     - name: Checkout
@@ -83,33 +70,10 @@ jobs:
       run: wget https://cloud-images.ubuntu.com/releases/lunar/release/ubuntu-23.04-server-cloudimg-amd64.img
     - name: Resize image
       run: qemu-img resize ./ubuntu-23.04-server-cloudimg-amd64.img +4G
-    - name: Print qemu args
+    - name: Build
       run: |
-        # notice: should be sedded, but it hides status
-        python3 scripts/qemu/qemu_config.py scripts/qemu/configs/${{matrix.config.name}}.xml
-    - name: Run qemu
-      run: |
-        sudo qemu-system-x86_64 \
-        -drive file=./ubuntu-23.04-server-cloudimg-amd64.img,format=qcow2,index=0,media=disk,id=hd \
-        -cdrom ./ubuntu-cloud-init.iso \
-        -machine q35,usb=off,hmat=${{matrix.config.hmat}} \
-        -enable-kvm \
-        -net nic -net user,hostfwd=tcp::2222-:22 \
-        $(echo `python3 scripts/qemu/qemu_config.py scripts/qemu/configs/${{matrix.config.name}}.xml | sed s/''\''/'/g`) \
-        -daemonize -display none
-    - name: Run ssh keyscan
-      run: |
-        set +e
-        ssh-keyscan -p 2222 -H 127.0.0.1 >> ~/.ssh/known_hosts
-        while [ $? -ne 0 ]
-        do
-          echo "Trying to connect..."
-          ps -aux | grep qemu
-          sleep 5
-          ssh-keyscan -p 2222 -H 127.0.0.1 >> ~/.ssh/known_hosts
-        done
-    - name: Run build on qemu
-      run: |
+        scripts/qemu/start_qemu.sh scripts/qemu/configs/default.xml
+
         if [ ${{ github.event_name }} = 'pull_request' ]; then
             CI_REPO="${{ github.event.pull_request.head.repo.full_name }}"
         else
@@ -117,4 +81,29 @@ jobs:
         fi
 
         scp -P 2222 ${{github.workspace}}/scripts/qemu/run-build.sh cxltest@127.0.0.1:/home/cxltest
+        scp -P 2222 ${{github.workspace}}/scripts/qemu/run-tests.sh cxltest@127.0.0.1:/home/cxltest
         ssh cxltest@127.0.0.1 -p 2222 -t "bash /home/cxltest/run-build.sh https://github.com/$CI_REPO ${{env.CI_BRANCH}}"
+
+        ssh cxltest@127.0.0.1 -p 2222 -t "sudo shutdown -h now"
+
+    - name: Run tests
+      run: |
+        for config_file in scripts/qemu/configs/*.xml; do
+          config_name=$(basename $config_file .xml)
+
+          echo testing $config_name
+          while ps -aux | grep qemu-system-x86_64 | grep -q -v grep; do
+            echo "Waiting for QEMU to shut down..."
+            sleep 5
+          done
+          scripts/qemu/start_qemu.sh $config_file
+          
+          if [ ${{ github.event_name }} = 'pull_request' ]; then
+            CI_REPO="${{ github.event.pull_request.head.repo.full_name }}"
+          else
+            CI_REPO="$GITHUB_REPOSITORY"
+          fi
+
+          ssh cxltest@127.0.0.1 -p 2222 -t "bash /home/cxltest/run-tests.sh"
+          ssh cxltest@127.0.0.1 -p 2222 -t "sudo shutdown -h now"
+        done

--- a/scripts/qemu/run-tests.sh
+++ b/scripts/qemu/run-tests.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright (C) 2024 Intel Corporation
+# Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set -e
+
+# Drop caches, restores free memory on NUMA nodes
+echo password | sudo sync;
+echo password | sudo sh -c "/usr/bin/echo 3 > /proc/sys/vm/drop_caches"
+# Set ptrace value for IPC test
+echo password | sudo bash -c "echo 0 > /proc/sys/kernel/yama/ptrace_scope"
+
+numactl -H
+
+cd umf/build
+ctest --verbose
+
+# run tests bound to a numa node
+numactl -N 0 ctest --output-on-failure
+numactl -N 1 ctest --output-on-failure
+
+# run tests under valgrind
+echo "Running tests under valgrind memcheck ..."
+../test/test_valgrind.sh .. . memcheck
+

--- a/scripts/qemu/start_qemu.sh
+++ b/scripts/qemu/start_qemu.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright (C) 2024 Intel Corporation
+# Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set -x
+set -e
+
+config_file=$1
+
+python3 scripts/qemu/qemu_config.py $config_file
+
+if grep -q '<interconnects>' "$config_file"; then
+    hmat="on"
+else
+    hmat="off"
+fi
+
+sudo qemu-system-x86_64 \
+    -drive file=./ubuntu-23.04-server-cloudimg-amd64.img,format=qcow2,index=0,media=disk,id=hd \
+    -cdrom ./ubuntu-cloud-init.iso \
+    -machine q35,usb=off,hmat=$hmat \
+    -enable-kvm \
+    -net nic -net user,hostfwd=tcp::2222-:22 \
+    $(python3 scripts/qemu/qemu_config.py $config_file | sed s/''\''/'/g) \
+    -daemonize -display none
+
+until ssh-keyscan -p 2222 -H 127.0.0.1 >> ~/.ssh/known_hosts 2>/dev/null; do
+    echo "Waiting for SSH..."
+    sleep 1
+done


### PR DESCRIPTION
In short this PR merges all qemu workflow in one. We can reuse the same image and build project only one time. 
We reduce Runner utilization from ~55min to 25 min (+ we gain time wasted for runner to pickup work and start, which is not counted)
As a downside we reduce parallelize - we had 11 -  5 min jobs  now we have a single 25 min long job. 
It should not be a problem, as we are blocked by runner availability, so qemu workflow should finish anyway before all other jobs. But to limit negative influence of this change, i changed qemu workflow dependency, to start it sooner, and do not block other workflows. 