### PR TITLE
Fix misspells in the repo

### DIFF
--- a/include/umf/memory_pool.h
+++ b/include/umf/memory_pool.h
@@ -147,7 +147,7 @@ umf_result_t umfFree(void *ptr);
 ///
 /// * The implementation of this function *should* be lock-free.
 /// @param hPool specified memory pool handle for which the last allocation error is returned
-/// @return Error code desciribng the failure of the last failed allocation operation.
+/// @return Error code describing the failure of the last failed allocation operation.
 ///         The value is undefined if the previous allocation was successful.
 ///
 umf_result_t umfPoolGetLastAllocationError(umf_memory_pool_handle_t hPool);

--- a/include/umf/memory_pool_ops.h
+++ b/include/umf/memory_pool_ops.h
@@ -116,7 +116,7 @@ typedef struct umf_memory_pool_ops_t {
     ///
     /// * The implementation of this function *should* be lock-free.
     /// @param pool pointer to the memory pool for which the last allocation error is returned
-    /// @return Error code desciribng the failure of the last failed allocation operation.
+    /// @return Error code describing the failure of the last failed allocation operation.
     ///         The value is undefined if the previous allocation was successful.
     ///
     umf_result_t (*get_last_allocation_error)(void *pool);

--- a/include/umf/mempolicy.h
+++ b/include/umf/mempolicy.h
@@ -22,9 +22,9 @@ typedef const struct umf_mempolicy_t *umf_const_mempolicy_handle_t;
 typedef enum umf_mempolicy_membind_t {
     /// Interleave memory from all memory in memspace
     UMF_MEMPOLICY_INTERLEAVE,
-    /// Bind memory to namespace
+    /// Bind memory to memspace
     UMF_MEMPOLICY_BIND,
-    /// Prefer memory from namespace but fallback to other memory if not available
+    /// Prefer memory from memspace but fallback to other memory if not available
     UMF_MEMPOLICY_PREFERRED,
     /// Allocation will be split evenly across nodes specified in nodemask.
     /// umf_mempolicy_split_partition_t can be used to specify different distribution.

--- a/scripts/docs_config/examples.rst
+++ b/scripts/docs_config/examples.rst
@@ -85,7 +85,7 @@ the :any:`umfPoolCreate` function::
     umfPoolCreate(pool_ops, provider, pool_params, flags, &pool);
 
 The ``pool`` has been created, we can allocate some memory now
-with ie. :any:`umfPoolCalloc`::
+with i.e. :any:`umfPoolCalloc`::
 
     size_t num = 1;
     alloc_size = 128;
@@ -169,7 +169,7 @@ to another process it can be opened by the :any:`umfOpenIPCHandle` function.
     void *mapped_buf = NULL;
     umf_result = umfOpenIPCHandle(consumer_pool, ipc_handle, &mapped_buf);
 
-The :any:`umfOpenIPCHandle` function requires the memory pool handle and the IPC handle as input parameters. It mapps
+The :any:`umfOpenIPCHandle` function requires the memory pool handle and the IPC handle as input parameters. It maps
 the handle to the current process address space and returns the pointer to the same memory region that was allocated
 in the producer process.
 

--- a/scripts/docs_config/introduction.rst
+++ b/scripts/docs_config/introduction.rst
@@ -139,7 +139,7 @@ Logging
 ============
 
 Logging in UMF is handled by logger. There are several levels of logging: *debug*, *info*, *warning*, and *error*.
-The level of logging determines what messages will be printed, ie. the level set to *warning* means all messages at levels *warning* and *error* will be printed.
+The level of logging determines what messages will be printed, i.e. the level set to *warning* means all messages at levels *warning* and *error* will be printed.
 
 By default, there is a guarantee that *error* messages are flushed immediately. One can change this behavior to flush on lower-level messages.
 

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -104,7 +104,7 @@ umf_result_t umfPutIPCHandle(umf_ipc_handle_t umfIPCHandle) {
     //       to upstream memory provider when umfMemoryProviderFree is called.
     //       To support incapsulation we should not take into account
     //       implementation details of tracking memory provider and find the
-    //       approrpiate pool, get memory provider of that pool and call
+    //       appropriate pool, get memory provider of that pool and call
     //       umfMemoryProviderPutIPCHandle(hProvider,
     //                                     umfIPCHandle->providerIpcData);
     umf_ba_global_free(umfIPCHandle);

--- a/src/libumf.h
+++ b/src/libumf.h
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023 Intel Corporation
+ * Copyright (C) 2023-2024 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -14,7 +14,7 @@
 extern "C" {
 #endif
 
-// initializes runtime state needed by the library (needed mostly for static libaries on windows)
+// initializes runtime state needed by the library (needed mostly for static libraries on Windows)
 void libumfInit(void);
 
 #ifdef __cplusplus

--- a/src/provider/provider_os_memory.c
+++ b/src/provider/provider_os_memory.c
@@ -580,7 +580,7 @@ static void os_finalize(void *provider) {
 static umf_result_t os_get_min_page_size(void *provider, void *ptr,
                                          size_t *page_size);
 
-// TODO: this function should be reenabled when CTL is implemented
+// TODO: this function should be re-enabled when CTL is implemented
 #if 0
 static void print_numa_nodes(os_memory_provider_t *os_provider, void *addr,
                              size_t size) {


### PR DESCRIPTION
most of them found by `codespell` and `sphinxcontrib-spelling`; other by hand