### PR TITLE
Close file descriptor in is_mapped_with_MAP_SYNC()

### DIFF
--- a/test/common/test_helpers_linux.c
+++ b/test/common/test_helpers_linux.c
@@ -40,6 +40,8 @@ bool is_mapped_with_MAP_SYNC(char *path, char *buf, size_t size_buf) {
         smaps = strstr(buf, path);
     }
 
+    (void)close(fd);
+
     // String starting from the "sf" flag
     // marking that memory was mapped with the MAP_SYNC flag.
     char *sf_flag = NULL;


### PR DESCRIPTION
### Description

Close file descriptor in `is_mapped_with_MAP_SYNC()`.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
