### PR TITLE
Remove excessive definition of NAME_MAX

### DIFF
--- a/src/utils/utils_common.h
+++ b/src/utils/utils_common.h
@@ -20,8 +20,6 @@
 extern "C" {
 #endif
 
-#define NAME_MAX 255
-
 #define DO_WHILE_EMPTY                                                         \
     do {                                                                       \
     } while (0)


### PR DESCRIPTION
### Description

Remove excessive definition of `NAME_MAX`.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
