### PR TITLE
remove optional symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,29 +423,6 @@ if((UMF_BUILD_GPU_TESTS OR UMF_BUILD_GPU_EXAMPLES) AND UMF_BUILD_CUDA_PROVIDER)
     # TODO do the same for ze_loader
 endif()
 
-# set optional symbols for map/def files
-#
-# TODO: ref. #649
-set(UMF_OPTIONAL_SYMBOLS_LINUX "")
-set(UMF_OPTIONAL_SYMBOLS_WINDOWS "")
-
-if(UMF_BUILD_LEVEL_ZERO_PROVIDER)
-    add_optional_symbol(umfLevelZeroMemoryProviderOps)
-endif()
-
-# Conditional configuration for CUDA provider
-if(UMF_BUILD_CUDA_PROVIDER)
-    add_optional_symbol(umfCUDAMemoryProviderOps)
-endif()
-
-if(NOT UMF_DISABLE_HWLOC)
-    add_optional_symbol(umfOsMemoryProviderOps)
-    if(LINUX)
-        add_optional_symbol(umfDevDaxMemoryProviderOps)
-        add_optional_symbol(umfFileMemoryProviderOps)
-    endif()
-endif()
-
 add_subdirectory(src)
 
 if(UMF_BUILD_TESTS)

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -446,12 +446,3 @@ macro(add_sanitizer_flag flag)
 
     set(CMAKE_REQUIRED_FLAGS ${SAVED_CMAKE_REQUIRED_FLAGS})
 endmacro()
