### PR TITLE
Fix arguments checking in IPC API of OS and file memory providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,9 @@ so it should be used with a pool manager that will take over
 the managing of the provided memory - for example the jemalloc pool
 with the `disable_provider_free` parameter set to true.
 
+IPC API requires the `UMF_MEM_MAP_SHARED` or `UMF_MEM_MAP_SYNC` memory `visibility` mode
+(`UMF_RESULT_ERROR_INVALID_ARGUMENT` is returned otherwise).
+
 The memory visibility mode parameter must be set to `UMF_MEM_MAP_SYNC` in case of FSDAX.
 
 ##### Requirements

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ OS memory provider supports two types of memory mappings (set by the `visibility
 1) private memory mapping (`UMF_MEM_MAP_PRIVATE`)
 2) shared memory mapping (`UMF_MEM_MAP_SHARED` - supported on Linux only yet)
 
+IPC API requires the `UMF_MEM_MAP_SHARED` memory `visibility` mode
+(`UMF_RESULT_ERROR_INVALID_ARGUMENT` is returned otherwise).
+
 There are available two mechanisms for the shared memory mapping:
 1) a named shared memory object (used if the `shm_name` parameter is not NULL) or
 2) an anonymous file descriptor (used if the `shm_name` parameter is NULL)

--- a/src/provider/provider_os_memory_internal.h
+++ b/src/provider/provider_os_memory_internal.h
@@ -9,6 +9,7 @@
 #define UMF_OS_MEMORY_PROVIDER_INTERNAL_H
 
 #include <limits.h>
+#include <stdbool.h>
 
 #if defined(_WIN32) && !defined(NAME_MAX)
 #include <stdlib.h>
@@ -29,8 +30,13 @@ extern "C" {
 typedef struct os_memory_provider_t {
     unsigned protection; // combination of OS-specific protection flags
     unsigned visibility; // memory visibility mode
+
+    // IPC is enabled only if (in_params->visibility == UMF_MEM_MAP_SHARED)
+    bool IPC_enabled;
+
     // a name of a shared memory file (valid only in case of the shared memory visibility)
     char shm_name[NAME_MAX];
+
     int fd;                // file descriptor for memory mapping
     size_t size_fd;        // size of file used for memory mapping
     size_t max_size_fd;    // maximum size of file used for memory mapping

--- a/test/provider_os_memory.cpp
+++ b/test/provider_os_memory.cpp
@@ -328,6 +328,41 @@ TEST_P(umfProviderTest, purge_force_INVALID_POINTER) {
                              UMF_OS_RESULT_ERROR_PURGE_FORCE_FAILED);
 }
 
+TEST_P(umfProviderTest, get_ipc_handle_size_wrong_visibility) {
+    size_t size;
+    umf_result_t umf_result =
+        umfMemoryProviderGetIPCHandleSize(provider.get(), &size);
+    ASSERT_EQ(umf_result, UMF_RESULT_ERROR_INVALID_ARGUMENT);
+}
+
+TEST_P(umfProviderTest, get_ipc_handle_wrong_visibility) {
+    char providerIpcData;
+    umf_result_t umf_result = umfMemoryProviderGetIPCHandle(
+        provider.get(), INVALID_PTR, 1, &providerIpcData);
+    ASSERT_EQ(umf_result, UMF_RESULT_ERROR_INVALID_ARGUMENT);
+}
+
+TEST_P(umfProviderTest, put_ipc_handle_wrong_visibility) {
+    char providerIpcData;
+    umf_result_t umf_result =
+        umfMemoryProviderPutIPCHandle(provider.get(), &providerIpcData);
+    ASSERT_EQ(umf_result, UMF_RESULT_ERROR_INVALID_ARGUMENT);
+}
+
+TEST_P(umfProviderTest, open_ipc_handle_wrong_visibility) {
+    char providerIpcData;
+    void *ptr;
+    umf_result_t umf_result =
+        umfMemoryProviderOpenIPCHandle(provider.get(), &providerIpcData, &ptr);
+    ASSERT_EQ(umf_result, UMF_RESULT_ERROR_INVALID_ARGUMENT);
+}
+
+TEST_P(umfProviderTest, close_ipc_handle_wrong_visibility) {
+    umf_result_t umf_result =
+        umfMemoryProviderCloseIPCHandle(provider.get(), INVALID_PTR, 1);
+    ASSERT_EQ(umf_result, UMF_RESULT_ERROR_INVALID_ARGUMENT);
+}
+
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(umfIpcTest);
 
 umf_os_memory_provider_params_t osMemoryProviderParamsShared() {


### PR DESCRIPTION
### Description

IPC API of OS memory provider requires the `UMF_MEM_MAP_SHARED` memory `visibility` mode (`UMF_RESULT_ERROR_INVALID_ARGUMENT` is returned otherwise).

IPC API of file memory provider requires the `UMF_MEM_MAP_SHARED`
or `UMF_MEM_MAP_SYNC` memory `visibility` mode
(`UMF_RESULT_ERROR_INVALID_ARGUMENT` is returned otherwise).

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
