### PR TITLE
Add support for mapping with MAP_SYNC to file provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ so it should be used with a pool manager that will take over
 the managing of the provided memory - for example the jemalloc pool
 with the `disable_provider_free` parameter set to true.
 
+The memory visibility mode parameter must be set to `UMF_MEM_MAP_SYNC` in case of FSDAX.
+
 ##### Requirements
 
 1) Linux OS

--- a/include/umf/memory_provider.h
+++ b/include/umf/memory_provider.h
@@ -20,7 +20,8 @@ extern "C" {
 /// @brief Memory visibility mode
 typedef enum umf_memory_visibility_t {
     UMF_MEM_MAP_PRIVATE = 1, ///< private memory mapping
-    UMF_MEM_MAP_SHARED, ///< shared memory mapping (supported on Linux only)
+    UMF_MEM_MAP_SHARED,      ///< shared memory mapping (Linux only)
+    UMF_MEM_MAP_SYNC, ///< direct mapping of persistent memory (supported only for files supporting DAX, Linux only)
 } umf_memory_visibility_t;
 
 /// @brief Protection of the memory allocations

--- a/src/provider/provider_file_memory.c
+++ b/src/provider/provider_file_memory.c
@@ -261,7 +261,7 @@ static umf_result_t file_mmap_aligned(file_memory_provider_t *file_provider,
     ASSERT_IS_ALIGNED(extended_size, page_size);
     ASSERT_IS_ALIGNED(offset_fd, page_size);
 
-    void *ptr = utils_mmap(NULL, extended_size, prot, flag, fd, offset_fd);
+    void *ptr = utils_mmap_file(NULL, extended_size, prot, flag, fd, offset_fd);
     if (ptr == NULL) {
         LOG_PERR("memory mapping failed");
         return UMF_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC;
@@ -612,8 +612,9 @@ static umf_result_t file_open_ipc_handle(void *provider, void *providerIpcData,
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
 
-    *ptr = utils_mmap(NULL, file_ipc_data->size, file_provider->protection,
-                      file_provider->visibility, fd, file_ipc_data->offset_fd);
+    *ptr = utils_mmap_file(NULL, file_ipc_data->size, file_provider->protection,
+                           file_provider->visibility, fd,
+                           file_ipc_data->offset_fd);
     (void)utils_close_fd(fd);
     if (*ptr == NULL) {
         file_store_last_native_error(UMF_FILE_RESULT_ERROR_ALLOC_FAILED, errno);

--- a/src/utils/utils_common.h
+++ b/src/utils/utils_common.h
@@ -124,7 +124,8 @@ int utils_set_file_size(int fd, size_t size);
 void *utils_mmap(void *hint_addr, size_t length, int prot, int flag, int fd,
                  size_t fd_offset);
 
-void *utils_devdax_mmap(void *hint_addr, size_t length, int prot, int fd);
+void *utils_mmap_file(void *hint_addr, size_t length, int prot, int flags,
+                      int fd, size_t fd_offset);
 
 int utils_munmap(void *addr, size_t length);
 

--- a/src/utils/utils_linux_common.c
+++ b/src/utils/utils_linux_common.c
@@ -31,6 +31,9 @@ utils_translate_mem_visibility_flag(umf_memory_visibility_t in_flag,
     case UMF_MEM_MAP_SHARED:
         *out_flag = MAP_SHARED;
         return UMF_RESULT_SUCCESS;
+    case UMF_MEM_MAP_SYNC:
+        *out_flag = MAP_SYNC;
+        return UMF_RESULT_SUCCESS;
     }
     return UMF_RESULT_ERROR_INVALID_ARGUMENT;
 }

--- a/src/utils/utils_macosx_common.c
+++ b/src/utils/utils_macosx_common.c
@@ -23,6 +23,8 @@ utils_translate_mem_visibility_flag(umf_memory_visibility_t in_flag,
         return UMF_RESULT_SUCCESS;
     case UMF_MEM_MAP_SHARED:
         return UMF_RESULT_ERROR_NOT_SUPPORTED; // not supported on MacOSX
+    case UMF_MEM_MAP_SYNC:
+        return UMF_RESULT_ERROR_NOT_SUPPORTED; // not supported on MacOSX
     }
     return UMF_RESULT_ERROR_INVALID_ARGUMENT;
 }

--- a/src/utils/utils_macosx_common.c
+++ b/src/utils/utils_macosx_common.c
@@ -29,11 +29,14 @@ utils_translate_mem_visibility_flag(umf_memory_visibility_t in_flag,
     return UMF_RESULT_ERROR_INVALID_ARGUMENT;
 }
 
-void *utils_devdax_mmap(void *hint_addr, size_t length, int prot, int fd) {
+void *utils_mmap_file(void *hint_addr, size_t length, int prot, int flags,
+                      int fd, size_t fd_offset) {
     (void)hint_addr; // unused
     (void)length;    // unused
     (void)prot;      // unused
+    (void)flags;     // unused
     (void)fd;        // unused
+    (void)fd_offset; // unused
     return NULL;     // not supported
 }
 

--- a/src/utils/utils_windows_common.c
+++ b/src/utils/utils_windows_common.c
@@ -147,12 +147,15 @@ void *utils_mmap(void *hint_addr, size_t length, int prot, int flag, int fd,
     return VirtualAlloc(hint_addr, length, MEM_RESERVE | MEM_COMMIT, prot);
 }
 
-void *utils_devdax_mmap(void *hint_addr, size_t length, int prot, int fd) {
+void *utils_mmap_file(void *hint_addr, size_t length, int prot, int flags,
+                      int fd, size_t fd_offset) {
     (void)hint_addr; // unused
     (void)length;    // unused
     (void)prot;      // unused
+    (void)flags;     // unused
     (void)fd;        // unused
-    return NULL;     // not supported on Windows
+    (void)fd_offset; // unused
+    return NULL;     // not supported
 }
 
 int utils_munmap(void *addr, size_t length) {

--- a/src/utils/utils_windows_common.c
+++ b/src/utils/utils_windows_common.c
@@ -96,6 +96,8 @@ utils_translate_mem_visibility_flag(umf_memory_visibility_t in_flag,
         return UMF_RESULT_SUCCESS;
     case UMF_MEM_MAP_SHARED:
         return UMF_RESULT_ERROR_NOT_SUPPORTED; // not supported on Windows yet
+    case UMF_MEM_MAP_SYNC:
+        return UMF_RESULT_ERROR_NOT_SUPPORTED; // not supported on Windows yet
     }
     return UMF_RESULT_ERROR_INVALID_ARGUMENT;
 }


### PR DESCRIPTION
### Description

Rename `utils_devdax_mmap()` to `utils_mmap_file()` and improve it:
- add support for `MAP_PRIVATE`
- add `flags` and `fd_offset` arguments

Add support for mapping with `MAP_SYNC` to file provider:
use `utils_mmap_file()` instead of `utils_mmap()`.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
