### PR TITLE
Disable opencl, cuda and nvml when configuring hwloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,8 @@ elseif(NOT UMF_DISABLE_HWLOC)
         COMMAND
             ./configure --prefix=${hwloc_targ_BINARY_DIR} --enable-static=yes
             --enable-shared=no --disable-libxml2 --disable-levelzero
-            CFLAGS=-fPIC CXXFLAGS=-fPIC
+            --disable-opencl --disable-cuda --disable-nvml CFLAGS=-fPIC
+            CXXFLAGS=-fPIC
         WORKING_DIRECTORY ${hwloc_targ_SOURCE_DIR}
         OUTPUT ${hwloc_targ_SOURCE_DIR}/Makefile
         DEPENDS ${hwloc_targ_SOURCE_DIR}/configure)


### PR DESCRIPTION
Without explicitly disabling them and if a system where hwloc is being build has opencl/cuda/nvml installed those libraries will become hwloc dependencies which would force umf to link with them.

The problem manifested on a system where opencl was installed and umf compilation failed due to missing clGetDevices symbol.
