### PR TITLE
Define UMF_SRC_VERSION in the proxy library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,7 +81,7 @@ set(UMF_SOURCES_WINDOWS libumf_windows.c)
 # Compile definitions for UMF library.
 #
 # TODO: Cleanup the compile definitions across all the CMake files
-set(UMF_PRIVATE_COMPILE_DEFINITIONS "-DUMF_SRC_VERSION=${UMF_SRC_VERSION}")
+set(UMF_PRIVATE_COMPILE_DEFINITIONS UMF_SRC_VERSION=${UMF_SRC_VERSION})
 
 set(UMF_SOURCES_COMMON_LINUX_MACOSX
     provider/provider_os_memory.c

--- a/src/proxy_lib/CMakeLists.txt
+++ b/src/proxy_lib/CMakeLists.txt
@@ -39,6 +39,8 @@ add_library(${PROJECT_NAME}::proxy ALIAS umf_proxy)
 
 target_link_directories(umf_proxy PRIVATE ${LIBHWLOC_LIBRARY_DIRS})
 
+target_compile_definitions(umf_proxy PRIVATE UMF_SRC_VERSION=${UMF_SRC_VERSION})
+
 if(PROXY_LIB_USES_SCALABLE_POOL)
     target_compile_definitions(umf_proxy PRIVATE PROXY_LIB_USES_SCALABLE_POOL=1)
 elseif(PROXY_LIB_USES_JEMALLOC_POOL)


### PR DESCRIPTION
### Description

Define `UMF_SRC_VERSION` in the proxy library.
It enables printing out the source version in `util_log_init()`.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
