### PR TITLE
Suppress warning 28251 for intrin.h

### DIFF
--- a/src/utils/utils_windows_math.c
+++ b/src/utils/utils_windows_math.c
@@ -8,7 +8,19 @@
  */
 
 #include "utils_math.h"
+
+// disable warning 28251: "inconsistent annotation for function" thrown in
+// intrin.h, as we do not want to modify this file
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 28251)
+#endif // _MSC_VER
+
 #include <intrin.h>
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif // _MSC_VER
 
 #pragma intrinsic(_BitScanReverse)
 


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->
UR CI reports `C28251` warning in Windows header `intrin.h`.
Logs: https://github.com/intel/llvm/actions/runs/9781171173/job/27004776301?pr=13343.
### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

