### PR TITLE
Add test if FSDAX is mapped with the MAP_SYNC flag

### DIFF
--- a/.github/workflows/dax.yml
+++ b/.github/workflows/dax.yml
@@ -1,9 +1,20 @@
-# This workflow builds and tests the devdax memory provider.
-# It requires a DAX device (e.g. /dev/dax0.0) configured in the OS.
-# This DAX device should be specified using the
+#
+# This workflow builds and tests the DEVDAX memory provider
+# and the file memory provider with FSDAX.
+# It requires:
+# - a DAX device (e.g. /dev/dax0.0) and
+# - a FSDAX device (e.g. /dev/pmem1)
+# configured and mounted in the OS.
+#
+# The DAX device should be specified using the
 # UMF_TESTS_DEVDAX_PATH and UMF_TESTS_DEVDAX_SIZE environment variables.
+#
+# The FSDAX device should be mounted in the OS (e.g. /mnt/pmem1)
+# and the UMF_TESTS_FSDAX_PATH environment variable
+# should contain a path to a file o this FSDAX device.
+#
 
-name: DevDax
+name: Dax
 
 on: [workflow_call]
 
@@ -11,12 +22,12 @@ permissions:
   contents: read
 
 env:
-  UMF_TESTS_DEVDAX_NAMESPACE : "0.0"
+  DEVDAX_NAMESPACE : "0.0"
   BUILD_DIR : "${{github.workspace}}/build"
   INSTL_DIR : "${{github.workspace}}/../install-dir"
 
 jobs:
-  devdax:
+  dax:
     name: Build
     # run only on upstream; forks may not have a DAX device
     if: github.repository == 'oneapi-src/unified-memory-framework'
@@ -27,12 +38,13 @@ jobs:
 
     runs-on: ["DSS-DEVDAX", "DSS-Ubuntu"]
     steps:
-      - name: Check if the devdax exists, print out UMF_TESTS_DEVDAX_PATH and UMF_TESTS_DEVDAX_SIZE
+      - name: Check configuration of the DEVDAX
         run: |
-          ndctl list -N --device-dax
-          ls -al /dev/dax${UMF_TESTS_DEVDAX_NAMESPACE}
-          echo UMF_TESTS_DEVDAX_PATH="/dev/dax${UMF_TESTS_DEVDAX_NAMESPACE}"
-          echo UMF_TESTS_DEVDAX_SIZE="$(ndctl list --namespace=namespace${UMF_TESTS_DEVDAX_NAMESPACE} | grep size | cut -d':' -f2 | cut -d',' -f1)"
+          echo DEVDAX_NAMESPACE="${{env.DEVDAX_NAMESPACE}}"
+          ndctl list --namespace=namespace${{env.DEVDAX_NAMESPACE}} --device-dax
+          ls -al /dev/dax${{env.DEVDAX_NAMESPACE}}
+          echo UMF_TESTS_DEVDAX_PATH="/dev/dax${{env.DEVDAX_NAMESPACE}}"
+          echo UMF_TESTS_DEVDAX_SIZE="$(ndctl list --namespace=namespace${{env.DEVDAX_NAMESPACE}} | grep size | cut -d':' -f2 | cut -d',' -f1)"
 
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -62,9 +74,9 @@ jobs:
       - name: Build UMF
         run: cmake --build ${{env.BUILD_DIR}} --config ${{matrix.build_type}} -j $(nproc)
 
-      - name: Run only devdax tests
+      - name: Run the DEVDAX tests
         working-directory: ${{env.BUILD_DIR}}
         run: >
-          UMF_TESTS_DEVDAX_PATH="/dev/dax${UMF_TESTS_DEVDAX_NAMESPACE}"
-          UMF_TESTS_DEVDAX_SIZE="$(ndctl list --namespace=namespace${UMF_TESTS_DEVDAX_NAMESPACE} | grep size | cut -d':' -f2 | cut -d',' -f1)"
+          UMF_TESTS_DEVDAX_PATH="/dev/dax${{env.DEVDAX_NAMESPACE}}"
+          UMF_TESTS_DEVDAX_SIZE="$(ndctl list --namespace=namespace${{env.DEVDAX_NAMESPACE}} | grep size | cut -d':' -f2 | cut -d',' -f1)"
           ctest -C ${{matrix.build_type}} -R devdax -V

--- a/.github/workflows/dax.yml
+++ b/.github/workflows/dax.yml
@@ -23,6 +23,9 @@ permissions:
 
 env:
   DEVDAX_NAMESPACE : "0.0"
+  FSDAX_NAMESPACE : "1.0"
+  FSDAX_PMEM: "pmem1"
+  UMF_TESTS_FSDAX_PATH: "/mnt/pmem1/file"
   BUILD_DIR : "${{github.workspace}}/build"
   INSTL_DIR : "${{github.workspace}}/../install-dir"
 
@@ -45,6 +48,16 @@ jobs:
           ls -al /dev/dax${{env.DEVDAX_NAMESPACE}}
           echo UMF_TESTS_DEVDAX_PATH="/dev/dax${{env.DEVDAX_NAMESPACE}}"
           echo UMF_TESTS_DEVDAX_SIZE="$(ndctl list --namespace=namespace${{env.DEVDAX_NAMESPACE}} | grep size | cut -d':' -f2 | cut -d',' -f1)"
