### PR TITLE
0.1.0 release

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
-Tue Jun 25 2024 Łukasz Stolarczuk <lukasz.stolarczuk@intel.com>
+Thu Jul 04 2024 Łukasz Stolarczuk <lukasz.stolarczuk@intel.com>
 
-	* Version 0.1.0-rc1
+	* Version 0.1.0
 
 	This is the first release of Unified Memory Framework (UMF) project.
 

--- a/scripts/docs_config/conf.py
+++ b/scripts/docs_config/conf.py
@@ -22,7 +22,7 @@ copyright = "2023-2024, Intel"
 author = "Intel"
 
 # The full version, including alpha/beta/rc tags
-release = "0.1.0-rc1"
+release = "0.1.0"
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Drop the `-rc1` part and move to a final 0.1.0 release.

Once this PR is merged, the `v0.1.0` tag will be created.