### PR TITLE
Minor fixes around hwloc in CMake and CI

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -32,24 +32,32 @@ jobs:
             shared_library: 'OFF'
             level_zero_provider: 'ON'
             install_tbb: 'ON'
+            disable_hwloc: 'OFF'
+            link_hwloc_statically: 'OFF'
           - os: 'ubuntu-22.04'
             build_type: Release
             compiler: {c: clang, cxx: clang++}
             shared_library: 'OFF'
             level_zero_provider: 'ON'
             install_tbb: 'ON'
+            disable_hwloc: 'OFF'
+            link_hwloc_statically: 'OFF'
           - os: 'ubuntu-22.04'
             build_type: Release
             compiler: {c: gcc, cxx: g++}
             shared_library: 'ON'
             level_zero_provider: 'ON'
             install_tbb: 'ON'
+            disable_hwloc: 'OFF'
+            link_hwloc_statically: 'OFF'
           - os: 'ubuntu-24.04'
             build_type: Debug
             compiler: {c: gcc, cxx: g++}
             shared_library: 'ON'
             level_zero_provider: 'ON'
             install_tbb: 'ON'
+            disable_hwloc: 'OFF'
+            link_hwloc_statically: 'OFF'
           # test level_zero_provider='OFF'
           - os: 'ubuntu-22.04'
             build_type: Release
@@ -57,13 +65,17 @@ jobs:
             shared_library: 'OFF'
             level_zero_provider: 'OFF'
             install_tbb: 'ON'
+            disable_hwloc: 'OFF'
+            link_hwloc_statically: 'OFF'
           # test icx compiler
           - os: 'ubuntu-22.04'
             build_type: Release
             compiler: {c: icx, cxx: icpx}
             shared_library: 'ON'
             level_zero_provider: 'ON'
-            install_tbb: 'ON' 
+            install_tbb: 'ON'
+            disable_hwloc: 'OFF'
+            link_hwloc_statically: 'OFF'
           # test without installing TBB
           - os: 'ubuntu-22.04'
             build_type: Release
@@ -71,6 +83,8 @@ jobs:
             shared_library: 'ON'
             level_zero_provider: 'ON'
             install_tbb: 'OFF'
+            disable_hwloc: 'OFF'
+            link_hwloc_statically: 'OFF'
           - os: 'ubuntu-22.04'
             build_type: Debug
             compiler: {c: gcc, cxx: g++}
@@ -78,12 +92,14 @@ jobs:
             level_zero_provider: 'ON'
             install_tbb: 'ON'
             disable_hwloc: 'ON'
+            link_hwloc_statically: 'OFF'
           - os: 'ubuntu-22.04'
             build_type: Release
             compiler: {c: gcc, cxx: g++}
             shared_library: 'ON'
             level_zero_provider: 'ON'
             install_tbb: 'ON'
+            disable_hwloc: 'OFF'
             link_hwloc_statically: 'ON'
     runs-on: ${{matrix.os}}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,10 @@ option(
     UMF_LINK_HWLOC_STATICALLY
     "Link UMF with HWLOC library statically (supported for Linux, MacOS and Release build on Windows)"
     OFF)
+option(
+    UMF_DISABLE_HWLOC
+    "Disable features that requires hwloc (OS provider, memory targets, topology discovery)"
+    OFF)
 option(UMF_FORMAT_CODE_STYLE
        "Add clang, cmake, and black -format-check and -format-apply targets"
        OFF)
@@ -63,10 +67,6 @@ option(UMF_USE_TSAN "Enable ThreadSanitizer checks" OFF)
 option(UMF_USE_MSAN "Enable MemorySanitizer checks" OFF)
 option(UMF_USE_VALGRIND "Enable Valgrind instrumentation" OFF)
 option(UMF_USE_GCOV "Enable gcov support" OFF)
