### PR TITLE
clang-cl.exe does not support /analyze flag

### DIFF
--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -258,7 +258,7 @@ function(add_umf_target_compile_options name)
             ${name}
             PRIVATE /MD$<$<CONFIG:Debug>:d>
                     $<$<CONFIG:Release>:/sdl>
-                    /analyze
+                    $<$<CXX_COMPILER_ID:MSVC>:/analyze>
                     /DYNAMICBASE
                     /W4
                     /Gy


### PR DESCRIPTION
### Description

Disable setting the `/analyze` flag on Windows if the compiler ID does not equal MSVC, this fixes builds using the `clang-cl.exe` frontend which does not support this flag.

### Checklist

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
