### PR TITLE
fix coverity issues in hwloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,12 @@ else()
         set(HWLOC_ENABLE_TESTING OFF)
         set(HWLOC_SKIP_LSTOPO ON)
         set(HWLOC_SKIP_TOOLS ON)
+        set(HWLOC_PATCH
+            git
+            apply
+            ${PROJECT_SOURCE_DIR}/cmake/fix_coverity_issues.patch
+            ||
+            true)
 
         message(
             STATUS
@@ -137,7 +143,8 @@ else()
             hwloc_targ
             GIT_REPOSITORY ${UMF_HWLOC_REPO}
             GIT_TAG ${UMF_HWLOC_TAG}
-            SOURCE_SUBDIR contrib/windows-cmake/ FIND_PACKAGE_ARGS)
+            PATCH_COMMAND ${HWLOC_PATCH} SOURCE_SUBDIR contrib/windows-cmake/
+                          FIND_PACKAGE_ARGS)
 
         FetchContent_GetProperties(hwloc_targ)
         if(NOT hwloc_targ_POPULATED)
@@ -150,6 +157,13 @@ else()
             ${hwloc_targ_BINARY_DIR}/Release;${hwloc_targ_BINARY_DIR}/Debug)
     else()
         include(FetchContent)
+        set(HWLOC_PATCH
+            git
+            apply
+            ${PROJECT_SOURCE_DIR}/cmake/fix_coverity_issues.patch
+            ||
+            true)
+
         message(
             STATUS
                 "Will fetch hwloc from ${UMF_HWLOC_REPO} (tag: ${UMF_HWLOC_TAG})"
@@ -158,7 +172,8 @@ else()
         FetchContent_Declare(
             hwloc_targ
             GIT_REPOSITORY ${UMF_HWLOC_REPO}
-            GIT_TAG ${UMF_HWLOC_TAG})
+            GIT_TAG ${UMF_HWLOC_TAG}
+            PATCH_COMMAND ${HWLOC_PATCH})
 
         FetchContent_GetProperties(hwloc_targ)
         if(NOT hwloc_targ_POPULATED)

--- a/cmake/fix_coverity_issues.patch
+++ b/cmake/fix_coverity_issues.patch
@@ -1,0 +1,14 @@
+diff --git a/hwloc/topology-x86.c b/hwloc/topology-x86.c
+index 7aabd168f..b01e44557 100644
+--- a/hwloc/topology-x86.c
++++ b/hwloc/topology-x86.c
+@@ -1375,6 +1375,9 @@ look_procs(struct hwloc_backend *backend, struct procinfo *infos, unsigned long
+   hwloc_bitmap_t set = NULL;
+   unsigned i;
+ 
++  if(!get_cpubind||!set_cpubind)
++    return -1;
++
+   if (!data->src_cpuiddump_path) {
+     orig_cpuset = hwloc_bitmap_alloc();
+     if (get_cpubind(topology, orig_cpuset, HWLOC_CPUBIND_STRICT)) {


### PR DESCRIPTION
fix coverity issues in hwloc - possible dereference of NULL pointers assigned to get_cpubind() and set_cpubind()
