### PR TITLE
Do not run cmake inside ctest tests

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -9,6 +9,8 @@ permissions:
 env:
   # for installation testing - it should match with version set in CMake
   UMF_VERSION: 0.1.0
+  BUILD_DIR : "${{github.workspace}}/build"
+  INSTL_DIR : "${{github.workspace}}/../install-dir"
 
 jobs:
   ubuntu-build:
@@ -67,9 +69,6 @@ jobs:
             shared_library: 'ON'
             level_zero_provider: 'ON'
             install_tbb: 'OFF'
-    env:
-      BUILD_DIR : "${{github.workspace}}/build/"
-      INSTL_DIR : "${{github.workspace}}/../install-dir"
     runs-on: ${{matrix.os}}
 
     steps:
@@ -131,6 +130,9 @@ jobs:
         ${{ matrix.compiler.cxx == 'icpx' && '. /opt/intel/oneapi/setvars.sh &&' || ''}} 
         ctest --output-on-failure --test-dir test
 
+    - name: Remove the installation directory
+      run: rm -rf ${{env.INSTL_DIR}}
+
     - name: Test UMF installation and uninstallation
       # The '--shared-library' parameter is added to the installation test when the UMF is built as a shared library
       run: >
@@ -148,8 +150,6 @@ jobs:
     name: Windows
     env:
       VCPKG_PATH: "${{github.workspace}}/build/vcpkg/packages/hwloc_x64-windows;${{github.workspace}}/build/vcpkg/packages/tbb_x64-windows;${{github.workspace}}/build/vcpkg/packages/jemalloc_x64-windows"
-      BUILD_DIR : "${{github.workspace}}/build/"
-      INSTL_DIR : "${{github.workspace}}/../install-dir"
     strategy:
       matrix:
         os: ['windows-2019', 'windows-2022']
@@ -185,7 +185,7 @@ jobs:
       uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5
       with:
         vcpkgGitCommitId: 3dd44b931481d7a8e9ba412621fa810232b66289
-        vcpkgDirectory: ${{github.workspace}}/build/vcpkg
+        vcpkgDirectory: ${{env.BUILD_DIR}}/vcpkg
         vcpkgJsonGlob: '**/vcpkg.json'
 
     - name: Install dependencies
@@ -197,6 +197,7 @@ jobs:
         cmake
         -B ${{env.BUILD_DIR}}
         ${{matrix.toolset}}
+        -DCMAKE_INSTALL_PREFIX="${{env.INSTL_DIR}}"
         -DCMAKE_PREFIX_PATH="${{env.VCPKG_PATH}}"
         -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
         -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
@@ -230,18 +231,16 @@ jobs:
         
     - name: check /DEPENDENTLOADFLAG in umf.dll
       if: ${{matrix.shared_library == 'ON' && matrix.compiler.cxx == 'cl'}}
-      run: ${{github.workspace}}/.github/scripts/check_dll_flags.ps1 ${{github.workspace}}/build/bin/${{matrix.build_type}}/umf.dll
+      run: ${{github.workspace}}/.github/scripts/check_dll_flags.ps1 ${{env.BUILD_DIR}}/bin/${{matrix.build_type}}/umf.dll
       shell: pwsh
 
     - name: check /DEPENDENTLOADFLAG in umf_proxy.dll
       if: ${{matrix.compiler.cxx == 'cl'}}
-      run: ${{github.workspace}}/.github/scripts/check_dll_flags.ps1 ${{github.workspace}}/build/src/proxy_lib/${{matrix.build_type}}/umf_proxy.dll
+      run: ${{github.workspace}}/.github/scripts/check_dll_flags.ps1 ${{env.BUILD_DIR}}/src/proxy_lib/${{matrix.build_type}}/umf_proxy.dll
       shell: pwsh
 
   windows-dynamic_build_hwloc:
     name: "Windows dynamic UMF + static hwloc"
-    env:
-      BUILD_DIR : "${{github.workspace}}/build"
     strategy:
       matrix:
         build_type: [Release]
@@ -256,6 +255,7 @@ jobs:
       run: >
         cmake
         -B ${{env.BUILD_DIR}}
+        -DCMAKE_INSTALL_PREFIX="${{env.INSTL_DIR}}"
         -DUMF_BUILD_SHARED_LIBRARY=ON
         -DUMF_BUILD_EXAMPLES=OFF
         -DUMF_FORMAT_CODE_STYLE=OFF
@@ -276,13 +276,11 @@ jobs:
       # we check umf.dll only here - note that the proxy library is disabled in
       # this configuration
     - name: check /DEPENDENTLOADFLAG in umf.dll
