### PR TITLE
Remove unused function get_block_node()

### DIFF
--- a/src/provider/provider_coarse.c
+++ b/src/provider/provider_coarse.c
@@ -120,11 +120,6 @@ static int coarse_ravl_comp(const void *lhs, const void *rhs) {
     return 0;
 }
 
-static inline ravl_node_t *get_block_node(struct ravl *rtree, block_t *block) {
-    ravl_data_t rdata = {(uintptr_t)block->data, NULL};
-    return ravl_find(rtree, &rdata, RAVL_PREDICATE_EQUAL);
-}
-
 static inline block_t *get_node_block(ravl_node_t *node) {
     ravl_data_t *node_data = ravl_data(node);
     assert(node_data);


### PR DESCRIPTION

### Description

Remove unused function `get_block_node()`.

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
