### PR TITLE
set custom name for hwloc lib

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -349,6 +349,56 @@ jobs:
         -DUMF_LINK_HWLOC_STATICALLY=ON
 
     - name: Build UMF
+      run: cmake --build ${{env.BUILD_DIR}} --config ${{matrix.build_type}} -j $Env:NUMBER_OF_PROCESSORS -v
+
+    - name: Run tests
+      working-directory: ${{env.BUILD_DIR}}
+      run: ctest -C ${{matrix.build_type}} --output-on-failure --test-dir test
+
+  windows-dynamic_mingw_hwloc:
+    env:
+      HWLOC_PACKAGE_NAME: hwloc-win64-build-2.10.0
+      TBB_PACKAGE_NAME: oneapi-tbb-2021.12.0
+      TBB_LIB_DIR: lib\intel64\vc14
+      TBB_BIN_DIR: redist\intel64\vc14
+
+    name: "Windows dynamic UMF + mingw libhwloc"
+    strategy:
+      matrix:
+        build_type: [Release]
+
+    runs-on: 'windows-2022'
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        fetch-depth: 0
+
+    - name: Get hwloc from official repo (mingw version)
+      run: |
+        Invoke-WebRequest -Uri https://download.open-mpi.org/release/hwloc/v2.10/${{env.HWLOC_PACKAGE_NAME}}.zip -OutFile ${{github.workspace}}\${{env.HWLOC_PACKAGE_NAME}}.zip -TimeoutSec 360
+        Expand-Archive ${{github.workspace}}\${{env.HWLOC_PACKAGE_NAME}}.zip -DestinationPath ${{github.workspace}}
+
+    - name: Get TBB from github
+      run: |
+        Invoke-WebRequest -Uri https://github.com/oneapi-src/oneTBB/releases/download/v2021.12.0/${{env.TBB_PACKAGE_NAME}}-win.zip -OutFile "${{github.workspace}}\${{env.TBB_PACKAGE_NAME}}-win.zip" -TimeoutSec 360
+        Expand-Archive "${{github.workspace}}\${{env.TBB_PACKAGE_NAME}}-win.zip" -DestinationPath ${{github.workspace}}
+
+    - name: Configure build
+      run: >
+        cmake
+        -B ${{env.BUILD_DIR}}
+        -DCMAKE_INSTALL_PREFIX="${{env.INSTL_DIR}}"
+        -DCMAKE_PREFIX_PATH="${{github.workspace}}\${{env.HWLOC_PACKAGE_NAME}};${{github.workspace}}\${{env.TBB_PACKAGE_NAME}};${{github.workspace}}\${{env.TBB_PACKAGE_NAME}}\${{env.TBB_LIB_DIR}};${{github.workspace}}\${{env.TBB_PACKAGE_NAME}}\${{env.TBB_BIN_DIR}}"
+        -DUMF_BUILD_SHARED_LIBRARY=ON
+        -DUMF_BUILD_EXAMPLES=ON
+        -DUMF_FORMAT_CODE_STYLE=OFF
+        -DUMF_DEVELOPER_MODE=ON
+        -DUMF_TESTS_FAIL_ON_SKIP=ON
+        -DUMF_HWLOC_NAME=libhwloc
+
+    - name: Build UMF
       run: cmake --build ${{env.BUILD_DIR}} --config ${{matrix.build_type}} -j $Env:NUMBER_OF_PROCESSORS
 
     - name: Run tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ else()
 
         # add PATH to DLL on Windows
         set(DLL_PATH_LIST
-            "${DLL_PATH_LIST};PATH=path_list_append:${LIBHWLOC_LIBRARY_DIRS}/../bin"
+            "${DLL_PATH_LIST};PATH=path_list_append:${LIBHWLOC_DLL_DIRS}"
         )
     elseif(WINDOWS)
         include(FetchContent)
