### PR TITLE
Remove definitions of NAME_MAX

### DIFF
--- a/src/provider/provider_os_memory_internal.h
+++ b/src/provider/provider_os_memory_internal.h
@@ -8,6 +8,13 @@
 #ifndef UMF_OS_MEMORY_PROVIDER_INTERNAL_H
 #define UMF_OS_MEMORY_PROVIDER_INTERNAL_H
 
+#include <limits.h>
+
+#if defined(_WIN32) && !defined(NAME_MAX)
+#include <stdlib.h>
+#define NAME_MAX _MAX_FNAME
+#endif /* defined(_WIN32) && !defined(NAME_MAX) */
+
 #include <umf/providers/provider_os_memory.h>
 
 #include "critnib.h"
@@ -23,8 +30,6 @@ typedef enum umf_purge_advise_t {
     UMF_PURGE_LAZY,
     UMF_PURGE_FORCE,
 } umf_purge_advise_t;
-
-#define NAME_MAX 255
 
 typedef struct os_memory_provider_t {
     unsigned protection; // combination of OS-specific protection flags

--- a/src/proxy_lib/proxy_lib.c
+++ b/src/proxy_lib/proxy_lib.c
@@ -38,6 +38,7 @@
 #endif
 
 #include <assert.h>
+#include <limits.h>
 #include <stdio.h>
 
 #include <umf/memory_pool.h>
@@ -113,7 +114,6 @@ void proxy_lib_create_common(void) {
     umf_result_t umf_result;
 
 #ifndef _WIN32
-#define NAME_MAX 255
     char shm_name[NAME_MAX];
 
     if (util_env_var_has_str("UMF_PROXY", "page.disposition=shared-fd")) {
@@ -136,7 +136,6 @@ void proxy_lib_create_common(void) {
                   "named shared memory: %s",
                   os_params.shm_name);
     }
-#undef NAME_MAX
 #endif
 
     umf_result = umfMemoryProviderCreate(umfOsMemoryProviderOps(), &os_params,


### PR DESCRIPTION
### Description

Remove definitions of `NAME_MAX` since it is defined in `<limits.h>`.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