-      run: ${{github.workspace}}/.github/scripts/check_dll_flags.ps1 ${{github.workspace}}/build/bin/${{matrix.build_type}}/umf.dll
+      run: ${{github.workspace}}/.github/scripts/check_dll_flags.ps1 ${{env.BUILD_DIR}}/bin/${{matrix.build_type}}/umf.dll
       shell: pwsh
 
   windows-static_build_hwloc:
     name: "Windows static UMF + static hwloc"
-    env:
-      BUILD_DIR : "${{github.workspace}}/build"
     strategy:
       matrix:
         build_type: [Release]
@@ -297,6 +295,7 @@ jobs:
       run: >
         cmake
         -B ${{env.BUILD_DIR}}
+        -DCMAKE_INSTALL_PREFIX="${{env.INSTL_DIR}}"
         -DUMF_BUILD_SHARED_LIBRARY=OFF
         -DUMF_BUILD_EXAMPLES=OFF
         -DUMF_FORMAT_CODE_STYLE=OFF
@@ -320,8 +319,6 @@ jobs:
       matrix:
         os: ['macos-12', 'macos-13']
     env:
-      BUILD_DIR : "${{github.workspace}}/build/"
-      INSTL_DIR : "${{github.workspace}}/../install-dir"
       BUILD_TYPE : "Release"
     runs-on: ${{matrix.os}}
 
@@ -339,6 +336,7 @@ jobs:
       run: >
         cmake
         -B ${{env.BUILD_DIR}}
+        -DCMAKE_INSTALL_PREFIX="${{env.INSTL_DIR}}"
         -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
         -DUMF_FORMAT_CODE_STYLE=OFF
         -DUMF_DEVELOPER_MODE=ON

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -6,11 +6,14 @@ on: workflow_call
 permissions:
   contents: read
 
+env:
+  BUILD_DIR : "${{github.workspace}}/build"
+  INSTL_DIR : "${{github.workspace}}/../install-dir"
+
 jobs:
   benchmarks:
     name: Benchmarks
     env:
-      BUILD_DIR : "${{github.workspace}}/build/"
       VCPKG_PATH: "${{github.workspace}}/build/vcpkg/packages/hwloc_x64-windows;${{github.workspace}}/build/vcpkg/packages/tbb_x64-windows;${{github.workspace}}/build/vcpkg/packages/jemalloc_x64-windows"
     strategy:
       matrix:
@@ -49,6 +52,7 @@ jobs:
           cmake
           -B ${{env.BUILD_DIR}}
           ${{matrix.extra_build_option}}
+          -DCMAKE_INSTALL_PREFIX="${{env.INSTL_DIR}}"
           -DCMAKE_PREFIX_PATH="${{env.VCPKG_PATH}}"
           -DUMF_BUILD_SHARED_LIBRARY=ON
           -DUMF_BUILD_BENCHMARKS=ON

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,10 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  BUILD_DIR : "${{github.workspace}}/build"
+  INSTL_DIR : "${{github.workspace}}/../install-dir"
+
 jobs:
   analyze:
     name: Analyze
@@ -50,7 +54,7 @@ jobs:
       uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5
       with:
         vcpkgGitCommitId: 3dd44b931481d7a8e9ba412621fa810232b66289
-        vcpkgDirectory: ${{github.workspace}}/build/vcpkg
+        vcpkgDirectory: ${{env.BUILD_DIR}}/vcpkg
         vcpkgJsonGlob: '**/vcpkg.json'
 
     - name: Install dependencies
@@ -70,8 +74,9 @@ jobs:
     - name: Configure CMake
       run: >
         cmake
-        -B ${{github.workspace}}/build
+        -B ${{env.BUILD_DIR}}
         ${{matrix.extra_build_option}}
+        -DCMAKE_INSTALL_PREFIX="${{env.INSTL_DIR}}"
         -DCMAKE_PREFIX_PATH="${{env.VCPKG_PATH}}"
         -DUMF_FORMAT_CODE_STYLE=OFF
         -DUMF_DEVELOPER_MODE=ON
@@ -80,7 +85,7 @@ jobs:
         -DUMF_TESTS_FAIL_ON_SKIP=ON
 
     - name: Build
-      run: cmake --build ${{github.workspace}}/build --config Release -j
+      run: cmake --build ${{env.BUILD_DIR}} --config Release -j
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@b7bf0a3ed3ecfa44160715d7c442788f65f0f923 # v3.23.2

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -6,6 +6,10 @@ on: workflow_call
 permissions:
   contents: read
 
+env:
+  BUILD_DIR : "${{github.workspace}}/build"
+  INSTL_DIR : "${{github.workspace}}/../install-dir"
+
 jobs:
   FastBuild:
     name: Fast builds
@@ -61,7 +65,7 @@ jobs:
       uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5
       with:
         vcpkgGitCommitId: 3dd44b931481d7a8e9ba412621fa810232b66289
