### PR TITLE
Wrap linker flags on Windows for IntelLLVM

### DIFF
--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -295,17 +295,17 @@ function(add_umf_target_link_options name)
         target_link_options(
             ${name}
             PRIVATE
-            /DYNAMICBASE
-            /HIGHENTROPYVA
+            LINKER:/DYNAMICBASE
+            LINKER:/HIGHENTROPYVA
             $<$<C_COMPILER_ID:MSVC>:/DEPENDENTLOADFLAG:0x2000>
             $<$<CXX_COMPILER_ID:MSVC>:/DEPENDENTLOADFLAG:0x2000>
-            /NXCOMPAT)
+            LINKER:/NXCOMPAT)
     endif()
 endfunction()
 
 function(add_umf_target_exec_options name)
     if(MSVC)
-        target_link_options(${name} PRIVATE /ALLOWISOLATION)
+        target_link_options(${name} PRIVATE LINKER:/ALLOWISOLATION)
     endif()
 endfunction()
 
@@ -362,7 +362,7 @@ function(add_umf_library)
 
         if(WINDOWS)
             target_link_options(${ARG_NAME} PRIVATE
-                                /DEF:${ARG_WINDOWS_DEF_FILE})
+                                LINKER:/DEF:${ARG_WINDOWS_DEF_FILE})
         elseif(LINUX)
             target_link_options(${ARG_NAME} PRIVATE
                                 "-Wl,--version-script=${ARG_LINUX_MAP_FILE}")


### PR DESCRIPTION
The Intel C++ compiler requires linker flags to be wrapped, because CMake passes them through the compiler driver.
Prefix Linker options with `LINKER:`.
CMake will transform it to the appropriate flag for the compiler driver: (Nothing for MSVC, clang-cl and /Qoption,link for ICX), so this will work for the other compilers too, and for earlier versions of CMake.

Fixes: #757

### Checklist
- [x] Code compiles without errors locally
- [ ] All tests pass locally -- (Only verified building)
- [ ] CI workflows execute properly