+
+      - name: Check configuration of the FSDAX
+        run: |
+          echo FSDAX_NAMESPACE="${{env.FSDAX_NAMESPACE}}"
+          echo UMF_TESTS_FSDAX_PATH="${{env.UMF_TESTS_FSDAX_PATH}}"
+          ndctl list --namespace=namespace${{env.FSDAX_NAMESPACE}}
+          ls -al /dev/${{env.FSDAX_PMEM}} /mnt/${{env.FSDAX_PMEM}}
+          mount | grep -e "/dev/${{env.FSDAX_PMEM}}"
+          touch ${{env.UMF_TESTS_FSDAX_PATH}}
+          rm -f ${{env.UMF_TESTS_FSDAX_PATH}}
 
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -80,3 +93,9 @@ jobs:
           UMF_TESTS_DEVDAX_PATH="/dev/dax${{env.DEVDAX_NAMESPACE}}"
           UMF_TESTS_DEVDAX_SIZE="$(ndctl list --namespace=namespace${{env.DEVDAX_NAMESPACE}} | grep size | cut -d':' -f2 | cut -d',' -f1)"
           ctest -C ${{matrix.build_type}} -R devdax -V
+
+      - name: Run the FSDAX tests
+        working-directory: ${{env.BUILD_DIR}}
+        run: >
+          UMF_TESTS_FSDAX_PATH=${{env.UMF_TESTS_FSDAX_PATH}}
+          ctest -C ${{matrix.build_type}} -R umf-provider_file_memory -V

--- a/.github/workflows/pr_push.yml
+++ b/.github/workflows/pr_push.yml
@@ -88,7 +88,7 @@ jobs:
     uses: ./.github/workflows/basic.yml
   DevDax:
     needs: [FastBuild]
-    uses: ./.github/workflows/devdax.yml
+    uses: ./.github/workflows/dax.yml
   Sanitizers:
     needs: [FastBuild]
     uses: ./.github/workflows/sanitizers.yml

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -9,6 +9,10 @@ set(COMMON_SOURCES
     provider_null.c
     provider_trace.c)
 
+if(LINUX)
+    set(COMMON_SOURCES ${COMMON_SOURCES} test_helpers_linux.c)
+endif(LINUX)
+
 add_umf_library(
     NAME umf_test_common
     TYPE STATIC

--- a/test/common/test_helpers_linux.c
+++ b/test/common/test_helpers_linux.c
@@ -1,0 +1,67 @@
+// Copyright (C) 2024 Intel Corporation
+// Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// This file contains tests for UMF pool API
+
+#include <fcntl.h>
+#include <stdbool.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "test_helpers_linux.h"
+
+// Check if the file given by the 'path' argument was mapped with the MAP_SYNC flag:
+// 1) Open and read the /proc/self/smaps file.
+// 2) Look for the section of the 'path' file.
+// 3) Check if the VmFlags of the 'path' file contains the "sf" flag
+//    marking that the file was mapped with the MAP_SYNC flag.
+bool is_mapped_with_MAP_SYNC(char *path, char *buf, size_t size_buf) {
+    memset(buf, 0, size_buf);
+
+    int fd = open("/proc/self/smaps", O_RDONLY);
+    if (fd == -1) {
+        return false;
+    }
+
+    // number of bytes read from the file
+    ssize_t nbytes = 1;
+    // string starting from the path of the smaps
+    char *smaps = NULL;
+
+    // Read the "/proc/self/smaps" file
+    // until the path of the smaps is found
+    // or EOF is reached.
+    while (nbytes > 0 && smaps == NULL) {
+        memset(buf, 0, nbytes); // erase previous data
+        nbytes = read(fd, buf, size_buf);
+        // look for the path of the smaps
+        smaps = strstr(buf, path);
+    }
+
+    // String starting from the "sf" flag
+    // marking that memory was mapped with the MAP_SYNC flag.
+    char *sf_flag = NULL;
+
+    if (smaps) {
+        // look for the "VmFlags:" string
+        char *VmFlags = strstr(smaps, "VmFlags:");
+        if (VmFlags) {
+            // look for the EOL
+            char *eol = strstr(VmFlags, "\n");
+            if (eol) {
+                // End the VmFlags string at EOL.
+                *eol = 0;
+                // Now the VmFlags string contains only one line with all VmFlags.
+
+                // Look for the "sf" flag in VmFlags
+                // marking that memory was mapped
+                // with the MAP_SYNC flag.
+                sf_flag = strstr(VmFlags, "sf");
+            }
+        }
+    }
+
+    return (sf_flag != NULL);
+}

--- a/test/common/test_helpers_linux.h
+++ b/test/common/test_helpers_linux.h
@@ -1,0 +1,21 @@
+// Copyright (C) 2024 Intel Corporation
+// Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// This file contains helpers for tests for UMF pool API
+
+#ifndef UMF_TEST_HELPERS_LINUX_H
+#define UMF_TEST_HELPERS_LINUX_H 1
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool is_mapped_with_MAP_SYNC(char *path, char *buf, size_t size_buf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UMF_TEST_HELPERS_LINUX_H */


### PR DESCRIPTION
### Description

Add test if FSDAX is mapped with the `MAP_SYNC` flag

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
