### PR TITLE
Fix: add missing header stdexcept in benchmark/multithread.hpp

### DIFF
--- a/benchmark/multithread.hpp
+++ b/benchmark/multithread.hpp
@@ -17,6 +17,7 @@
 #include <functional>
 #include <mutex>
 #include <numeric>
+#include <stdexcept>
 #include <thread>
 #include <vector>
 


### PR DESCRIPTION
### Description

Fix: add missing header `<stdexcept>` in benchmark/multithread.hpp

It fixes the following build error:
```
In file included from /home/runner/work/unified-memory-framework/unified-memory-framework/benchmark/multithread.cpp:10:
/home/runner/work/unified-memory-framework/unified-memory-framework/benchmark/multithread.hpp: In function ‘auto umf_bench::measure(size_t, size_t, F&&)’:
/home/runner/work/unified-memory-framework/unified-memory-framework/benchmark/multithread.hpp:42:20: error: ‘runtime_error’ is not a member of ‘std’
   42 |         throw std::runtime_error("iterations must be > 1");
      |                    ^~~~~~~~~~~~~
/home/runner/work/unified-memory-framework/unified-memory-framework/benchmark/multithread.hpp:24:1: note: ‘std::runtime_error’ is defined in header ‘<stdexcept>’; did you forget to ‘#include <stdexcept>’?
   23 | #include "multithread_helpers.hpp"
  +++ |+#include <stdexcept>
   24 | 
```

See: https://github.com/ldorau/unified-memory-framework/actions/runs/11323579534/job/31486568812

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