-
-function(add_optional_symbol symbol)
-    set(UMF_OPTIONAL_SYMBOLS_WINDOWS
-        "${UMF_OPTIONAL_SYMBOLS_WINDOWS} \n    ${symbol}"
-        PARENT_SCOPE)
-    set(UMF_OPTIONAL_SYMBOLS_LINUX
-        "${UMF_OPTIONAL_SYMBOLS_LINUX} \n    ${symbol};"
-        PARENT_SCOPE)
-endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -110,6 +110,16 @@ set(UMF_SOURCES
     memtarget.c
     mempolicy.c
     memspace.c
+    memspaces/memspace_host_all.c
+    memspaces/memspace_highest_capacity.c
+    memspaces/memspace_highest_bandwidth.c
+    memspaces/memspace_lowest_latency.c
+    memspaces/memspace_numa.c
+    provider/provider_cuda.c
+    provider/provider_devdax_memory.c
+    provider/provider_file_memory.c
+    provider/provider_level_zero.c
+    provider/provider_os_memory.c
     provider/provider_tracking.c
     critnib/critnib.c
     ravl/ravl.c
@@ -117,62 +127,35 @@ set(UMF_SOURCES
     pool/pool_scalable.c)
 
 if(NOT UMF_DISABLE_HWLOC)
-    set(UMF_SOURCES ${UMF_SOURCES} ${HWLOC_DEPENDENT_SOURCES})
+    set(UMF_SOURCES ${UMF_SOURCES} ${HWLOC_DEPENDENT_SOURCES}
+                    memtargets/memtarget_numa.c)
+    set(UMF_LIBS ${UMF_LIBS} ${LIBHWLOC_LIBRARIES})
+    set(UMF_PRIVATE_LIBRARY_DIRS ${UMF_PRIVATE_LIBRARY_DIRS}
+                                 ${LIBHWLOC_LIBRARY_DIRS})
+else()
+    set(UMF_COMMON_COMPILE_DEFINITIONS ${UMF_COMMON_COMPILE_DEFINITIONS}
+                                       "UMF_NO_HWLOC=1")
 endif()
 
 set(UMF_SOURCES_LINUX libumf_linux.c)
-
 set(UMF_SOURCES_MACOSX libumf_linux.c)
-
 set(UMF_SOURCES_WINDOWS libumf_windows.c)
 
-set(UMF_SOURCES_COMMON_LINUX_MACOSX
-    provider/provider_devdax_memory.c
-    provider/provider_file_memory.c
-    provider/provider_os_memory.c
-    memtargets/memtarget_numa.c
-    memspaces/memspace_numa.c
-    memspaces/memspace_host_all.c
-    memspaces/memspace_highest_capacity.c
-    memspaces/memspace_highest_bandwidth.c
-    memspaces/memspace_lowest_latency.c)
-
-if(NOT UMF_DISABLE_HWLOC)
-    set(UMF_SOURCES_LINUX ${UMF_SOURCES_LINUX}
-                          ${UMF_SOURCES_COMMON_LINUX_MACOSX})
-
-    set(UMF_SOURCES_MACOSX ${UMF_SOURCES_MACOSX}
-                           ${UMF_SOURCES_COMMON_LINUX_MACOSX})
-
-    set(UMF_SOURCES_WINDOWS ${UMF_SOURCES_WINDOWS}
-                            provider/provider_os_memory.c)
-
-    set(UMF_LIBS ${UMF_LIBS} ${LIBHWLOC_LIBRARIES})
-
-    if(NOT WINDOWS)
-        add_optional_symbol(umfMemspaceCreateFromNumaArray)
-        add_optional_symbol(umfMemspaceHighestBandwidthGet)
-        add_optional_symbol(umfMemspaceHighestCapacityGet)
-        add_optional_symbol(umfMemspaceHostAllGet)
-        add_optional_symbol(umfMemspaceLowestLatencyGet)
-    endif()
+# Add compile definitions to handle unsupported functions
+if(NOT UMF_BUILD_CUDA_PROVIDER)
+    set(UMF_COMMON_COMPILE_DEFINITIONS ${UMF_COMMON_COMPILE_DEFINITIONS}
+                                       "UMF_NO_CUDA_PROVIDER=1")
 endif()
-
-if(WINDOWS)
-    message(STATUS "UMF_OPTIONAL_SYMBOLS: ${UMF_OPTIONAL_SYMBOLS_WINDOWS}")
-else()
-    message(STATUS "UMF_OPTIONAL_SYMBOLS: ${UMF_OPTIONAL_SYMBOLS_LINUX}")
+if(NOT UMF_BUILD_LEVEL_ZERO_PROVIDER)
+    set(UMF_COMMON_COMPILE_DEFINITIONS ${UMF_COMMON_COMPILE_DEFINITIONS}
+                                       "UMF_NO_LEVEL_ZERO_PROVIDER=1")
 endif()
-
-# Configure map/def files with optional symbols
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/libumf.def.in"
-               "${CMAKE_CURRENT_BINARY_DIR}/libumf.def" @ONLY)
-
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/libumf.map.in"
-               "${CMAKE_CURRENT_BINARY_DIR}/libumf.map" @ONLY)
-
-set(UMF_PRIVATE_LIBRARY_DIRS ${UMF_PRIVATE_LIBRARY_DIRS}
-                             ${LIBHWLOC_LIBRARY_DIRS})
+if(UMF_DISABLE_HWLOC OR WINDOWS)
+    set(UMF_COMMON_COMPILE_DEFINITIONS ${UMF_COMMON_COMPILE_DEFINITIONS}
+                                       "UMF_NO_DEVDAX_PROVIDER=1")
+    set(UMF_COMMON_COMPILE_DEFINITIONS ${UMF_COMMON_COMPILE_DEFINITIONS}
+                                       "UMF_NO_FILE_PROVIDER=1")
+endif()
 
 if(LINUX)
     set(UMF_SOURCES ${UMF_SOURCES} ${UMF_SOURCES_LINUX})
@@ -197,8 +180,8 @@ if(UMF_BUILD_SHARED_LIBRARY)
         TYPE SHARED
         SRCS ${UMF_SOURCES}
         LIBS ${UMF_LIBS} ${HWLOC_LIB}
-        LINUX_MAP_FILE ${CMAKE_CURRENT_BINARY_DIR}/libumf.map
-        WINDOWS_DEF_FILE ${CMAKE_CURRENT_BINARY_DIR}/libumf.def)
+        LINUX_MAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/libumf.map
+        WINDOWS_DEF_FILE ${CMAKE_CURRENT_SOURCE_DIR}/libumf.def)
     set(UMF_COMMON_COMPILE_DEFINITIONS ${UMF_COMMON_COMPILE_DEFINITIONS}
                                        "UMF_SHARED_LIBRARY")
     set_target_properties(
@@ -214,11 +197,6 @@ else()
         LIBS ${UMF_LIBS})
 endif()
 
-if(UMF_DISABLE_HWLOC)
-    set(UMF_COMMON_COMPILE_DEFINITIONS ${UMF_COMMON_COMPILE_DEFINITIONS}
-                                       UMF_NO_HWLOC=1)
-endif()
-
 if(UMF_LINK_HWLOC_STATICALLY)
     add_dependencies(umf ${UMF_HWLOC_NAME})
 endif()
