### PR TITLE
Extend L0 provider to match UR capabilities

### DIFF
--- a/include/umf/providers/provider_level_zero.h
+++ b/include/umf/providers/provider_level_zero.h
@@ -14,6 +14,9 @@
 extern "C" {
 #endif
 
+typedef struct _ze_context_handle_t *ze_context_handle_t;
+typedef struct _ze_device_handle_t *ze_device_handle_t;
+
 /// @brief USM memory allocation type
 typedef enum umf_usm_memory_type_t {
     UMF_MEMORY_TYPE_UNKNOWN = 0, ///< The memory pointed to is of unknown type
@@ -24,9 +27,17 @@ typedef enum umf_usm_memory_type_t {
 
 /// @brief Level Zero Memory Provider settings struct
 typedef struct level_zero_memory_provider_params_t {
-    void *level_zero_context_handle;   ///< Handle to the Level Zero context
-    void *level_zero_device_handle;    ///< Handle to the Level Zero device
+    ze_context_handle_t
+        level_zero_context_handle; ///< Handle to the Level Zero context
+    ze_device_handle_t
+        level_zero_device_handle; ///< Handle to the Level Zero device
+
     umf_usm_memory_type_t memory_type; ///< Allocation memory type
+
+    ze_device_handle_t *
+        resident_device_handles; ///< Array of devices for which the memory should be made resident
+    uint32_t
+        resident_device_count; ///< Number of devices for which the memory should be made resident
 } level_zero_memory_provider_params_t;
 
 umf_memory_provider_ops_t *umfLevelZeroMemoryProviderOps(void);

--- a/src/provider/provider_level_zero.c
+++ b/src/provider/provider_level_zero.c
@@ -63,6 +63,25 @@ typedef struct ze_ops_t {
 static ze_ops_t g_ze_ops;
 static UTIL_ONCE_FLAG ze_is_initialized = UTIL_ONCE_FLAG_INIT;
 static bool Init_ze_global_state_failed;
+static __TLS ze_result_t TLS_last_native_error;
+
+static void store_last_native_error(int32_t native_error) {
+    TLS_last_native_error = native_error;
+}
+
+umf_result_t ze2umf_result(ze_result_t result) {
+    switch (result) {
+    case ZE_RESULT_SUCCESS:
+        return UMF_RESULT_SUCCESS;
+    case ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY:
+        return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    case ZE_RESULT_ERROR_INVALID_ARGUMENT:
+        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+    default:
+        store_last_native_error(result);
+        return UMF_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC;
+    }
+}
 
 static void init_ze_global_state(void) {
 #ifdef _WIN32
@@ -130,11 +149,12 @@ umf_result_t ze_memory_provider_initialize(void *params, void **provider) {
     ze_provider->device = ze_params->level_zero_device_handle;
     ze_provider->memory_type = (ze_memory_type_t)ze_params->memory_type;
 
-    ze_result_t ret = g_ze_ops.zeDeviceGetProperties(
-        ze_provider->device, &ze_provider->device_properties);
-    if (ret != ZE_RESULT_SUCCESS) {
+    umf_result_t ret = ze2umf_result(g_ze_ops.zeDeviceGetProperties(
+        ze_provider->device, &ze_provider->device_properties));
+
+    if (ret != UMF_RESULT_SUCCESS) {
         umf_ba_global_free(ze_provider);
-        return UMF_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC;
+        return ret;
     }
 
     *provider = ze_provider;
@@ -211,7 +231,11 @@ static umf_result_t ze_memory_provider_alloc(void *provider, size_t size,
         break;
     }
     default:
-        return UMF_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC;
+        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (ze_result != ZE_RESULT_SUCCESS) {
+        return ze2umf_result(ze_result);
     }
 
     for (uint32_t i = 0; i < ze_provider->resident_device_count; i++) {
@@ -219,14 +243,11 @@ static umf_result_t ze_memory_provider_alloc(void *provider, size_t size,
             ze_provider->context, ze_provider->resident_device_handles[i],
             *resultPtr, size);
         if (ze_result != ZE_RESULT_SUCCESS) {
-            break;
+            return ze2umf_result(ze_result);
         }
     }
 
-    // TODO add error reporting
-    return (ze_result == ZE_RESULT_SUCCESS)
-               ? UMF_RESULT_SUCCESS
-               : UMF_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC;
+    return ze2umf_result(ze_result);
 }
 
 static umf_result_t ze_memory_provider_free(void *provider, void *ptr,
@@ -236,11 +257,7 @@ static umf_result_t ze_memory_provider_free(void *provider, void *ptr,
     assert(provider);
     ze_memory_provider_t *ze_provider = (ze_memory_provider_t *)provider;
     ze_result_t ze_result = g_ze_ops.zeMemFree(ze_provider->context, ptr);
-
-    // TODO add error reporting
-    return (ze_result == ZE_RESULT_SUCCESS)
-               ? UMF_RESULT_SUCCESS
-               : UMF_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC;
+    return ze2umf_result(ze_result);
 }
 
 void ze_memory_provider_get_last_native_error(void *provider,
@@ -249,9 +266,9 @@ void ze_memory_provider_get_last_native_error(void *provider,
     (void)provider;
     (void)ppMessage;
 
-    // TODO
     assert(pError);
-    *pError = 0;
+
+    *pError = TLS_last_native_error;
 }
 
 static umf_result_t ze_memory_provider_get_min_page_size(void *provider,
@@ -356,7 +373,7 @@ static umf_result_t ze_memory_provider_get_ipc_handle(void *provider,
                                            &ze_ipc_data->ze_handle);
     if (ze_result != ZE_RESULT_SUCCESS) {
         LOG_ERR("zeMemGetIpcHandle() failed.");
-        return UMF_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC;
+        return ze2umf_result(ze_result);
     }
 
     ze_ipc_data->pid = utils_getpid();
@@ -384,7 +401,7 @@ static umf_result_t ze_memory_provider_put_ipc_handle(void *provider,
                                            ze_ipc_data->ze_handle);
     if (ze_result != ZE_RESULT_SUCCESS) {
         LOG_ERR("zeMemPutIpcHandle() failed.");
-        return UMF_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC;
+        return ze2umf_result(ze_result);
     }
     return UMF_RESULT_SUCCESS;
 }
@@ -421,7 +438,7 @@ static umf_result_t ze_memory_provider_open_ipc_handle(void *provider,
     }
     if (ze_result != ZE_RESULT_SUCCESS) {
         LOG_ERR("zeMemOpenIpcHandle() failed.");
-        return UMF_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC;
+        return ze2umf_result(ze_result);
     }
 
     return UMF_RESULT_SUCCESS;
@@ -439,7 +456,7 @@ ze_memory_provider_close_ipc_handle(void *provider, void *ptr, size_t size) {
     ze_result = g_ze_ops.zeMemCloseIpcHandle(ze_provider->context, ptr);
     if (ze_result != ZE_RESULT_SUCCESS) {
         LOG_ERR("zeMemCloseIpcHandle() failed.");
-        return UMF_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC;
+        return ze2umf_result(ze_result);
     }
 
     return UMF_RESULT_SUCCESS;


### PR DESCRIPTION
Extend L0 provider with:
- ability to make memory resident on devices
- ability to allocate memory exceeding maxMemAllocSize

to match L0 provider capabilities from UR.

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->