### PR TITLE
Add proxy_lib_is_from_UMF() to the proxy_lib API

### DIFF
--- a/src/proxy_lib/proxy_lib.c
+++ b/src/proxy_lib/proxy_lib.c
@@ -292,6 +292,22 @@ void free(void *ptr) {
     return;
 }
 
+// returns 1 if the pointer comes from UMF, 0 otherwise
+int proxy_lib_is_from_UMF(void *ptr) {
+    if (ba_leak_pool_contains_pointer(ptr)) {
+        return 1;
+    }
+
+    if (Proxy_pool) {
+        was_called_from_umfPool = 1;
+        void *pool = umfPoolByPtr(ptr);
+        was_called_from_umfPool = 0;
+        return pool ? 1 : 0;
+    }
+
+    return 0;
+}
+
 void *realloc(void *ptr, size_t size) {
     if (ptr == NULL) {
         return malloc(size);

--- a/src/proxy_lib/proxy_lib.def
+++ b/src/proxy_lib/proxy_lib.def
@@ -21,3 +21,4 @@ EXPORTS
 	_aligned_offset_malloc
 	_aligned_offset_realloc
 	_aligned_offset_recalloc
+	proxy_lib_is_from_UMF

--- a/src/proxy_lib/proxy_lib.h
+++ b/src/proxy_lib/proxy_lib.h
@@ -14,6 +14,7 @@ extern "C" {
 
 void proxy_lib_create_common(void);
 void proxy_lib_destroy_common(void);
+int proxy_lib_is_from_UMF(void *ptr);
 
 #ifdef __cplusplus
 }

--- a/src/proxy_lib/proxy_lib.map
+++ b/src/proxy_lib/proxy_lib.map
@@ -12,6 +12,7 @@
         malloc;
         malloc_usable_size;
         realloc;
+        proxy_lib_is_from_UMF;
     local:
         *;
 };


### PR DESCRIPTION
### Description

Add `proxy_lib_is_from_UMF()` to the proxy_lib API.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
