### PR TITLE
Disable warning 28251: Inconsistent annotation for _BitScanForward

### DIFF
--- a/src/utils/utils_concurrency.h
+++ b/src/utils/utils_concurrency.h
@@ -14,6 +14,10 @@
 
 #ifdef _WIN32
 #include <windows.h>
+
+#include "utils_windows_intrin.h"
+
+#pragma intrinsic(_BitScanForward64)
 #else
 #include <pthread.h>
 

--- a/src/utils/utils_windows_intrin.h
+++ b/src/utils/utils_windows_intrin.h
@@ -1,0 +1,26 @@
+/*
+ *
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ */
+
+#ifndef UMF_UTILS_WINDOWS_INTRIN_H
+#define UMF_UTILS_WINDOWS_INTRIN_H 1
+
+#ifdef _WIN32
+
+// Disable warning 28251: "inconsistent annotation for function" thrown in
+// intrin.h, as we do not want to modify this file.
+#pragma warning(push)
+#pragma warning(disable : 28251)
+
+#include <intrin.h>
+
+#pragma warning(pop)
+
+#endif /* _WIN32 */
+
+#endif /* UMF_UTILS_WINDOWS_INTRIN_H */

--- a/src/utils/utils_windows_math.c
+++ b/src/utils/utils_windows_math.c
@@ -8,19 +8,7 @@
  */
 
 #include "utils_math.h"
-
-// disable warning 28251: "inconsistent annotation for function" thrown in
-// intrin.h, as we do not want to modify this file
-#if defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 28251)
-#endif // _MSC_VER
-
-#include <intrin.h>
-
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif // _MSC_VER
+#include "utils_windows_intrin.h"
 
 #pragma intrinsic(_BitScanReverse)
 


### PR DESCRIPTION
### Description

Disable warning 28251: Inconsistent annotation for `_BitScanForward` in `utils_concurrency.h`.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
