### PR TITLE
Add umfPoolGetIPCHandleSize API

### DIFF
--- a/include/umf/ipc.h
+++ b/include/umf/ipc.h
@@ -20,6 +20,14 @@ extern "C" {
 typedef struct umf_ipc_data_t *umf_ipc_handle_t;
 
 ///
+/// @brief Returns the size of IPC handles for the specified pool.
+/// @param hPool [in] Pool handle
+/// @param size [out] size of IPC handle in bytes.
+/// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
+umf_result_t umfPoolGetIPCHandleSize(umf_memory_pool_handle_t hPool,
+                                     size_t *size);
+
+///
 /// @brief Creates an IPC handle for the specified UMF allocation.
 /// @param ptr pointer to the allocated memory.
 /// @param ipcHandle [out] returned IPC handle.

--- a/src/libumf.def.in
+++ b/src/libumf.def.in
@@ -50,6 +50,7 @@ EXPORTS
     umfPoolCreateFromMemspace
     umfPoolDestroy
     umfPoolFree
+    umfPoolGetIPCHandleSize
     umfPoolGetLastAllocationError
     umfPoolGetMemoryProvider
     umfPoolMalloc

--- a/src/libumf.map
+++ b/src/libumf.map
@@ -50,6 +50,7 @@ UMF_1.0 {
         umfPoolCreateFromMemspace;
         umfPoolDestroy;
         umfPoolFree;
+        umfPoolGetIPCHandleSize;
         umfPoolGetLastAllocationError;
         umfPoolGetMemoryProvider;
         umfPoolMalloc;

--- a/test/ipcFixtures.hpp
+++ b/test/ipcFixtures.hpp
@@ -112,6 +112,13 @@ struct umfIpcTest : umf_test::test,
     MemoryAccessor *memAccessor = nullptr;
 };
 
+TEST_P(umfIpcTest, GetIPCHandleSize) {
+    size_t size = 0;
+    umf_result_t ret = umfPoolGetIPCHandleSize(pool.get(), &size);
+    EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
+    EXPECT_GT(size, 0);
+}
+
 TEST_P(umfIpcTest, BasicFlow) {
     constexpr size_t SIZE = 100;
     std::vector<int> expected_data(SIZE);


### PR DESCRIPTION
### Description
The MPI team requested this API. It allows to get the size of the IPC handle created by a particular pool.

### Checklist

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
- [x] New tests added, especially if they will fail without my changes