### PR TITLE
fix: substitute UT_ASSERTs with asserts from GTEST part 1

### DIFF
--- a/test/test_base_alloc.cpp
+++ b/test/test_base_alloc.cpp
@@ -37,7 +37,7 @@ TEST_F(test, baseAllocMultiThreadedAllocMemset) {
 
         for (int i = 0; i < ITERATIONS; i++) {
             for (int k = 0; k < ALLOCATION_SIZE; k++) {
-                UT_ASSERTeq(*(ptrs[i].get() + k), ((i + TID) & 0xFF));
+                ASSERT_EQ(*(ptrs[i].get() + k), ((i + TID) & 0xFF));
             }
         }
     };

--- a/test/test_base_alloc_linear.cpp
+++ b/test/test_base_alloc_linear.cpp
@@ -24,7 +24,7 @@ TEST_F(test, baseAllocLinearAllocMoreThanPoolSize) {
 
     size_t new_size = 20 * 1024 * 1024; // = 20 MB
     void *ptr = umf_ba_linear_alloc(pool.get(), new_size);
-    UT_ASSERTne(ptr, NULL);
+    ASSERT_NE(ptr, nullptr);
     memset(ptr, 0, new_size);
 
     umf_ba_linear_free(pool.get(), ptr);
@@ -37,15 +37,14 @@ TEST_F(test, baseAllocLinearPoolContainsPointer) {
 
     size_t size = 16;
     void *ptr = umf_ba_linear_alloc(pool.get(), size);
-    UT_ASSERTne(ptr, NULL);
+    ASSERT_NE(ptr, nullptr);
     memset(ptr, 0, size);
-
     // assert pool contains pointer ptr
-    UT_ASSERTne(umf_ba_linear_pool_contains_pointer(pool.get(), ptr), 0);
+    ASSERT_NE(umf_ba_linear_pool_contains_pointer(pool.get(), ptr), 0);
 
     // assert pool does NOT contain pointer 0x0123
-    UT_ASSERTeq(umf_ba_linear_pool_contains_pointer(pool.get(), (void *)0x0123),
-                0);
+    ASSERT_EQ(umf_ba_linear_pool_contains_pointer(pool.get(), (void *)0x0123),
+              0);
 
     umf_ba_linear_free(pool.get(), ptr);
 }
@@ -78,14 +77,14 @@ TEST_F(test, baseAllocLinearMultiThreadedAllocMemset) {
                                            (rand() / (double)RAND_MAX));
             buffer[i].size = size;
             buffer[i].ptr = (unsigned char *)umf_ba_linear_alloc(pool, size);
-            UT_ASSERTne(buffer[i].ptr, NULL);
+            ASSERT_NE(buffer[i].ptr, nullptr);
             memset(buffer[i].ptr, (i + TID) & 0xFF, buffer[i].size);
         }
 
         for (int i = 0; i < ITERATIONS; i++) {
-            UT_ASSERTne(buffer[i].ptr, NULL);
+            ASSERT_NE(buffer[i].ptr, nullptr);
             for (size_t k = 0; k < buffer[i].size; k++) {
-                UT_ASSERTeq(*(buffer[i].ptr + k), (i + TID) & 0xFF);
+                ASSERT_EQ(*(buffer[i].ptr + k), (i + TID) & 0xFF);
             }
         }
 

--- a/test/test_proxy_lib.cpp
+++ b/test/test_proxy_lib.cpp
@@ -31,5 +31,5 @@ TEST_F(test, proxyLibBasic) {
 #else
     size_t size = ::malloc_usable_size(ptr);
 #endif
-    UT_ASSERTeq(size, 0xDEADBEEF);
+    ASSERT_EQ(size, 0xDEADBEEF);
 }


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->
The PR is a part of a major fix: to substitute UT_ASSERTs with asserts provided by GTEST, in multiple files.

Ref. #569 
### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
