### PR TITLE
Remove umfTearDown call on windows

### DIFF
--- a/src/libumf_windows.c
+++ b/src/libumf_windows.c
@@ -40,7 +40,6 @@ BOOL CALLBACK initOnceCb(PINIT_ONCE InitOnce, PVOID Parameter,
     (void)lpContext; // unused
 
     int ret = umfInit();
-    atexit(umfTearDown);
     return (ret == 0) ? TRUE : FALSE;
 }
 


### PR DESCRIPTION
### Description

windows calls `atexit` before it calls object destructors, this would create seg-fault problems where it will call `atexit(umfTearDown)` which will destroy umf, but the libraries that use umf will start calling the destructors after to destruct umf objects and as `umfTearDown` was already called, this umf objects will begin seg-faulting with errors, and memory leaks also happen. 

For example: Unified-runtime library is using umf pools in l0 contexts, when the destructor for the context will start being called, it will start calling umf pool destruction `umfPoolDestroy` on umf pool objects. This will error as before it have called these destructors, `umfTearDown` would have already been called. 

We should give the control of calling `umfTearDown()` to the calling library. for example: calling `umfTearDown` with `urLoaderTearDown`/`urAdapterRelease`. 

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
