### PR TITLE
commits for 0.9x rc3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -599,10 +599,10 @@ endif()
 # --------------------------------------------------------------------------- #
 # Configure make install/uninstall and packages
 # --------------------------------------------------------------------------- #
-install(FILES ${CMAKE_SOURCE_DIR}/LICENSE.TXT
+install(FILES ${PROJECT_SOURCE_DIR}/LICENSE.TXT
         DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME}/")
 install(
-    FILES ${CMAKE_SOURCE_DIR}/licensing/third-party-programs.txt
+    FILES ${PROJECT_SOURCE_DIR}/licensing/third-party-programs.txt
     DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME}/licensing/")
 
 install(DIRECTORY examples DESTINATION "${CMAKE_INSTALL_DOCDIR}")


### PR DESCRIPTION
#656 commit: [CMake] Don't use CMAKE_SOURCE_DIR during install 