-option(
-    UMF_DISABLE_HWLOC
-    "Disable features that requires hwloc (OS provider, memory targets, topology discovery)"
-    OFF)
 
 # set UMF_PROXY_LIB_BASED_ON_POOL to one of: SCALABLE or JEMALLOC
 set(KNOWN_PROXY_LIB_POOLS SCALABLE JEMALLOC)
@@ -289,8 +289,7 @@ if(UMF_BUILD_FUZZTESTS
     add_link_options("-fsanitize=fuzzer-no-link")
 endif()
 
-# A header only library to specify include directories in transitive
-# dependencies.
+# A header-only lib to specify include directories in transitive dependencies
 add_library(umf_headers INTERFACE)
 
 # Alias target to support FetchContent.
@@ -343,7 +342,6 @@ if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
     )
 endif()
 
-# set UMF_PROXY_LIB_ENABLED
 if(WINDOWS)
     # TODO: enable the proxy library in the Debug build on Windows
     #
@@ -362,6 +360,7 @@ if(WINDOWS)
         )
     endif()
 endif()
+# set UMF_PROXY_LIB_ENABLED
 if(UMF_PROXY_LIB_BASED_ON_POOL STREQUAL SCALABLE)
     if(UMF_POOL_SCALABLE_ENABLED)
         set(UMF_PROXY_LIB_ENABLED ON)
@@ -391,10 +390,12 @@ else()
     )
 endif()
 
+# set optional symbols for map/def files
+#
+# TODO: ref. #649
 set(UMF_OPTIONAL_SYMBOLS_LINUX "")
 set(UMF_OPTIONAL_SYMBOLS_WINDOWS "")
 
-# Conditional configuration for Level Zero provider
 if(UMF_BUILD_LEVEL_ZERO_PROVIDER)
     add_optional_symbol(umfLevelZeroMemoryProviderOps)
 endif()
