### PR TITLE
Update UMF version to 0.10.0 in headers, CI and docs config file

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -8,7 +8,7 @@ permissions:
 
 env:
   # for installation testing - it should match with version set in CMake
-  UMF_VERSION: 0.9.0
+  UMF_VERSION: 0.10.0
   BUILD_DIR : "${{github.workspace}}/build"
   INSTL_DIR : "${{github.workspace}}/../install-dir"
 

--- a/include/umf/base.h
+++ b/include/umf/base.h
@@ -28,7 +28,7 @@ extern "C" {
 #define UMF_MINOR_VERSION(_ver) (_ver & 0x0000ffff)
 
 /// @brief Current version of the UMF headers
-#define UMF_VERSION_CURRENT UMF_MAKE_VERSION(0, 9)
+#define UMF_VERSION_CURRENT UMF_MAKE_VERSION(0, 10)
 
 /// @brief Operation results
 typedef enum umf_result_t {

--- a/scripts/docs_config/conf.py
+++ b/scripts/docs_config/conf.py
@@ -22,7 +22,7 @@ copyright = "2023-2024, Intel"
 author = "Intel"
 
 # The full version, including alpha/beta/rc tags
-release = "0.9.0"
+release = "0.10.0"
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
### Description

Update UMF version to 0.10.0 in CI and docs config file.

None CI build on the main branch will pass until this patch is merged.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [ ] CI workflows execute properly
