### PR TITLE
Run setvars.sh also before building for icpx compiler

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -158,12 +158,14 @@ jobs:
         -DUMF_LINK_HWLOC_STATICALLY=${{matrix.link_hwloc_statically}}
 
     - name: Build UMF
-      run: cmake --build ${{env.BUILD_DIR}} -j $(nproc)
+      run: |
+        ${{ matrix.compiler.cxx == 'icpx' && '. /opt/intel/oneapi/setvars.sh' || true }}
+        cmake --build ${{env.BUILD_DIR}} -j $(nproc)
 
     - name: Run tests
       working-directory: ${{env.BUILD_DIR}}
-      run: >
-        ${{ matrix.compiler.cxx == 'icpx' && '. /opt/intel/oneapi/setvars.sh &&' || ''}} 
+      run: |
+        ${{ matrix.compiler.cxx == 'icpx' && '. /opt/intel/oneapi/setvars.sh' || true }}
         ctest --output-on-failure --test-dir test
 
     - name: Remove the installation directory

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -66,12 +66,14 @@ jobs:
         -DUMF_TESTS_FAIL_ON_SKIP=ON
 
     - name: Build UMF
-      run: cmake --build ${{env.BUILD_DIR}} -j $(nproc)
+      run: |
+        ${{ matrix.compiler.cxx == 'icpx' && '. /opt/intel/oneapi/setvars.sh' || true }}
+        cmake --build ${{env.BUILD_DIR}} -j $(nproc)
 
     - name: Run tests
       working-directory: ${{env.BUILD_DIR}}
-      run: > 
-        ${{ matrix.compiler.cxx == 'icpx' && '. /opt/intel/oneapi/setvars.sh &&' || ''}}
+      run: |
+        ${{ matrix.compiler.cxx == 'icpx' && '. /opt/intel/oneapi/setvars.sh' || true }}
         ctest --output-on-failure
 
   windows-build:


### PR DESCRIPTION
### Description

Run setvars.sh also before building for icpx compiler. It fixes the following warnings:
```
/usr/bin/ld: warning: libsvml.so, needed by ../lib/libumf.so.0.9.0, not found (try using -rpath or -rpath-link)
/usr/bin/ld: warning: libirng.so, needed by ../lib/libumf.so.0.9.0, not found (try using -rpath or -rpath-link)
/usr/bin/ld: warning: libimf.so, needed by ../lib/libumf.so.0.9.0, not found (try using -rpath or -rpath-link)
/usr/bin/ld: warning: libintlc.so.5, needed by ../lib/libumf.so.0.9.0, not found (try using -rpath or -rpath-link)
```

See the build: https://github.com/oneapi-src/unified-memory-framework/actions/runs/10700901541/job/29666095891#logs

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