@@ -551,12 +552,12 @@ if(UMF_FORMAT_CODE_STYLE)
 
         add_custom_target(
             black-format-check
-            COMMAND ${BLACK} --check --verbose ${CMAKE_SOURCE_DIR}
+            COMMAND ${BLACK} --check --verbose ${UMF_CMAKE_SOURCE_DIR}
             COMMENT "Check Python files formatting using black formatter")
 
         add_custom_target(
             black-format-apply
-            COMMAND ${BLACK} ${CMAKE_SOURCE_DIR}
+            COMMAND ${BLACK} ${UMF_CMAKE_SOURCE_DIR}
             COMMENT "Format Python files using black formatter")
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,12 +49,12 @@ option(UMF_BUILD_FUZZTESTS "Build UMF fuzz tests" OFF)
 option(UMF_BUILD_GPU_EXAMPLES "Build UMF GPU examples" OFF)
 option(UMF_DEVELOPER_MODE "Enable additional developer checks" OFF)
 option(
-    UMF_LINK_HWLOC_STATICALLY
-    "Link UMF with HWLOC library statically (supported for Linux, MacOS and Release build on Windows)"
+    UMF_DISABLE_HWLOC
+    "Disable hwloc and UMF features requiring it (OS provider, memtargets, topology discovery)"
     OFF)
 option(
-    UMF_DISABLE_HWLOC
-    "Disable features that requires hwloc (OS provider, memory targets, topology discovery)"
+    UMF_LINK_HWLOC_STATICALLY
+    "Link UMF with HWLOC library statically (supported for Linux, MacOS and Release build on Windows)"
     OFF)
 option(UMF_FORMAT_CODE_STYLE
        "Add clang, cmake, and black -format-check and -format-apply targets"
@@ -100,16 +100,19 @@ else()
     message(FATAL_ERROR "Unknown OS type")
 endif()
 
-if(NOT DEFINED UMF_HWLOC_REPO)
-    set(UMF_HWLOC_REPO "https://github.com/open-mpi/hwloc.git")
-endif()
+if(UMF_DISABLE_HWLOC)
+    message(STATUS "hwloc is disabled, hence OS provider, memtargets, "
+                   "topology discovery, examples won't be available!")
+else()
+    if(NOT DEFINED UMF_HWLOC_REPO)
+        set(UMF_HWLOC_REPO "https://github.com/open-mpi/hwloc.git")
+    endif()
 
-if(NOT DEFINED UMF_HWLOC_TAG)
-    set(UMF_HWLOC_TAG hwloc-2.10.0)
-endif()
+    if(NOT DEFINED UMF_HWLOC_TAG)
+        set(UMF_HWLOC_TAG hwloc-2.10.0)
+    endif()
 
-if(NOT UMF_LINK_HWLOC_STATICALLY)
-    if(NOT UMF_DISABLE_HWLOC)
+    if(NOT UMF_LINK_HWLOC_STATICALLY)
         pkg_check_modules(LIBHWLOC hwloc>=2.3.0)
         if(NOT LIBHWLOC_FOUND)
             find_package(LIBHWLOC 2.3.0 REQUIRED hwloc)
@@ -119,86 +122,83 @@ if(NOT UMF_LINK_HWLOC_STATICALLY)
         set(DLL_PATH_LIST
             "${DLL_PATH_LIST};PATH=path_list_append:${LIBHWLOC_LIBRARY_DIRS}/../bin"
         )
+    elseif(WINDOWS)
+        include(FetchContent)
+        set(HWLOC_ENABLE_TESTING OFF)
+        set(HWLOC_SKIP_LSTOPO ON)
+        set(HWLOC_SKIP_TOOLS ON)
+
+        message(
+            STATUS
+                "Will fetch hwloc from ${UMF_HWLOC_REPO} (tag: ${UMF_HWLOC_TAG})"
+        )
+
+        FetchContent_Declare(
+            hwloc_targ
+            GIT_REPOSITORY ${UMF_HWLOC_REPO}
+            GIT_TAG ${UMF_HWLOC_TAG}
+            SOURCE_SUBDIR contrib/windows-cmake/ FIND_PACKAGE_ARGS)
+
+        FetchContent_GetProperties(hwloc_targ)
+        if(NOT hwloc_targ_POPULATED)
+            FetchContent_MakeAvailable(hwloc_targ)
+        endif()
+
+        set(LIBHWLOC_INCLUDE_DIRS
+            ${hwloc_targ_SOURCE_DIR}/include;${hwloc_targ_BINARY_DIR}/include)
+        set(LIBHWLOC_LIBRARY_DIRS
+            ${hwloc_targ_BINARY_DIR}/Release;${hwloc_targ_BINARY_DIR}/Debug)
+    else()
+        include(FetchContent)
+        message(
+            STATUS
+                "Will fetch hwloc from ${UMF_HWLOC_REPO} (tag: ${UMF_HWLOC_TAG})"
+        )
+
+        FetchContent_Declare(
+            hwloc_targ
+            GIT_REPOSITORY ${UMF_HWLOC_REPO}
+            GIT_TAG ${UMF_HWLOC_TAG})
+
+        FetchContent_GetProperties(hwloc_targ)
+        if(NOT hwloc_targ_POPULATED)
+            FetchContent_MakeAvailable(hwloc_targ)
+        endif()
+
+        add_custom_command(
+            COMMAND ./autogen.sh
+            WORKING_DIRECTORY ${hwloc_targ_SOURCE_DIR}
+            OUTPUT ${hwloc_targ_SOURCE_DIR}/configure)
+        add_custom_command(
+            COMMAND
+                ./configure --prefix=${hwloc_targ_BINARY_DIR}
+                --enable-static=yes --enable-shared=no --disable-libxml2
+                --disable-levelzero CFLAGS=-fPIC CXXFLAGS=-fPIC
+            WORKING_DIRECTORY ${hwloc_targ_SOURCE_DIR}
+            OUTPUT ${hwloc_targ_SOURCE_DIR}/Makefile
+            DEPENDS ${hwloc_targ_SOURCE_DIR}/configure)
+        add_custom_command(
+            COMMAND make
+            WORKING_DIRECTORY ${hwloc_targ_SOURCE_DIR}
+            OUTPUT ${hwloc_targ_SOURCE_DIR}/lib/libhwloc.la
+            DEPENDS ${hwloc_targ_SOURCE_DIR}/Makefile)
+        add_custom_command(
+            COMMAND make install
+            WORKING_DIRECTORY ${hwloc_targ_SOURCE_DIR}
+            OUTPUT ${hwloc_targ_BINARY_DIR}/lib/libhwloc.a
+            DEPENDS ${hwloc_targ_SOURCE_DIR}/lib/libhwloc.la)
+
+        add_custom_target(hwloc_prod
+                          DEPENDS ${hwloc_targ_BINARY_DIR}/lib/libhwloc.a)
+        add_library(hwloc INTERFACE)
+        target_link_libraries(hwloc
+                              INTERFACE ${hwloc_targ_BINARY_DIR}/lib/libhwloc.a)
+        add_dependencies(hwloc hwloc_prod)
+
+        set(LIBHWLOC_LIBRARY_DIRS ${hwloc_targ_BINARY_DIR}/lib)
+        set(LIBHWLOC_INCLUDE_DIRS ${hwloc_targ_BINARY_DIR}/include)
+        set(LIBHWLOC_LIBRARIES ${hwloc_targ_BINARY_DIR}/lib/libhwloc.a)
     endif()
-    # add PATH to DLL on Windows
-    set(DLL_PATH_LIST
-        "${DLL_PATH_LIST};PATH=path_list_append:${LIBHWLOC_LIBRARY_DIRS}/../bin"
-    )
-elseif(WINDOWS AND NOT UMF_DISABLE_HWLOC)
-    include(FetchContent)
-    set(HWLOC_ENABLE_TESTING OFF)
-    set(HWLOC_SKIP_LSTOPO ON)
-    set(HWLOC_SKIP_TOOLS ON)
-
-    message(STATUS "Will fetch hwloc from ${UMF_HWLOC_REPO}")
-
-    FetchContent_Declare(
-        hwloc_targ
-        GIT_REPOSITORY ${UMF_HWLOC_REPO}
-        GIT_TAG ${UMF_HWLOC_TAG}
-        SOURCE_SUBDIR contrib/windows-cmake/ FIND_PACKAGE_ARGS)
-
-    FetchContent_GetProperties(hwloc_targ)
-    if(NOT hwloc_targ_POPULATED)
-        FetchContent_MakeAvailable(hwloc_targ)
-    endif()
-
-    set(LIBHWLOC_INCLUDE_DIRS
-        ${hwloc_targ_SOURCE_DIR}/include;${hwloc_targ_BINARY_DIR}/include)
-    set(LIBHWLOC_LIBRARY_DIRS
-        ${hwloc_targ_BINARY_DIR}/Release;${hwloc_targ_BINARY_DIR}/Debug)
-
-    message(STATUS "    LIBHWLOC_LIBRARIES = ${LIBHWLOC_LIBRARIES}")
-    message(STATUS "    LIBHWLOC_INCLUDE_DIRS = ${LIBHWLOC_INCLUDE_DIRS}")
-    message(STATUS "    LIBHWLOC_LIBRARY_DIRS = ${LIBHWLOC_LIBRARY_DIRS}")
-elseif(NOT UMF_DISABLE_HWLOC)
-    include(FetchContent)
-    message(STATUS "Will fetch hwloc from ${UMF_HWLOC_REPO}")
-
-    FetchContent_Declare(
-        hwloc_targ
-        GIT_REPOSITORY ${UMF_HWLOC_REPO}
-        GIT_TAG ${UMF_HWLOC_TAG})
-
-    FetchContent_GetProperties(hwloc_targ)
-    if(NOT hwloc_targ_POPULATED)
-        FetchContent_MakeAvailable(hwloc_targ)
-    endif()
-
-    add_custom_command(
-        COMMAND ./autogen.sh
-        WORKING_DIRECTORY ${hwloc_targ_SOURCE_DIR}
-        OUTPUT ${hwloc_targ_SOURCE_DIR}/configure)
-    add_custom_command(
-        COMMAND
-            ./configure --prefix=${hwloc_targ_BINARY_DIR} --enable-static=yes
-            --enable-shared=no --disable-libxml2 --disable-levelzero
-            --disable-opencl --disable-cuda --disable-nvml CFLAGS=-fPIC
-            CXXFLAGS=-fPIC
-        WORKING_DIRECTORY ${hwloc_targ_SOURCE_DIR}
-        OUTPUT ${hwloc_targ_SOURCE_DIR}/Makefile
-        DEPENDS ${hwloc_targ_SOURCE_DIR}/configure)
-    add_custom_command(
-        COMMAND make
-        WORKING_DIRECTORY ${hwloc_targ_SOURCE_DIR}
-        OUTPUT ${hwloc_targ_SOURCE_DIR}/lib/libhwloc.la
-        DEPENDS ${hwloc_targ_SOURCE_DIR}/Makefile)
-    add_custom_command(
-        COMMAND make install
-        WORKING_DIRECTORY ${hwloc_targ_SOURCE_DIR}
-        OUTPUT ${hwloc_targ_BINARY_DIR}/lib/libhwloc.a
-        DEPENDS ${hwloc_targ_SOURCE_DIR}/lib/libhwloc.la)
-
-    add_custom_target(hwloc_prod
-                      DEPENDS ${hwloc_targ_BINARY_DIR}/lib/libhwloc.a)
-    add_library(hwloc INTERFACE)
-    target_link_libraries(hwloc
-                          INTERFACE ${hwloc_targ_BINARY_DIR}/lib/libhwloc.a)
-    add_dependencies(hwloc hwloc_prod)
-
-    set(LIBHWLOC_LIBRARY_DIRS ${hwloc_targ_BINARY_DIR}/lib)
-    set(LIBHWLOC_INCLUDE_DIRS ${hwloc_targ_BINARY_DIR}/include)
-    set(LIBHWLOC_LIBRARIES ${hwloc_targ_BINARY_DIR}/lib/libhwloc.a)
 
     message(STATUS "    LIBHWLOC_LIBRARIES = ${LIBHWLOC_LIBRARIES}")
     message(STATUS "    LIBHWLOC_INCLUDE_DIRS = ${LIBHWLOC_INCLUDE_DIRS}")
@@ -414,12 +414,8 @@ if(UMF_BUILD_BENCHMARKS)
     add_subdirectory(benchmark)
 endif()
 
-if(UMF_BUILD_EXAMPLES)
-    if(NOT UMF_DISABLE_HWLOC)
-        add_subdirectory(examples)
-    else()
-        message(WARNING "Examples cannot be build - hwloc disabled")
-    endif()
+if(UMF_BUILD_EXAMPLES AND NOT UMF_DISABLE_HWLOC)
+    add_subdirectory(examples)
 endif()
 
 if(UMF_FORMAT_CODE_STYLE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -128,7 +128,7 @@ else()
     message(STATUS "UMF_OPTIONAL_SYMBOLS: ${UMF_OPTIONAL_SYMBOLS_LINUX}")
 endif()
 
-# Configure the DEF file based on whether Level Zero provider is built
+# Configure map/def files with optional symbols
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/libumf.def.in"
                "${CMAKE_CURRENT_BINARY_DIR}/libumf.def" @ONLY)
 


### PR DESCRIPTION
A small fixes in CMake and CI around hwloc options.

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly