### PR TITLE
Fix name of the umf-standalone_examples test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -552,7 +552,7 @@ if(LINUX
 
     if(EXAMPLES AND NOT UMF_DISABLE_HWLOC)
         add_test(
-            NAME umf_standalone_examples
+            NAME umf-standalone_examples
             COMMAND
                 ${UMF_CMAKE_SOURCE_DIR}/test/test_examples.sh
                 ${UMF_CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR}


### PR DESCRIPTION
### Description

Replace `umf_standalone_examples` with `umf-standalone_examples`.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
