### PR TITLE
Fix assert in ravl_node_rank_difference_parent()

### DIFF
--- a/src/ravl/ravl.c
+++ b/src/ravl/ravl.c
@@ -255,7 +255,8 @@ static int ravl_node_rank_difference_parent(struct ravl_node *p,
                                             struct ravl_node *n) {
     int rv = ravl_node_rank(p) - ravl_node_rank(n);
     // assert to check integer overflow
-    assert(rv < ravl_node_rank(p));
+    // ravl_node_rank(x) is >= -1
+    assert(rv <= ravl_node_rank(p) + 1);
     return rv;
 }
 


### PR DESCRIPTION
### Description

Fix assert in `ravl_node_rank_difference_parent()`.
`ravl_node_rank()` do not have to be positive - it can return (-1), so the assert has to be corrected.

For example:
if `ravl_node_rank(p) = 0` and `ravl_node_rank(n) = -1`, then `rv = 1`.

Ref: #717

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly

This patch is tested in #715 
