### PR TITLE
Fix build with hwloc support disabled

### DIFF
--- a/src/libumf.map.in
+++ b/src/libumf.map.in
@@ -37,7 +37,6 @@ UMF_1.0 {
         umfMempolicySetCustomSplitPartitions;
         umfMempolicySetInterleavePartSize;
         umfMemspaceClone;
-        umfMemspaceCreateFromNumaArray;
         umfMemspaceDestroy;
         umfMemspaceFilterByCapacity;
         umfMemspaceFilterById;


### PR DESCRIPTION
### Description

`umfMemspaceCreateFromNumaArray` is defined in
`memspaces/memspace_numa.c` which is only added to the build if hwloc is enabled.

When hwloc is enabled this is added as an optional symbol to the linker script through `UMF_OPTIONAL_SYMBOLS_LINUX`.

When hwloc is disabled this symbol isn't available so this linker script would fail, I believe the correct fix is just to remove the symbol from the linker script.

I ran into this issue while building DPC++ with hwloc disabled.

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

