### PR TITLE
Update CMake warning when libhwloc is not found to inform user about UMF_DISABLE_HWLOC flag

### DIFF
--- a/cmake/FindLIBHWLOC.cmake
+++ b/cmake/FindLIBHWLOC.cmake
@@ -67,7 +67,8 @@ if(LIBHWLOC_LIBRARY)
     endif()
 else()
     set(MSG_NOT_FOUND
-        "libhwloc NOT found (set CMAKE_PREFIX_PATH to point the location)")
+        "libhwloc NOT found (set CMAKE_PREFIX_PATH to point the location or disable with -DUMF_DISABLE_HWLOC=ON)"
+    )
     if(LIBHWLOC_FIND_REQUIRED)
         message(FATAL_ERROR ${MSG_NOT_FOUND})
     else()


### PR DESCRIPTION
### Description

When libhwloc is not found users are warned with this message `libhwloc NOT found (set CMAKE_PREFIX_PATH to point the location)`. This can be disabled with the flag `UMF_DISABLE_HWLOC` which they would need to look up in the project documentation, so just adding it to the warning message to skip that. The updated message is `libhwloc NOT found (set CMAKE_PREFIX_PATH to point the location) or disable with -DUMF_DISABLE_HWLOC=ON`

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [ ] CI workflows execute properly
