### PR TITLE
Fix hwloc patch application on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ else()
             apply
             ${PROJECT_SOURCE_DIR}/cmake/fix_coverity_issues.patch
             ||
-            true)
+            (exit 0))
 
         message(
             STATUS
@@ -165,7 +165,7 @@ else()
             apply
             ${PROJECT_SOURCE_DIR}/cmake/fix_coverity_issues.patch
             ||
-            true)
+            (exit 0))
 
         message(
             STATUS


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

Windows `cmd.exe` doesn't have a `true` command which causes the DPC++ build to fail, `(exit 0)` will do the same thing but it will work on both linux and windows.

This issue only shows up on Windows and not on a first build, since when building the first time the patch applies cleanly so the `||` branch is not taken, but then when rebuilding the patch doens't apply and the command errors out in the `||` branch.
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [X] Code compiles without errors locally
- [X] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->