@@ -322,7 +322,7 @@ endif()
 if(TBB_FOUND OR TBB_LIBRARY_DIRS)
     # add PATH to DLL on Windows
     set(DLL_PATH_LIST
-        "${DLL_PATH_LIST};PATH=path_list_append:${TBB_LIBRARY_DIRS}/../bin")
+        "${DLL_PATH_LIST};PATH=path_list_append:${TBB_DLL_DIRS}")
     set(UMF_POOL_SCALABLE_ENABLED TRUE)
 else()
     message(
@@ -339,7 +339,7 @@ if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
     endif()
     # add PATH to DLL on Windows
     set(DLL_PATH_LIST
-        "${DLL_PATH_LIST};PATH=path_list_append:${JEMALLOC_LIBRARY_DIRS}/../bin"
+        "${DLL_PATH_LIST};PATH=path_list_append:${JEMALLOC_DLL_DIRS}"
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,10 @@ option(
 option(UMF_FORMAT_CODE_STYLE
        "Add clang, cmake, and black -format-check and -format-apply targets"
        OFF)
+set(UMF_HWLOC_NAME
+    "hwloc"
+    CACHE STRING "Custom name for hwloc library w/o extension")
+
 # Only a part of skips is treated as a failure now. TODO: extend to all tests
 option(UMF_TESTS_FAIL_ON_SKIP "Treat skips in tests as fail" OFF)
 option(UMF_USE_ASAN "Enable AddressSanitizer checks" OFF)
@@ -120,8 +124,7 @@ else()
 
         # add PATH to DLL on Windows
         set(DLL_PATH_LIST
-            "${DLL_PATH_LIST};PATH=path_list_append:${LIBHWLOC_DLL_DIRS}"
-        )
+            "${DLL_PATH_LIST};PATH=path_list_append:${LIBHWLOC_DLL_DIRS}")
     elseif(WINDOWS)
         include(FetchContent)
         set(HWLOC_ENABLE_TESTING OFF)
@@ -321,8 +324,7 @@ if(NOT TBB_FOUND)
 endif()
 if(TBB_FOUND OR TBB_LIBRARY_DIRS)
     # add PATH to DLL on Windows
-    set(DLL_PATH_LIST
-        "${DLL_PATH_LIST};PATH=path_list_append:${TBB_DLL_DIRS}")
+    set(DLL_PATH_LIST "${DLL_PATH_LIST};PATH=path_list_append:${TBB_DLL_DIRS}")
     set(UMF_POOL_SCALABLE_ENABLED TRUE)
 else()
     message(
@@ -339,8 +341,7 @@ if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
     endif()
     # add PATH to DLL on Windows
     set(DLL_PATH_LIST
-        "${DLL_PATH_LIST};PATH=path_list_append:${JEMALLOC_DLL_DIRS}"
-    )
+        "${DLL_PATH_LIST};PATH=path_list_append:${JEMALLOC_DLL_DIRS}")
 endif()
 
 if(WINDOWS)

--- a/cmake/FindJEMALLOC.cmake
+++ b/cmake/FindJEMALLOC.cmake
@@ -28,7 +28,7 @@ else()
 endif()
 
 if(WINDOWS)
-    find_file(JEMALLOC_DLL NAMES "bin/jemalloc.dll")
+    find_file(JEMALLOC_DLL NAMES "bin/jemalloc.dll" "jemalloc.dll")
     get_filename_component(JEMALLOC_DLL_DIR ${JEMALLOC_DLL} DIRECTORY)
     set(JEMALLOC_DLL_DIRS ${JEMALLOC_DLL_DIR})
 endif()

--- a/cmake/FindLIBHWLOC.cmake
+++ b/cmake/FindLIBHWLOC.cmake
@@ -4,7 +4,7 @@
 
 message(STATUS "Checking for module 'libhwloc' using find_library()")
 
-find_library(LIBHWLOC_LIBRARY NAMES libhwloc hwloc)
+find_library(LIBHWLOC_LIBRARY NAMES ${UMF_HWLOC_NAME})
 set(LIBHWLOC_LIBRARIES ${LIBHWLOC_LIBRARY})
 
 get_filename_component(LIBHWLOC_LIB_DIR ${LIBHWLOC_LIBRARIES} DIRECTORY)
@@ -38,7 +38,8 @@ try_run(
     RUN_OUTPUT_VARIABLE LIBHWLOC_API_VERSION)
 
 if(WINDOWS)
-    find_file(LIBHWLOC_DLL NAMES "bin/hwloc-15.dll" "bin/libhwloc-15.dll")
+    find_file(LIBHWLOC_DLL NAMES "bin/${UMF_HWLOC_NAME}-15.dll"
+                                 "${UMF_HWLOC_NAME}-15.dll")
     get_filename_component(LIBHWLOC_DLL_DIR ${LIBHWLOC_DLL} DIRECTORY)
     set(LIBHWLOC_DLL_DIRS ${LIBHWLOC_DLL_DIR})
 endif()

--- a/cmake/FindTBB.cmake
+++ b/cmake/FindTBB.cmake
@@ -26,7 +26,7 @@ else()
 endif()
 
 if(WINDOWS)
-    find_file(TBB_DLL NAMES "bin/tbbmalloc.dll")
+    find_file(TBB_DLL NAMES "bin/tbbmalloc.dll" "tbbmalloc.dll")
     get_filename_component(TBB_DLL_DIR ${TBB_DLL} DIRECTORY)
     set(TBB_DLL_DIRS ${TBB_DLL_DIR})
 endif()

--- a/examples/cmake/FindLIBHWLOC.cmake
+++ b/examples/cmake/FindLIBHWLOC.cmake
@@ -38,7 +38,8 @@ try_run(
     RUN_OUTPUT_VARIABLE LIBHWLOC_API_VERSION)
 
 if(WINDOWS)
-    find_file(LIBHWLOC_DLL NAMES "bin/hwloc-15.dll" "bin/libhwloc-15.dll" "hwloc-15.dll" "libhwloc-15.dll")
+    find_file(LIBHWLOC_DLL NAMES "bin/hwloc-15.dll" "bin/libhwloc-15.dll"
+                                 "hwloc-15.dll" "libhwloc-15.dll")
     get_filename_component(LIBHWLOC_DLL_DIR ${LIBHWLOC_DLL} DIRECTORY)
     set(LIBHWLOC_DLL_DIRS ${LIBHWLOC_DLL_DIR})
 endif()

--- a/examples/cmake/FindLIBHWLOC.cmake
+++ b/examples/cmake/FindLIBHWLOC.cmake
@@ -38,7 +38,7 @@ try_run(
     RUN_OUTPUT_VARIABLE LIBHWLOC_API_VERSION)
 
 if(WINDOWS)
-    find_file(LIBHWLOC_DLL NAMES "bin/hwloc-15.dll" "bin/libhwloc-15.dll")
+    find_file(LIBHWLOC_DLL NAMES "bin/hwloc-15.dll" "bin/libhwloc-15.dll" "hwloc-15.dll" "libhwloc-15.dll")
     get_filename_component(LIBHWLOC_DLL_DIR ${LIBHWLOC_DLL} DIRECTORY)
     set(LIBHWLOC_DLL_DIRS ${LIBHWLOC_DLL_DIR})
 endif()

--- a/examples/cmake/FindTBB.cmake
+++ b/examples/cmake/FindTBB.cmake
@@ -26,7 +26,7 @@ else()
 endif()
 
 if(WINDOWS)
-    find_file(TBB_DLL NAMES "bin/tbbmalloc.dll")
+    find_file(TBB_DLL NAMES "bin/tbbmalloc.dll" "tbbmalloc.dll")
     get_filename_component(TBB_DLL_DIR ${TBB_DLL} DIRECTORY)
     set(TBB_DLL_DIRS ${TBB_DLL_DIR})
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -154,7 +154,7 @@ endif()
 
 if(UMF_BUILD_SHARED_LIBRARY)
     if(NOT UMF_DISABLE_HWLOC)
-        set(HWLOC_LIB hwloc)
+        set(HWLOC_LIB ${UMF_HWLOC_NAME})
     endif()
     add_umf_library(
         NAME umf
@@ -184,7 +184,7 @@ if(UMF_DISABLE_HWLOC)
 endif()
 
 if(UMF_LINK_HWLOC_STATICALLY)
-    add_dependencies(umf hwloc)
+    add_dependencies(umf ${UMF_HWLOC_NAME})
 endif()
 
 target_link_directories(umf PRIVATE ${UMF_PRIVATE_LIBRARY_DIRS})


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

If hwloc is got from vcpkg it is named "hwloc" while mingw version names it "libhwloc".

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly