### PR TITLE
Fix Coverity issues in RAVL tree

### DIFF
--- a/src/ravl/ravl.c
+++ b/src/ravl/ravl.c
@@ -253,7 +253,10 @@ static int ravl_node_rank(struct ravl_node *n) {
  */
 static int ravl_node_rank_difference_parent(struct ravl_node *p,
                                             struct ravl_node *n) {
-    return ravl_node_rank(p) - ravl_node_rank(n);
+    int rv = ravl_node_rank(p) - ravl_node_rank(n);
+    // assert to check integer overflow
+    assert(rv < ravl_node_rank(p));
+    return rv;
 }
 
 /*
@@ -330,6 +333,7 @@ static void ravl_balance(struct ravl *ravl, struct ravl_node *n) {
         ravl_rotate(ravl, z);
         ravl_node_promote(z);
         ravl_node_demote(n);
+        assert(y != NULL);
         ravl_node_demote(y);
     }
 }


### PR DESCRIPTION
### Description

Fix Coverity issues in RAVL tree:
- 468502 Dereference after null check
- 462949 Overflowed return value

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
