### PR TITLE
[CMake] Don't use CMAKE_SOURCE_DIR during install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -599,10 +599,10 @@ endif()
 # --------------------------------------------------------------------------- #
 # Configure make install/uninstall and packages
 # --------------------------------------------------------------------------- #
-install(FILES ${CMAKE_SOURCE_DIR}/LICENSE.TXT
+install(FILES ${PROJECT_SOURCE_DIR}/LICENSE.TXT
         DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME}/")
 install(
-    FILES ${CMAKE_SOURCE_DIR}/licensing/third-party-programs.txt
+    FILES ${PROJECT_SOURCE_DIR}/licensing/third-party-programs.txt
     DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME}/licensing/")
 
 install(DIRECTORY examples DESTINATION "${CMAKE_INSTALL_DOCDIR}")


### PR DESCRIPTION
Referring to an installed file using `CMAKE_SOURCE_DIR` only works when UMF is built and installed standalone, but not when it's included by other projects.

Only `LICENSE.TXT` and `licensing/third-party-programs.txt` still had these issue, while other files already used `PROJECT_SOURCE_DIR`.

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [ ] CI workflows execute properly