### PR TITLE
Skip tests requiring NUMA if NUMA is not supported

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -167,6 +167,8 @@ else()
 endif()
 
 if(LINUX)
+    set(UMF_TEST_SKIP_RETURN_CODE 125)
+
     set(EXAMPLE_NAME umf_example_memspace_numa)
 
     add_umf_executable(
@@ -175,8 +177,10 @@ if(LINUX)
         LIBS umf ${LIBHWLOC_LIBRARIES} numa)
 
     target_include_directories(
-        ${EXAMPLE_NAME} PRIVATE ${UMF_CMAKE_SOURCE_DIR}/src/utils
-                                ${UMF_CMAKE_SOURCE_DIR}/include)
+        ${EXAMPLE_NAME}
+        PRIVATE ${UMF_CMAKE_SOURCE_DIR}/src/utils
+                ${UMF_CMAKE_SOURCE_DIR}/include
+                ${UMF_CMAKE_SOURCE_DIR}/examples/common)
 
     target_link_directories(${EXAMPLE_NAME} PRIVATE ${LIBHWLOC_LIBRARY_DIRS})
 
@@ -184,6 +188,9 @@ if(LINUX)
         NAME ${EXAMPLE_NAME}
         COMMAND ${EXAMPLE_NAME}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+    set_tests_properties(${EXAMPLE_NAME} PROPERTIES
+                         SKIP_RETURN_CODE ${UMF_TEST_SKIP_RETURN_CODE})
 
     set(EXAMPLE_NAME umf_example_memspace_hmat)
 
@@ -193,8 +200,10 @@ if(LINUX)
         LIBS umf ${LIBHWLOC_LIBRARIES} numa)
 
     target_include_directories(
-        ${EXAMPLE_NAME} PRIVATE ${UMF_CMAKE_SOURCE_DIR}/src/utils
-                                ${UMF_CMAKE_SOURCE_DIR}/include)
+        ${EXAMPLE_NAME}
+        PRIVATE ${UMF_CMAKE_SOURCE_DIR}/src/utils
+                ${UMF_CMAKE_SOURCE_DIR}/include
+                ${UMF_CMAKE_SOURCE_DIR}/examples/common)
 
     target_link_directories(${EXAMPLE_NAME} PRIVATE ${LIBHWLOC_LIBRARY_DIRS})
 
@@ -203,7 +212,8 @@ if(LINUX)
         COMMAND ${EXAMPLE_NAME}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-    set_tests_properties(${EXAMPLE_NAME} PROPERTIES SKIP_RETURN_CODE 125)
