### PR TITLE
fix: substitute UT_ASSERTs with asserts from GTEST part 4

### DIFF
--- a/test/common/base.hpp
+++ b/test/common/base.hpp
@@ -14,6 +14,8 @@
 
 namespace umf_test {
 
+#define IS_SKIPPED_OR_FAILED() (HasFatalFailure() || IsSkipped())
+
 #define NOEXCEPT_COND(cond, val, expected_val)                                                                   \
     try {                                                                                                        \
         cond(val, expected_val);                                                                                 \

--- a/test/memspaces/memspace_highest_bandwidth.cpp
+++ b/test/memspaces/memspace_highest_bandwidth.cpp
@@ -9,16 +9,17 @@
 #include "memspace_internal.h"
 #include "test_helpers.h"
 
-static bool canQueryBandwidth(size_t nodeId) {
+static void canQueryBandwidth(size_t nodeId) {
     hwloc_topology_t topology = nullptr;
     int ret = hwloc_topology_init(&topology);
-    UT_ASSERTeq(ret, 0);
+    ASSERT_EQ(ret, 0);
+
     ret = hwloc_topology_load(topology);
-    UT_ASSERTeq(ret, 0);
+    ASSERT_EQ(ret, 0);
 
     hwloc_obj_t numaNode =
         hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, nodeId);
-    UT_ASSERTne(numaNode, nullptr);
+    ASSERT_NE(numaNode, nullptr);
 
     // Setup initiator structure.
     struct hwloc_location initiator;
@@ -30,7 +31,12 @@ static bool canQueryBandwidth(size_t nodeId) {
                                   numaNode, &initiator, 0, &value);
 
     hwloc_topology_destroy(topology);
-    return (ret == 0);
+
+    if (ret != 0) {
+        GTEST_SKIP()
+            << "Error: hwloc_memattr_get_value return value is equal to " << ret
+            << ", should be " << 0;
+    }
 }
 
 INSTANTIATE_TEST_SUITE_P(memspaceLowestLatencyTest, memspaceGetTest,

--- a/test/memspaces/memspace_lowest_latency.cpp
+++ b/test/memspaces/memspace_lowest_latency.cpp
@@ -9,16 +9,17 @@
 #include "memspace_internal.h"
 #include "test_helpers.h"
 
-static bool canQueryLatency(size_t nodeId) {
+static void canQueryLatency(size_t nodeId) {
     hwloc_topology_t topology = nullptr;
     int ret = hwloc_topology_init(&topology);
-    UT_ASSERTeq(ret, 0);
+    ASSERT_EQ(ret, 0);
+
     ret = hwloc_topology_load(topology);
-    UT_ASSERTeq(ret, 0);
+    ASSERT_EQ(ret, 0);
 
     hwloc_obj_t numaNode =
         hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, nodeId);
-    UT_ASSERTne(numaNode, nullptr);
+    ASSERT_NE(numaNode, nullptr);
 
     // Setup initiator structure.
     struct hwloc_location initiator;
@@ -30,7 +31,12 @@ static bool canQueryLatency(size_t nodeId) {
                                   &initiator, 0, &value);
 
     hwloc_topology_destroy(topology);
-    return (ret == 0);
+
+    if (ret != 0) {
+        GTEST_SKIP()
+            << "Error: hwloc_memattr_get_value return value is equal to " << ret
+            << ", should be " << 0;
+    }
 }
 
 INSTANTIATE_TEST_SUITE_P(memspaceLowestLatencyTest, memspaceGetTest,


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->
The PR is a part of a major fix, which will be provided in multiple files.

Ref. #569 

canQuery*(...) are changed to void. The success, failure or the need to skip the tests are determined in the function body using GTEST asserts, which set the appropriate flags for the current test. The flags are checked then in the fixture. The solution is inspired by [GTEST docs.](https://google.github.io/googletest/advanced.html#checking-for-failures-in-the-current-test).

The condition using ::memspaceGetTest::IsSkipped() in memspaceProviderTest is replaced due to its ineffectiveness: it has used the method from superclass for itself, before skipping any tests.

EXPECT_* and ADD_FAILURE() interefere with GTEST_SKIP() when used in a non-void helper function - tests are run in spite of labelling as ,,skipped" by the fixture.

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
