### PR TITLE
Clear tracker for the current pool on destroy

### DIFF
--- a/src/memory_pool.c
+++ b/src/memory_pool.c
@@ -41,8 +41,12 @@ static umf_result_t umfPoolCreateInternal(const umf_memory_pool_ops_t *ops,
     assert(ops->version == UMF_VERSION_CURRENT);
 
     if (!(flags & UMF_POOL_CREATE_FLAG_DISABLE_TRACKING)) {
-        // wrap provider with memory tracking provider
-        ret = umfTrackingMemoryProviderCreate(provider, pool, &pool->provider);
+        // Wrap provider with memory tracking provider.
+        // Check if the provider supports the free() operation.
+        bool upstreamDoesNotFree = (umfMemoryProviderFree(provider, NULL, 0) ==
+                                    UMF_RESULT_ERROR_NOT_SUPPORTED);
+        ret = umfTrackingMemoryProviderCreate(provider, pool, &pool->provider,
+                                              upstreamDoesNotFree);
         if (ret != UMF_RESULT_SUCCESS) {
             goto err_provider_create;
         }

--- a/src/provider/provider_tracking.h
+++ b/src/provider/provider_tracking.h
@@ -11,6 +11,7 @@
 #define UMF_MEMORY_TRACKER_INTERNAL_H 1
 
 #include <assert.h>
+#include <stdbool.h>
 #include <stdlib.h>
 
 #include <umf/base.h>
@@ -53,7 +54,7 @@ umf_result_t umfMemoryTrackerGetAllocInfo(const void *ptr,
 // forwards all requests to hUpstream memory Provider. hUpstream lifetime should be managed by the user of this function.
 umf_result_t umfTrackingMemoryProviderCreate(
     umf_memory_provider_handle_t hUpstream, umf_memory_pool_handle_t hPool,
-    umf_memory_provider_handle_t *hTrackingProvider);
+    umf_memory_provider_handle_t *hTrackingProvider, bool upstreamDoesNotFree);
 
 void umfTrackingMemoryProviderGetUpstreamProvider(
     umf_memory_provider_handle_t hTrackingProvider,

--- a/test/memoryPoolAPI.cpp
+++ b/test/memoryPoolAPI.cpp
@@ -139,7 +139,8 @@ TEST_P(umfPoolWithCreateFlagsTest, memoryPoolWithCustomProvider) {
 }
 
 TEST_F(test, retrieveMemoryProvider) {
-    umf_memory_provider_handle_t provider = (umf_memory_provider_handle_t)0x1;
+    auto nullProvider = umf_test::wrapProviderUnique(nullProviderCreate());
+    umf_memory_provider_handle_t provider = nullProvider.get();
 
     auto pool =
         wrapPoolUnique(createPoolChecked(umfProxyPoolOps(), provider, nullptr));
@@ -258,7 +259,8 @@ TEST_P(poolInitializeTest, errorPropagation) {
 }
 
 TEST_F(test, retrieveMemoryProvidersError) {
-    umf_memory_provider_handle_t provider = (umf_memory_provider_handle_t)0x1;
+    auto nullProvider = umf_test::wrapProviderUnique(nullProviderCreate());
+    umf_memory_provider_handle_t provider = nullProvider.get();
 
     auto pool =
         wrapPoolUnique(createPoolChecked(umfProxyPoolOps(), provider, nullptr));

--- a/test/pools/disjoint_pool.cpp
+++ b/test/pools/disjoint_pool.cpp
@@ -82,7 +82,10 @@ TEST_F(test, sharedLimits) {
         }
         umf_result_t free(void *ptr, [[maybe_unused]] size_t size) noexcept {
             ::free(ptr);
-            numFrees++;
+            // umfMemoryProviderFree(provider, NULL, 0) is called inside umfPoolCreateInternal()
+            if (ptr != NULL && size != 0) {
+                numFrees++;
+            }
             return UMF_RESULT_SUCCESS;
         }
     };


### PR DESCRIPTION
### Description

Clear tracker for the current pool when destroying the pool
and clear the whole tracker when destroying the UMF library.
Print error messages about unfreed allocations left in the tracker
only if provider supports the `free()` operation.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