+    set_tests_properties(${EXAMPLE_NAME} PROPERTIES
+                         SKIP_RETURN_CODE ${UMF_TEST_SKIP_RETURN_CODE})
     set(EXAMPLE_NAME umf_example_file_provider)
 
     add_umf_executable(

--- a/examples/common/utils_examples.h
+++ b/examples/common/utils_examples.h
@@ -1,0 +1,16 @@
+/*
+ *
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ */
+
+#ifndef UMF_EXAMPLE_UTILS_H
+#define UMF_EXAMPLE_UTILS_H
+
+// Needed for CI
+#define TEST_SKIP_ERROR_CODE 125
+
+#endif /* UMF_EXAMPLE_UTILS_H */

--- a/examples/memspace/memspace_hmat.c
+++ b/examples/memspace/memspace_hmat.c
@@ -15,8 +15,7 @@
 #include <stdio.h>
 #include <string.h>
 
-// Needed for CI
-#define test_skip_error_code 125
+#include "utils_examples.h"
 
 // Function to create a memory provider which allocates memory from the specified NUMA node
 int createMemoryProvider(umf_memory_provider_handle_t *hProvider,
@@ -63,13 +62,13 @@ int main(void) {
     // Check if NUMA is available
     if (numa_available() < 0) {
         fprintf(stderr, "NUMA is not available on this system.\n");
-        return -1;
+        return TEST_SKIP_ERROR_CODE;
     }
 
     // Create the memory provider that allocates memory from the highest bandwidth numa nodes
     ret = createMemoryProvider(&hProvider, umfMemspaceHighestBandwidthGet());
     if (ret != UMF_RESULT_SUCCESS) {
-        return ret == 1 ? test_skip_error_code : -1;
+        return ret == 1 ? TEST_SKIP_ERROR_CODE : -1;
     }
 
     // Allocate memory from the memory provider

--- a/examples/memspace/memspace_numa.c
+++ b/examples/memspace/memspace_numa.c
@@ -15,6 +15,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "utils_examples.h"
+
 // Function to create a memory provider which allocates memory from the specified NUMA node
 int createMemoryProvider(umf_memory_provider_handle_t *hProvider,
                          unsigned numa) {
@@ -65,7 +67,7 @@ int main(void) {
     // Check if NUMA is available
     if (numa_available() < 0) {
         fprintf(stderr, "NUMA is not available on this system.\n");
-        return -1;
+        return TEST_SKIP_ERROR_CODE;
     }
 
     // Create the memory provider that allocates memory from the specified NUMA node

--- a/test/common/test_helpers.h
+++ b/test/common/test_helpers.h
@@ -19,6 +19,9 @@
 extern "C" {
 #endif
 
+// Needed for CI
+#define TEST_SKIP_ERROR_CODE 125
+
 static inline void UT_FATAL(const char *format, ...) {
     va_list args_list;
     va_start(args_list, format);

--- a/test/memspaces/memspace_fixtures.hpp
+++ b/test/memspaces/memspace_fixtures.hpp
@@ -30,7 +30,7 @@ struct numaNodesTest : ::umf_test::test {
         ::umf_test::test::SetUp();
 
         if (numa_available() == -1 || numa_all_nodes_ptr == nullptr) {
-            GTEST_FAIL() << "Failed to initialize libnuma";
+            GTEST_SKIP() << "No available NUMA support; skipped";
         }
 
         int maxNode = numa_max_node();
@@ -58,6 +58,10 @@ struct memspaceGetTest : ::numaNodesTest,
                          ::testing::WithParamInterface<memspaceGetParams> {
     void SetUp() override {
         ::numaNodesTest::SetUp();
+
+        if (numa_available() == -1 || numa_all_nodes_ptr == nullptr) {
+            GTEST_SKIP() << "No available NUMA support; skipped";
+        }
 
         auto [isQuerySupported, memspaceGet] = this->GetParam();
 

--- a/test/memspaces/memspace_numa.cpp
+++ b/test/memspaces/memspace_numa.cpp
@@ -14,6 +14,10 @@ struct memspaceNumaTest : ::numaNodesTest {
     void SetUp() override {
         ::numaNodesTest::SetUp();
 
+        if (numa_available() == -1) {
+            GTEST_SKIP() << "NUMA not supported on this system; test skipped";
+        }
+
         umf_result_t ret = umfMemspaceCreateFromNumaArray(
             nodeIds.data(), nodeIds.size(), &hMemspace);
         ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
@@ -33,6 +37,10 @@ struct memspaceNumaTest : ::numaNodesTest {
 struct memspaceNumaProviderTest : ::memspaceNumaTest {
     void SetUp() override {
         ::memspaceNumaTest::SetUp();
+
+        if (numa_available() == -1) {
+            GTEST_SKIP() << "NUMA not supported on this system; test skipped";
+        }
 
         umf_result_t ret =
             umfMemoryProviderCreateFromMemspace(hMemspace, nullptr, &hProvider);


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->
Checks with numa_available() whether NUMA is supported on the system, then runs tests requiring NUMA according to the result. 

- Adds GTEST_SKIP() or substitutes GTEST_FAIL() with GTEST_SKIP() if failure has been determined by the lack of NUMA support;
- removes UT_ASSERTs checking for NUMA if NUMA support has been checked in the test fixture;
- allows uninstantiated tests in /test/provider_os_memory_multiple_numa_nodes.cpp, which suppresses failures caused by GoogleTestVerification test suite - the potentially uninstantiated tests are never run but skipped by the fixture if NUMA is not supported
- a helper function get_available_numa_nodes() in /test/provider_os_memory_multiple_numa_nodes.cpp returns an empty vector in case of lacking NUMA support (which causes tests to be uninstantiated)
- in examples/memspace, in case of NUMA not supported, the exit code is 0, however, the error message can be displayed with `ctest --verbose` instead of `ctest --output-on-failure`

Fixes #635 

Yours first customer ❤️ 
### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used

