### PR TITLE
Fix disjoint pool memory poison macro

### DIFF
--- a/src/pool/pool_disjoint.cpp
+++ b/src/pool/pool_disjoint.cpp
@@ -40,14 +40,14 @@
 
 static inline void annotate_memory_inaccessible([[maybe_unused]] void *ptr,
                                                 [[maybe_unused]] size_t size) {
-#ifdef POISON_MEMORY
+#if (POISON_MEMORY != 0)
     utils_annotate_memory_inaccessible(ptr, size);
 #endif
 }
 
 static inline void annotate_memory_undefined([[maybe_unused]] void *ptr,
                                              [[maybe_unused]] size_t size) {
-#ifdef POISON_MEMORY
+#if (POISON_MEMORY != 0)
     utils_annotate_memory_undefined(ptr, size);
 #endif
 }


### PR DESCRIPTION
The poison memory macro definition is always defined, so an #ifdef check is insufficient.

<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
