### PR TITLE
Remove unneeded functions

### DIFF
--- a/src/utils/utils_macosx_common.c
+++ b/src/utils/utils_macosx_common.c
@@ -90,31 +90,3 @@ int utils_shm_unlink(const char *shm_name) {
 int utils_create_anonymous_fd(void) {
     return 0; // ignored on MacOSX
 }
-
-int os_get_file_size(int fd, size_t *size) {
-    (void)fd;   // unused
-    (void)size; // unused
-    return -1;  // not supported on MacOSX
-}
-
-int os_set_file_size(int fd, size_t size) {
-    (void)fd;   // unused
-    (void)size; // unused
-    return 0;   // ignored on MacOSX
-}
-
-void *os_devdax_mmap(void *hint_addr, size_t length, int prot, int fd) {
-    (void)hint_addr; // unused
-    (void)length;    // unused
-    (void)prot;      // unused
-    (void)fd;        // unused
-    return NULL;     // not supported on Windows
-}
-
-int os_fallocate(int fd, long offset, long len) {
-    (void)fd;     // unused
-    (void)offset; // unused
-    (void)len;    // unused
-
-    return -1;
-}


### PR DESCRIPTION
### Description

Remove unneeded functions.
All those functions have `utils_*` counterparts in the same file. They were left here by mistake.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
