### PR TITLE
Fix handling resident_device_handles in L0 provider

### DIFF
--- a/benchmark/ubench.c
+++ b/benchmark/ubench.c
@@ -430,7 +430,7 @@ int create_level_zero_params(level_zero_memory_provider_params_t *params) {
 UBENCH_EX(ipc, disjoint_pool_with_level_zero_provider) {
     const size_t BUFFER_SIZE = 100;
     const size_t N_BUFFERS = 1000;
-    level_zero_memory_provider_params_t level_zero_params;
+    level_zero_memory_provider_params_t level_zero_params = {0};
 
     int ret = create_level_zero_params(&level_zero_params);
     if (ret != 0) {

--- a/examples/ipc_level_zero/ipc_level_zero.c
+++ b/examples/ipc_level_zero/ipc_level_zero.c
@@ -20,7 +20,7 @@ int create_level_zero_pool(ze_context_handle_t context,
                            ze_device_handle_t device,
                            umf_memory_pool_handle_t *pool) {
     // setup params
-    level_zero_memory_provider_params_t params;
+    level_zero_memory_provider_params_t params = {0};
     params.level_zero_context_handle = context;
     params.level_zero_device_handle = device;
     params.memory_type = UMF_MEMORY_TYPE_DEVICE;

--- a/examples/level_zero_shared_memory/level_zero_shared_memory.c
+++ b/examples/level_zero_shared_memory/level_zero_shared_memory.c
@@ -49,7 +49,7 @@ int main(void) {
 
     // Setup parameters for the Level Zero memory provider. It will be used for
     // allocating memory from Level Zero devices.
-    level_zero_memory_provider_params_t ze_memory_provider_params;
+    level_zero_memory_provider_params_t ze_memory_provider_params = {0};
     ze_memory_provider_params.level_zero_context_handle = hContext;
     ze_memory_provider_params.level_zero_device_handle = hDevice;
     // Set the memory type to shared to allow the memory to be accessed on both

--- a/src/provider/provider_level_zero.c
+++ b/src/provider/provider_level_zero.c
@@ -177,6 +177,25 @@ static umf_result_t ze_memory_provider_initialize(void *params,
                sizeof(ze_provider->device_properties));
     }
 
+    if (ze_params->resident_device_count) {
+        ze_provider->resident_device_handles = umf_ba_global_alloc(
+            sizeof(ze_device_handle_t) * ze_params->resident_device_count);
+        if (!ze_provider->resident_device_handles) {
+            umf_ba_global_free(ze_provider);
+            return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+        }
+
+        ze_provider->resident_device_count = ze_params->resident_device_count;
+
+        for (uint32_t i = 0; i < ze_provider->resident_device_count; i++) {
+            ze_provider->resident_device_handles[i] =
+                ze_params->resident_device_handles[i];
+        }
+    } else {
+        ze_provider->resident_device_handles = NULL;
+        ze_provider->resident_device_count = 0;
+    }
+
     *provider = ze_provider;
 
     return UMF_RESULT_SUCCESS;
@@ -187,6 +206,9 @@ static void ze_memory_provider_finalize(void *provider) {
         ASSERT(0);
         return;
     }
+
+    ze_memory_provider_t *ze_provider = (ze_memory_provider_t *)provider;
+    umf_ba_global_free(ze_provider->resident_device_handles);
 
     umf_ba_global_free(provider);
 }


### PR DESCRIPTION
handles were being ignored in the initialize function.

Unfortunetaly there is no easy way to test the residency here. I'm working on a test in UR repo for that.