@@ -228,8 +206,6 @@ target_link_directories(umf PRIVATE ${UMF_PRIVATE_LIBRARY_DIRS})
 target_compile_definitions(umf PRIVATE ${UMF_COMMON_COMPILE_DEFINITIONS})
 
 if(UMF_BUILD_LEVEL_ZERO_PROVIDER)
-    target_sources(umf PRIVATE provider/provider_level_zero.c)
-
     if(LINUX)
         # WA for error ze_api.h:14234:20: no newline at end of file
         # [-Werror,-Wnewline-eof]
@@ -243,7 +219,6 @@ if(UMF_BUILD_LEVEL_ZERO_PROVIDER)
 endif()
 
 if(UMF_BUILD_CUDA_PROVIDER)
-    target_sources(umf PRIVATE provider/provider_cuda.c)
     set(UMF_COMPILE_DEFINITIONS ${UMF_COMPILE_DEFINITIONS}
                                 "UMF_BUILD_CUDA_PROVIDER=1")
 endif()

--- a/src/libumf.def
+++ b/src/libumf.def
@@ -14,10 +14,13 @@ EXPORTS
     umfTearDown
     umfGetCurrentVersion
     umfCloseIPCHandle
+    umfCUDAMemoryProviderOps
+    umfDevDaxMemoryProviderOps
     umfFree
+    umfFileMemoryProviderOps
     umfGetIPCHandle
     umfGetLastFailedMemoryProvider
-    umfMemoryTrackerGetAllocInfo
+    umfLevelZeroMemoryProviderOps
     umfMemoryProviderAlloc
     umfMemoryProviderAllocationMerge
     umfMemoryProviderAllocationSplit
@@ -36,14 +39,20 @@ EXPORTS
     umfMemoryProviderPurgeForce
     umfMemoryProviderPurgeLazy
     umfMemoryProviderPutIPCHandle
+    umfMemoryTrackerGetAllocInfo
     umfMempolicyCreate
     umfMempolicyDestroy
     umfMempolicySetCustomSplitPartitions
     umfMempolicySetInterleavePartSize
     umfMemspaceClone
+    umfMemspaceCreateFromNumaArray
     umfMemspaceDestroy
     umfMemspaceFilterByCapacity
     umfMemspaceFilterById
+    umfMemspaceHighestBandwidthGet
+    umfMemspaceHighestCapacityGet
+    umfMemspaceHostAllGet
+    umfMemspaceLowestLatencyGet
     umfMemspaceMemtargetAdd
     umfMemspaceMemtargetGet
     umfMemspaceMemtargetNum
@@ -53,7 +62,8 @@ EXPORTS
     umfMemtargetGetCapacity
     umfMemtargetGetId
     umfMemtargetGetType
-    umfOpenIPCHandle    
+    umfOpenIPCHandle
+    umfOsMemoryProviderOps
     umfPoolAlignedMalloc
     umfPoolByPtr
     umfPoolCalloc
@@ -70,4 +80,3 @@ EXPORTS
     umfProxyPoolOps
     umfPutIPCHandle
     umfScalablePoolOps
-    @UMF_OPTIONAL_SYMBOLS_WINDOWS@