-        vcpkgDirectory: ${{github.workspace}}/build/vcpkg
+        vcpkgDirectory: ${{env.BUILD_DIR}}/vcpkg
         vcpkgJsonGlob: '**/vcpkg.json'
 
     - name: Install dependencies
@@ -90,7 +94,8 @@ jobs:
       if: matrix.simple_cmake == 'OFF'
       run: >
         cmake
-        -B ${{github.workspace}}/build
+        -B ${{env.BUILD_DIR}}
+        -DCMAKE_INSTALL_PREFIX="${{env.INSTL_DIR}}"
         -DCMAKE_PREFIX_PATH="${{env.VCPKG_PATH}}"
         -DUMF_FORMAT_CODE_STYLE=OFF
         -DUMF_DEVELOPER_MODE=ON
@@ -107,29 +112,30 @@ jobs:
       if: matrix.simple_cmake == 'ON'
       run: >
         cmake
-        -B ${{github.workspace}}/build
+        -B ${{env.BUILD_DIR}}
+        -DCMAKE_INSTALL_PREFIX="${{env.INSTL_DIR}}"
         -DUMF_BUILD_SHARED_LIBRARY=ON
         -DUMF_TESTS_FAIL_ON_SKIP=ON
         ${{matrix.extra_build_options}}
 
     - name: Build
-      run: cmake --build ${{github.workspace}}/build --config Release -j
+      run: cmake --build ${{env.BUILD_DIR}} --config Release -j
 
     - name: Run examples
-      working-directory: ${{github.workspace}}/build
+      working-directory: ${{env.BUILD_DIR}}
       run: ctest --output-on-failure --test-dir examples -C Release
 
     - name: Run tests
       if: matrix.build_tests == 'ON'
-      working-directory: ${{github.workspace}}/build
+      working-directory: ${{env.BUILD_DIR}}
       run: ctest --output-on-failure --test-dir test -C Release
 
     - name: check /DEPENDENTLOADFLAG (Windows only)
       if: matrix.os == 'windows-latest'
-      run: ${{github.workspace}}/.github/scripts/check_dll_flags.ps1 ${{github.workspace}}/build/bin/Release/umf.dll
+      run: ${{github.workspace}}/.github/scripts/check_dll_flags.ps1 ${{env.BUILD_DIR}}/bin/Release/umf.dll
       shell: pwsh
 
     - name: check /DEPENDENTLOADFLAG in umf_proxy.dll
       if: matrix.os == 'windows-latest'
-      run: ${{github.workspace}}/.github/scripts/check_dll_flags.ps1 ${{github.workspace}}/build/src/proxy_lib/Release/umf_proxy.dll
+      run: ${{github.workspace}}/.github/scripts/check_dll_flags.ps1 ${{env.BUILD_DIR}}/src/proxy_lib/Release/umf_proxy.dll
       shell: pwsh

--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -8,6 +8,10 @@ on: [workflow_call]
 permissions:
   contents: read
 
+env:
+  BUILD_DIR : "${{github.workspace}}/build"
+  INSTL_DIR : "${{github.workspace}}/../install-dir"
+
 jobs:
   gpu:
     name: Build
@@ -42,7 +46,8 @@ jobs:
         run: >
           cmake
           -DCMAKE_PREFIX_PATH="${{env.VCPKG_PATH}}"
-          -B ${{github.workspace}}/build
+          -B ${{env.BUILD_DIR}}
+          -DCMAKE_INSTALL_PREFIX="${{env.INSTL_DIR}}"
           -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
           -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
           -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
@@ -62,7 +67,8 @@ jobs:
         if: matrix.os == 'Ubuntu'
         run: >
           cmake
-          -B ${{github.workspace}}/build
+          -B ${{env.BUILD_DIR}}
+          -DCMAKE_INSTALL_PREFIX="${{env.INSTL_DIR}}"
           -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
           -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
           -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
@@ -79,16 +85,16 @@ jobs:
           -DUMF_TESTS_FAIL_ON_SKIP=ON
 
       - name: Build UMF
-        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} -j ${{matrix.number_of_processors}}
+        run: cmake --build ${{env.BUILD_DIR}} --config ${{env.BUILD_TYPE}} -j ${{matrix.number_of_processors}}
 
       - name: Run tests
-        working-directory: ${{github.workspace}}/build
+        working-directory: ${{env.BUILD_DIR}}
         run: ctest -C ${{env.BUILD_TYPE}} --output-on-failure --test-dir test
 
       - name: Run examples
-        working-directory: ${{github.workspace}}/build
+        working-directory: ${{env.BUILD_DIR}}
         run: ctest --output-on-failure --test-dir examples -C ${{env.BUILD_TYPE}}
 
       - name: Run benchmarks
-        working-directory: ${{github.workspace}}/build
+        working-directory: ${{env.BUILD_DIR}}
         run: ctest --output-on-failure --test-dir benchmark -C ${{env.BUILD_TYPE}} --exclude-regex umf-bench-multithreaded

