### PR TITLE
Fix includes in memspace test fixtures

### DIFF
--- a/test/memspaces/memspace_fixtures.hpp
+++ b/test/memspaces/memspace_fixtures.hpp
@@ -5,6 +5,7 @@
 #ifndef UMF_TEST_MEMSPACE_FIXTURES_HPP
 #define UMF_TEST_MEMSPACE_FIXTURES_HPP
 
+#include <algorithm>
 #include <numa.h>
 #include <numaif.h>
 #include <thread>


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

This file uses `std::find` and `std::any_of` which are part of the `<algorithm>` header, but it wasn't including it.

When building with gcc 14 this caused build issues such as:

```
memspace_fixtures.hpp:204:26: error: ‘any_of’ is not a member of ‘std’
```

With this patch adding the include building UMF with gcc 14 works fine.
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [X] Code compiles without errors locally
- [X] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