--- a/src/libumf.map
+++ b/src/libumf.map
@@ -8,10 +8,13 @@ UMF_1.0 {
         umfTearDown;
         umfGetCurrentVersion;
         umfCloseIPCHandle;
+        umfCUDAMemoryProviderOps;
+        umfDevDaxMemoryProviderOps;
         umfFree;
+        umfFileMemoryProviderOps;
         umfGetIPCHandle;
         umfGetLastFailedMemoryProvider;
-        umfMemoryTrackerGetAllocInfo;
+        umfLevelZeroMemoryProviderOps;
         umfMemoryProviderAlloc;
         umfMemoryProviderAllocationMerge;
         umfMemoryProviderAllocationSplit;
@@ -30,6 +33,7 @@ UMF_1.0 {
         umfMemoryProviderPurgeForce;
         umfMemoryProviderPurgeLazy;
         umfMemoryProviderPutIPCHandle;
+        umfMemoryTrackerGetAllocInfo;
         umfMempolicyCreate;
         umfMempolicyDestroy;
         umfMempolicySetCustomSplitPartitions;
@@ -39,6 +43,10 @@ UMF_1.0 {
         umfMemspaceDestroy;
         umfMemspaceFilterByCapacity;
         umfMemspaceFilterById;
+        umfMemspaceHighestBandwidthGet;
+        umfMemspaceHighestCapacityGet;
+        umfMemspaceHostAllGet;
+        umfMemspaceLowestLatencyGet;
         umfMemspaceMemtargetAdd;
         umfMemspaceMemtargetGet;
         umfMemspaceMemtargetNum;
@@ -49,6 +57,7 @@ UMF_1.0 {
         umfMemtargetGetId;
         umfMemtargetGetType;
         umfOpenIPCHandle;
+        umfOsMemoryProviderOps;
         umfPoolAlignedMalloc;
         umfPoolByPtr;
         umfPoolCalloc;
@@ -65,7 +74,6 @@ UMF_1.0 {
         umfProxyPoolOps;
         umfPutIPCHandle;
         umfScalablePoolOps;
-        @UMF_OPTIONAL_SYMBOLS_LINUX@
     local:
         *;
 };

--- a/src/memspaces/memspace_highest_bandwidth.c
+++ b/src/memspaces/memspace_highest_bandwidth.c
@@ -11,6 +11,20 @@
 #include <ctype.h>
 #include <stdlib.h>
 
+#include <umf.h>
+#include <umf/memspace.h>
+
+// UMF_MEMSPACE_HIGHEST_BANDWIDTH requires HWLOC
+// Additionally, it is currently unsupported on Win
+#if defined(_WIN32) || defined(UMF_NO_HWLOC)
+
+umf_const_memspace_handle_t umfMemspaceHighestBandwidthGet(void) {
+    // not supported
+    return NULL;
+}
+
+#else // !defined(_WIN32) && !defined(UMF_NO_HWLOC)
+
 #include "base_alloc_global.h"
 #include "memspace_internal.h"
 #include "memtarget_numa.h"
@@ -100,3 +114,5 @@ umf_const_memspace_handle_t umfMemspaceHighestBandwidthGet(void) {
                     umfMemspaceHighestBandwidthInit);
     return UMF_MEMSPACE_HIGHEST_BANDWIDTH;
 }
+
+#endif // !defined(_WIN32) && !defined(UMF_NO_HWLOC)

--- a/src/memspaces/memspace_highest_capacity.c
+++ b/src/memspaces/memspace_highest_capacity.c
@@ -10,6 +10,20 @@
 #include <assert.h>
 #include <stdlib.h>
 
+#include <umf.h>
+#include <umf/memspace.h>
+
+// UMF_MEMSPACE_HIGHEST_CAPACITY requires HWLOC
+// Additionally, it is currently unsupported on Win
+#if defined(_WIN32) || defined(UMF_NO_HWLOC)
+
+umf_const_memspace_handle_t umfMemspaceHighestCapacityGet(void) {
+    // not supported
+    return NULL;
+}
+
+#else // !defined(_WIN32) && !defined(UMF_NO_HWLOC)
+
 #include "base_alloc_global.h"
 #include "memspace_internal.h"
 #include "memtarget_numa.h"
@@ -72,3 +86,5 @@ umf_const_memspace_handle_t umfMemspaceHighestCapacityGet(void) {
                     umfMemspaceHighestCapacityInit);
     return UMF_MEMSPACE_HIGHEST_CAPACITY;
 }
+
+#endif // !defined(_WIN32) && !defined(UMF_NO_HWLOC)

--- a/src/memspaces/memspace_host_all.c
+++ b/src/memspaces/memspace_host_all.c
@@ -10,6 +10,20 @@
 #include <assert.h>
 #include <stdlib.h>
 
+#include <umf.h>
+#include <umf/memspace.h>
+
+// UMF_MEMSPACE_HOST_ALL requires HWLOC
+// Additionally, it is currently unsupported on Win
+
+#if defined(_WIN32) || defined(UMF_NO_HWLOC)
+umf_const_memspace_handle_t umfMemspaceHostAllGet(void) {
+    // not supported
+    return NULL;
+}
+
+#else // !defined(_WIN32) && !defined(UMF_NO_HWLOC)
+
 #include "base_alloc_global.h"
 #include "memspace_internal.h"
 #include "memtarget_numa.h"
@@ -93,3 +107,5 @@ umf_const_memspace_handle_t umfMemspaceHostAllGet(void) {
     utils_init_once(&UMF_MEMSPACE_HOST_ALL_INITIALIZED, umfMemspaceHostAllInit);
     return UMF_MEMSPACE_HOST_ALL;
 }
+
+#endif // !defined(_WIN32) && !defined(UMF_NO_HWLOC)

--- a/src/memspaces/memspace_lowest_latency.c
+++ b/src/memspaces/memspace_lowest_latency.c
@@ -11,6 +11,20 @@
 #include <ctype.h>
 #include <stdlib.h>
 
+#include <umf.h>
+#include <umf/memspace.h>
+
+// UMF_MEMSPACE_LOWEST_LATENCY requires HWLOC
+// Additionally, it is currently unsupported on Win
+#if defined(_WIN32) || defined(UMF_NO_HWLOC)
+
+umf_const_memspace_handle_t umfMemspaceLowestLatencyGet(void) {
+    // not supported
+    return NULL;
+}
+
+#else // !defined(_WIN32) && !defined(UMF_NO_HWLOC)
+
 #include "base_alloc_global.h"
 #include "memspace_internal.h"
 #include "memtarget_numa.h"
@@ -100,3 +114,5 @@ umf_const_memspace_handle_t umfMemspaceLowestLatencyGet(void) {
                     umfMemspaceLowestLatencyInit);
     return UMF_MEMSPACE_LOWEST_LATENCY;
 }
+
+#endif // !defined(_WIN32) && !defined(UMF_NO_HWLOC)

--- a/src/memspaces/memspace_numa.c
+++ b/src/memspaces/memspace_numa.c
@@ -9,6 +9,24 @@
 
 #include <stdlib.h>
 
+#include <umf.h>
+#include <umf/memspace.h>
+
+// umfMemspaceCreateFromNumaArray requires HWLOC
+// Additionally, it is currently unsupported on Win
+#if defined(_WIN32) || defined(UMF_NO_HWLOC)
+umf_result_t umfMemspaceCreateFromNumaArray(unsigned *nodeIds, size_t numIds,
+                                            umf_memspace_handle_t *hMemspace) {
+    (void)nodeIds;
+    (void)numIds;
+    (void)hMemspace;
+
+    // not supported
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+}
+
+#else // !defined(_WIN32) && !defined(UMF_NO_HWLOC)
+
 #include "../memspace_internal.h"
 #include "../memtargets/memtarget_numa.h"
 #include "base_alloc_global.h"
@@ -57,3 +75,5 @@ err_nodes_alloc:
     umf_ba_global_free(memspace);
     return ret;
 }