--- a/.github/workflows/proxy_lib.yml
+++ b/.github/workflows/proxy_lib.yml
@@ -6,6 +6,10 @@ on: workflow_call
 permissions:
   contents: read
 
+env:
+  BUILD_DIR : "${{github.workspace}}/build"
+  INSTL_DIR : "${{github.workspace}}/../install-dir"
+
 jobs:
   proxy-ubuntu:
     name: Ubuntu
@@ -33,7 +37,8 @@ jobs:
       - name: Configure build
         run: >
           cmake
-          -B ${{github.workspace}}/build
+          -B ${{env.BUILD_DIR}}
+          -DCMAKE_INSTALL_PREFIX="${{env.INSTL_DIR}}"
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
           -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
           -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
@@ -48,20 +53,20 @@ jobs:
           -DUMF_PROXY_LIB_BASED_ON_POOL=${{matrix.proxy_lib_pool}}
 
       - name: Build UMF
-        run: cmake --build ${{github.workspace}}/build -j $(nproc)
+        run: cmake --build ${{env.BUILD_DIR}} -j $(nproc)
 
       - name: Run "ctest --output-on-failure" with proxy library
-        working-directory: ${{github.workspace}}/build
+        working-directory: ${{env.BUILD_DIR}}
         run: LD_PRELOAD=./lib/libumf_proxy.so ctest --output-on-failure
 
       - name: Run "./test/umf_test-memoryPool" with proxy library
-        working-directory: ${{github.workspace}}/build
+        working-directory: ${{env.BUILD_DIR}}
         run: LD_PRELOAD=./lib/libumf_proxy.so ./test/umf_test-memoryPool
 
       - name: Run "/usr/bin/ls" with proxy library
-        working-directory: ${{github.workspace}}/build
+        working-directory: ${{env.BUILD_DIR}}
         run: LD_PRELOAD=./lib/libumf_proxy.so /usr/bin/ls
 
       - name: Run "/usr/bin/date" with proxy library
-        working-directory: ${{github.workspace}}/build
+        working-directory: ${{env.BUILD_DIR}}
         run: LD_PRELOAD=./lib/libumf_proxy.so /usr/bin/date

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -4,7 +4,8 @@ name: Sanitizers
 on: workflow_call
 
 env:
-  BUILD_DIR : "${{github.workspace}}/build/"
+  BUILD_DIR : "${{github.workspace}}/build"
+  INSTL_DIR : "${{github.workspace}}/../install-dir"
 
 permissions:
   contents: read
@@ -46,6 +47,7 @@ jobs:
         ${{ matrix.compiler.cxx == 'icpx' && '. /opt/intel/oneapi/setvars.sh &&' || ''}} 
         cmake
         -B ${{env.BUILD_DIR}}
+        -DCMAKE_INSTALL_PREFIX="${{env.INSTL_DIR}}"
         -DCMAKE_BUILD_TYPE=Debug
         -DUMF_BUILD_SHARED_LIBRARY=OFF
         -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
@@ -103,7 +105,7 @@ jobs:
       uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5
       with:
         vcpkgGitCommitId: 3dd44b931481d7a8e9ba412621fa810232b66289
-        vcpkgDirectory: ${{github.workspace}}/build/vcpkg
+        vcpkgDirectory: ${{env.BUILD_DIR}}/vcpkg
         vcpkgJsonGlob: '**/vcpkg.json'
 
     - name: Install dependencies
@@ -115,6 +117,7 @@ jobs:
       run: >
         cmake
         -B ${{env.BUILD_DIR}}
+        -DCMAKE_INSTALL_PREFIX="${{env.INSTL_DIR}}"
         -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
         -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
         -DCMAKE_PREFIX_PATH="${{env.VCPKG_PATH}}"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -431,7 +431,7 @@ if(LINUX
         NAME umf_standalone_examples
         COMMAND
             ${UMF_CMAKE_SOURCE_DIR}/test/test_examples.sh
-            ${UMF_CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR}
-            ${CMAKE_BINARY_DIR}/install ${EXAMPLES}
+            ${UMF_CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} ${CMAKE_INSTALL_PREFIX}
+            ${EXAMPLES}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 endif()

--- a/test/test_examples.sh
+++ b/test/test_examples.sh
@@ -47,7 +47,6 @@ cd ${BUILD_DIR}
 echo "DIR=$(pwd)"
 
 set -x
-cmake .. -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR"
 make -j$(nproc) install
 set +x
 


### PR DESCRIPTION
### Description

1) Set `CMAKE_INSTALL_PREFIX` in all CI builds.
2) Clean up setting and using of `env.BUILD_DIR`.
3) Do not run cmake inside ctest tests.

Ref: https://github.com/oneapi-src/unified-memory-framework/pull/599/files#r1670260245

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
