### PR TITLE
[CI] Run Coverity only on upstream

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -18,6 +18,8 @@ permissions:
 jobs:
   coverity:
     name: Coverity
+    # run only on upstream; forks do not know Username/Password
+    if: github.repository == 'oneapi-src/unified-memory-framework'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository


### PR DESCRIPTION
### Description

Run Coverity only on upstream.
Forks do not know Username/Password.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
