### PR TITLE
Use UMF_MEM_MAP_SYNC for FSDAX in the FSDAX IPC example

### DIFF
--- a/test/ipc_file_prov_consumer.c
+++ b/test/ipc_file_prov_consumer.c
@@ -5,8 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <strings.h>
 
 #include <umf/providers/provider_file_memory.h>
 
@@ -15,17 +18,30 @@
 
 int main(int argc, char *argv[]) {
     if (argc < 3) {
-        fprintf(stderr, "usage: %s <port> <file_name>\n", argv[0]);
+        fprintf(stderr, "usage: %s <port> <file_name> <fsdax>\n", argv[0]);
+        fprintf(stderr, "       <fsdax> should be \"FSDAX\" or \"fsdax\" if "
+                        "<file_name> is located on FSDAX \n");
         return -1;
     }
 
     int port = atoi(argv[1]);
     char *file_name = argv[2];
+    bool is_fsdax = false;
+
+    if (argc >= 4) {
+        if (strncasecmp(argv[3], "FSDAX", strlen("FSDAX")) == 0) {
+            is_fsdax = true;
+        }
+    }
 
     umf_file_memory_provider_params_t file_params;
 
     file_params = umfFileMemoryProviderParamsDefault(file_name);
-    file_params.visibility = UMF_MEM_MAP_SHARED;
+    if (is_fsdax) {
+        file_params.visibility = UMF_MEM_MAP_SYNC;
+    } else {
+        file_params.visibility = UMF_MEM_MAP_SHARED;
+    }
 
     return run_consumer(port, umfFileMemoryProviderOps(), &file_params, memcopy,
                         NULL);

--- a/test/ipc_file_prov_fsdax.sh
+++ b/test/ipc_file_prov_fsdax.sh
@@ -25,13 +25,13 @@ UMF_LOG_VAL="level:debug;flush:debug;output:stderr;pid:yes"
 rm -f ${FILE_NAME}
 
 echo "Starting ipc_file_prov_fsdax CONSUMER on port $PORT ..."
-UMF_LOG=$UMF_LOG_VAL ./umf_test-ipc_file_prov_consumer $PORT $FILE_NAME &
+UMF_LOG=$UMF_LOG_VAL ./umf_test-ipc_file_prov_consumer $PORT $FILE_NAME "FSDAX" &
 
 echo "Waiting 1 sec ..."
 sleep 1
 
 echo "Starting ipc_file_prov_fsdax PRODUCER on port $PORT ..."
-UMF_LOG=$UMF_LOG_VAL ./umf_test-ipc_file_prov_producer $PORT $FILE_NAME
+UMF_LOG=$UMF_LOG_VAL ./umf_test-ipc_file_prov_producer $PORT $FILE_NAME "FSDAX"
 
 # remove the SHM file
 rm -f ${FILE_NAME}

--- a/test/ipc_file_prov_producer.c
+++ b/test/ipc_file_prov_producer.c
@@ -5,8 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <strings.h>
 
 #include <umf/providers/provider_file_memory.h>
 
@@ -15,17 +18,30 @@
 
 int main(int argc, char *argv[]) {
     if (argc < 3) {
-        fprintf(stderr, "usage: %s <port> <file_name>\n", argv[0]);
+        fprintf(stderr, "usage: %s <port> <file_name> <fsdax>\n", argv[0]);
+        fprintf(stderr, "       <fsdax> should be \"FSDAX\" or \"fsdax\" if "
+                        "<file_name> is located on FSDAX \n");
         return -1;
     }
 
     int port = atoi(argv[1]);
     char *file_name = argv[2];
+    bool is_fsdax = false;
+
+    if (argc >= 4) {
+        if (strncasecmp(argv[3], "FSDAX", strlen("FSDAX")) == 0) {
+            is_fsdax = true;
+        }
+    }
 
     umf_file_memory_provider_params_t file_params;
 
     file_params = umfFileMemoryProviderParamsDefault(file_name);
-    file_params.visibility = UMF_MEM_MAP_SHARED;
+    if (is_fsdax) {
+        file_params.visibility = UMF_MEM_MAP_SYNC;
+    } else {
+        file_params.visibility = UMF_MEM_MAP_SHARED;
+    }
 
     return run_producer(port, umfFileMemoryProviderOps(), &file_params, memcopy,
                         NULL);


### PR DESCRIPTION
### Description

Use `UMF_MEM_MAP_SYNC` for FSDAX in the FSDAX IPC example.

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