+
+#endif // !defined(_WIN32) && !defined(UMF_NO_HWLOC)

--- a/src/provider/provider_cuda.c
+++ b/src/provider/provider_cuda.c
@@ -12,6 +12,15 @@
 #include <umf.h>
 #include <umf/providers/provider_cuda.h>
 
+#if defined(UMF_NO_CUDA_PROVIDER)
+
+umf_memory_provider_ops_t *umfCUDAMemoryProviderOps(void) {
+    // not supported
+    return NULL;
+}
+
+#else // !defined(UMF_NO_CUDA_PROVIDER)
+
 #include "cuda.h"
 
 #include "base_alloc_global.h"
@@ -370,3 +379,5 @@ static struct umf_memory_provider_ops_t UMF_CUDA_MEMORY_PROVIDER_OPS = {
 umf_memory_provider_ops_t *umfCUDAMemoryProviderOps(void) {
     return &UMF_CUDA_MEMORY_PROVIDER_OPS;
 }
+
+#endif // !defined(UMF_NO_CUDA_PROVIDER)

--- a/src/provider/provider_devdax_memory.c
+++ b/src/provider/provider_devdax_memory.c
@@ -13,14 +13,23 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <umf.h>
+#include <umf/memory_provider_ops.h>
+#include <umf/providers/provider_devdax_memory.h>
+
+#if defined(_WIN32) || defined(UMF_NO_HWLOC)
+
+umf_memory_provider_ops_t *umfDevDaxMemoryProviderOps(void) {
+    // not supported
+    return NULL;
+}
+
+#else // !defined(_WIN32) && !defined(UMF_NO_HWLOC)
+
 #include "base_alloc_global.h"
 #include "utils_common.h"
 #include "utils_concurrency.h"
 #include "utils_log.h"
-
-#include <umf.h>
-#include <umf/memory_provider_ops.h>
-#include <umf/providers/provider_devdax_memory.h>
 
 #define NODESET_STR_BUF_LEN 1024
 
@@ -528,3 +537,5 @@ static umf_memory_provider_ops_t UMF_DEVDAX_MEMORY_PROVIDER_OPS = {
 umf_memory_provider_ops_t *umfDevDaxMemoryProviderOps(void) {
     return &UMF_DEVDAX_MEMORY_PROVIDER_OPS;
 }
+
+#endif // !defined(_WIN32) && !defined(UMF_NO_HWLOC)

--- a/src/provider/provider_file_memory.c
+++ b/src/provider/provider_file_memory.c
@@ -14,15 +14,24 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <umf.h>
+#include <umf/memory_provider_ops.h>
+#include <umf/providers/provider_file_memory.h>
+
+#if defined(_WIN32) || defined(UMF_NO_HWLOC)
+
+umf_memory_provider_ops_t *umfFileMemoryProviderOps(void) {
+    // not supported
+    return NULL;
+}
+
+#else // !defined(_WIN32) && !defined(UMF_NO_HWLOC)
+
 #include "base_alloc_global.h"
 #include "critnib.h"
 #include "utils_common.h"
 #include "utils_concurrency.h"
 #include "utils_log.h"
-
-#include <umf.h>
-#include <umf/memory_provider_ops.h>
-#include <umf/providers/provider_file_memory.h>
 
 #define TLS_MSG_BUF_LEN 1024
 
@@ -696,3 +705,5 @@ static umf_memory_provider_ops_t UMF_FILE_MEMORY_PROVIDER_OPS = {
 umf_memory_provider_ops_t *umfFileMemoryProviderOps(void) {
     return &UMF_FILE_MEMORY_PROVIDER_OPS;
 }
+
+#endif // !defined(_WIN32) && !defined(UMF_NO_HWLOC)

--- a/src/provider/provider_level_zero.c
+++ b/src/provider/provider_level_zero.c
@@ -14,6 +14,15 @@
 #include <umf/memory_provider_ops.h>
 #include <umf/providers/provider_level_zero.h>
 
+#if defined(UMF_NO_LEVEL_ZERO_PROVIDER)
+
+umf_memory_provider_ops_t *umfLevelZeroMemoryProviderOps(void) {
+    // not supported
+    return NULL;
+}
+
+#else // !defined(UMF_NO_LEVEL_ZERO_PROVIDER)
+
 #include "base_alloc_global.h"
 #include "utils_assert.h"
 #include "utils_common.h"
@@ -564,3 +573,5 @@ static struct umf_memory_provider_ops_t UMF_LEVEL_ZERO_MEMORY_PROVIDER_OPS = {
 umf_memory_provider_ops_t *umfLevelZeroMemoryProviderOps(void) {
     return &UMF_LEVEL_ZERO_MEMORY_PROVIDER_OPS;
 }
+
+#endif // !defined(UMF_NO_LEVEL_ZERO_PROVIDER)

--- a/src/provider/provider_os_memory.c
+++ b/src/provider/provider_os_memory.c
@@ -13,16 +13,23 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <umf.h>
+#include <umf/memory_provider_ops.h>
+#include <umf/providers/provider_os_memory.h>
+
+// OS Memory Provider requires HWLOC
+#if defined(UMF_NO_HWLOC)
+
+umf_memory_provider_ops_t *umfOsMemoryProviderOps(void) { return NULL; }
+
+#else // !defined(UMF_NO_HWLOC)
+
 #include "base_alloc_global.h"
 #include "critnib.h"
 #include "provider_os_memory_internal.h"
 #include "utils_common.h"
 #include "utils_concurrency.h"
 #include "utils_log.h"
-
-#include <umf.h>
-#include <umf/memory_provider_ops.h>
-#include <umf/providers/provider_os_memory.h>
 
 #define NODESET_STR_BUF_LEN 1024
 
@@ -1329,3 +1336,5 @@ static umf_memory_provider_ops_t UMF_OS_MEMORY_PROVIDER_OPS = {
 umf_memory_provider_ops_t *umfOsMemoryProviderOps(void) {
     return &UMF_OS_MEMORY_PROVIDER_OPS;
 }
+
+#endif // !defined(UMF_NO_HWLOC)


### PR DESCRIPTION
UMF version used as base here, is the one from UR https://github.com/intel/llvm/commit/5f2192a4f1674d0f3a2f2c3cbfe4466644c9208c#diff-b90e982b821d255cf9a86ddc9eb53c4e97138b9980e6b84f9a7f5017f2b5738aR126, which is:
```
# main 03.10.2024: Add umfIsFreeOpDefault(hProvider)
set(UMF_TAG fa006eea503a58e79fa197891f1391c9dcda73e1)
```

This is just a PR for review purpose, **the real CI is on the push trigger**, **HERE**: https://github.com/oneapi-src/unified-memory-framework/actions?query=branch%3Aumf_pulldown_with_fix.

I had to remove a pieces of code related to coarse provider (which was merged Oct, 8).