### PR TITLE
Fix issue in trackingGetIpcHandle

### DIFF
--- a/src/provider/provider_os_memory.c
+++ b/src/provider/provider_os_memory.c
@@ -1179,12 +1179,17 @@ static umf_result_t os_get_ipc_handle_size(void *provider, size_t *size) {
 static umf_result_t os_get_ipc_handle(void *provider, const void *ptr,
                                       size_t size, void *providerIpcData) {
     if (provider == NULL || ptr == NULL || providerIpcData == NULL) {
+        LOG_ERR(
+            "Some argument is NULL, provider=%p, ptr=%p, providerIpcData=%p",
+            provider, ptr, providerIpcData);
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
 
     os_memory_provider_t *os_provider = (os_memory_provider_t *)provider;
     if (!os_provider->IPC_enabled) {
-        LOG_ERR("memory visibility mode is not UMF_MEM_MAP_SHARED")
+        LOG_ERR("memory visibility mode is not UMF_MEM_MAP_SHARED, ptr=%p, "
+                "size=%lu",
+                ptr, size);
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
 
@@ -1213,6 +1218,9 @@ static umf_result_t os_get_ipc_handle(void *provider, const void *ptr,
 
 static umf_result_t os_put_ipc_handle(void *provider, void *providerIpcData) {
     if (provider == NULL || providerIpcData == NULL) {
+        LOG_ERR("provider or providerIpcData are NULL, provider=%p, "
+                "providerIpcData=%p",
+                provider, providerIpcData);
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
 
@@ -1225,19 +1233,28 @@ static umf_result_t os_put_ipc_handle(void *provider, void *providerIpcData) {
     os_ipc_data_t *os_ipc_data = (os_ipc_data_t *)providerIpcData;
 
     if (os_ipc_data->pid != utils_getpid()) {
+        LOG_ERR("invalid PID, os_ipc_data->pid = %d", os_ipc_data->pid);
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
 
     size_t shm_name_len = strlen(os_provider->shm_name);
     if (shm_name_len > 0) {
         if (os_ipc_data->shm_name_len != shm_name_len) {
+            LOG_ERR("invalid shm_name_len, os_ipc_data->shm_name_len=%lu, "
+                    "expected shm_name_len=%lu",
+                    os_ipc_data->shm_name_len, shm_name_len);
             return UMF_RESULT_ERROR_INVALID_ARGUMENT;
         } else if (strncmp(os_ipc_data->shm_name, os_provider->shm_name,
                            shm_name_len)) {
+            LOG_ERR("invalid shm_name, os_ipc_data->shm_name=%s, "
+                    "os_provider->shm_name=%s",
+                    os_ipc_data->shm_name, os_provider->shm_name);
             return UMF_RESULT_ERROR_INVALID_ARGUMENT;
         }
     } else {
         if (os_ipc_data->fd != os_provider->fd) {
+            LOG_ERR("invalid fd, os_ipc_data->fd=%d, os_provider->fd=%d",
+                    os_ipc_data->fd, os_provider->fd);
             return UMF_RESULT_ERROR_INVALID_ARGUMENT;
         }
     }

--- a/src/provider/provider_tracking.c
+++ b/src/provider/provider_tracking.c
@@ -571,8 +571,8 @@ static umf_result_t trackingGetIpcHandle(void *provider, const void *ptr,
                 // 2. critnib failed to allocate memory internally. We need
                 //    to cleanup and return corresponding error.
                 umf_ba_global_free(cache_value);
-                ret = umfMemoryProviderPutIPCHandle(p->hUpstream,
-                                                    providerIpcData);
+                ret = umfMemoryProviderPutIPCHandle(
+                    p->hUpstream, cache_value->providerIpcData);
                 if (ret != UMF_RESULT_SUCCESS) {
                     LOG_ERR("upstream provider is failed to put IPC handle");
                     return ret;


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description
During the work on the #736 the issue in the `trackingGetIpcHandle` function was found. It was found due to CI failure: the `osProviderTest/umfIpcTest.ConcurrentGetPutHandles` start failing.

### Checklist

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [ ] CI workflows execute properly
