### PR TITLE
Bump pip dependencies

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,6 +46,11 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Setup newer Python
+      uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
+      with:
+        python-version: "3.10"
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@b7bf0a3ed3ecfa44160715d7c442788f65f0f923 # v3.23.2
       with:

--- a/third_party/requirements.txt
+++ b/third_party/requirements.txt
@@ -4,14 +4,14 @@ clang-format==15.0.7
 cmake-format==0.6.13
 black==24.3.0
 # Tests
-packaging==24.0
+packaging==24.1
 # Generating HTML documentation
-pygments==2.15.1
-sphinxcontrib_applehelp==1.0.4
-sphinxcontrib_devhelp==1.0.2
-sphinxcontrib_htmlhelp==2.0.1
-sphinxcontrib_serializinghtml==1.1.5
-sphinxcontrib_qthelp==1.0.3
+pygments==2.18.0
+sphinxcontrib_applehelp==2.0.0
+sphinxcontrib_devhelp==2.0.0
+sphinxcontrib_htmlhelp==2.1.0
+sphinxcontrib_serializinghtml==2.0.0
+sphinxcontrib_qthelp==2.0.0
 breathe==4.35.0
-sphinx==4.5.0
-sphinx_book_theme==0.3.3
+sphinx==8.0.2
+sphinx_book_theme==1.1.3


### PR DESCRIPTION
Bump pip dependencies to the newest versions. One small downside is that on Windows `sphinx==8.x` requires `python>=3.10`, which is not installed by default on Windows runners (meaning, it's probably not a standard there yet?).

Generated website did not change much:
new, on my fork: https://lukaszstolarczuk.github.io/unified-memory-framework/index.html
current on upstream: https://oneapi-src.github.io/unified-memory-framework/