### PR TITLE
Add disable_provider_free parameter to pool jemalloc

### DIFF
--- a/include/umf/pools/pool_jemalloc.h
+++ b/include/umf/pools/pool_jemalloc.h
@@ -14,7 +14,14 @@
 extern "C" {
 #endif
 
+#include <stdbool.h>
 #include <umf/memory_pool_ops.h>
+
+/// @brief Configuration of Jemalloc Pool
+typedef struct umf_jemalloc_pool_params_t {
+    /// Set to true if umfMemoryProviderFree() should never be called.
+    bool disable_provider_free;
+} umf_jemalloc_pool_params_t;
 
 umf_memory_pool_ops_t *umfJemallocPoolOps(void);
 


### PR DESCRIPTION
### Description

Add the `disable_provider_free ` parameter to pool jemalloc. It should be set to true if `umfMemoryProviderFree()` should never be called.

This option will be needed by the future memory providers that will not provide the free() op.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
