### PR TITLE
Do not run benchmarks in the proxy_lib CI

### DIFF
--- a/.github/workflows/proxy_lib.yml
+++ b/.github/workflows/proxy_lib.yml
@@ -44,7 +44,7 @@ jobs:
           -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
           -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
           -DUMF_BUILD_SHARED_LIBRARY=ON
-          -DUMF_BUILD_BENCHMARKS=ON
+          -DUMF_BUILD_BENCHMARKS=OFF
           -DUMF_BUILD_TESTS=ON
           -DUMF_FORMAT_CODE_STYLE=OFF
           -DUMF_DEVELOPER_MODE=OFF


### PR DESCRIPTION
### Description

Do not run benchmarks in the proxy_lib CI,
since it takes about 4 minutes to run
the umf-bench-ubench benchmark.
Benchmarks are run in a separate workflow.

See https://github.com/oneapi-src/unified-memory-framework/actions/runs/10696438586/job/29652522203 for an example.

Times of builds:
1) ProxyLib / Ubuntu (Release, gcc, g++, SCALABLE
2) ProxyLib / Ubuntu (Release, gcc, g++, JEMALLOC
3) ProxyLib / Ubuntu (Debug, gcc, g++, SCALABLE
4) ProxyLib / Ubuntu (Debug, gcc, g++, JEMALLOC

Before:
1) 11m 33s
2) 11m 5s
3) 6m 22s
4) 6m 47s

With this patch:
1) 2m 21s
2) 2m 22s
3) 1m 57s
4) 1m 57s

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
