### PR TITLE
Fix a typo in critnib.c

### DIFF
--- a/src/critnib/critnib.c
+++ b/src/critnib/critnib.c
@@ -315,7 +315,7 @@ static struct critnib_leaf *alloc_leaf(struct critnib *__restrict c) {
 }
 
 /*
- * crinib_insert -- write a key:value pair to the critnib structure
+ * critnib_insert -- write a key:value pair to the critnib structure
  *
  * Returns:
  *  • 0 on success


### PR DESCRIPTION
### Description

Fix a typo in critnib.c.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
