### PR TITLE
[CMake] Fix hwloc configure params

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,8 +173,8 @@ else()
             COMMAND
                 ./configure --prefix=${hwloc_targ_BINARY_DIR}
                 --enable-static=yes --enable-shared=no --disable-libxml2
-                --disable-pciaccess --disable-levelzero CFLAGS=-fPIC
-                CXXFLAGS=-fPIC
+                --disable-pciaccess --disable-levelzero --disable-opencl
+                --disable-cuda --disable-nvml CFLAGS=-fPIC CXXFLAGS=-fPIC
             WORKING_DIRECTORY ${hwloc_targ_SOURCE_DIR}
             OUTPUT ${hwloc_targ_SOURCE_DIR}/Makefile
             DEPENDS ${hwloc_targ_SOURCE_DIR}/configure)


### PR DESCRIPTION
Around changes in #667, perhaps in merge conflict resolution, extra hwloc configure params were accidentally removed (ref. #660).