### PR TITLE
Remove the warning message of the base allocator

### DIFF
--- a/src/base_alloc/base_alloc_global.c
+++ b/src/base_alloc/base_alloc_global.c
@@ -164,9 +164,6 @@ void *umf_ba_global_aligned_alloc(size_t size, size_t alignment) {
 
     int ac_index = size_to_idx(size);
     if (ac_index >= NUM_ALLOCATION_CLASSES) {
-        LOG_WARN("base_alloc: allocation size (%zu) larger than the biggest "
-                 "allocation class. Falling back to OS memory allocation.",
-                 size);
         return add_metadata_and_align(ba_os_alloc(size), size, alignment);
     }
 


### PR DESCRIPTION
### Description

Remove the warning message of the base allocator.
This situation can happen often and it is nothing wrong, so this message just spams the debug output.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
