### PR TITLE
Fix all pip installations

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -27,8 +27,13 @@ jobs:
       with:
         fetch-depth: 0
 
+    # Latest distros do not allow global pip installation
     - name: Install Bandit
-      run: python3 -m pip install bandit
+      run: |
+        python3 -m venv .venv
+        . .venv/bin/activate
+        echo "$PATH" >> $GITHUB_PATH
+        python3 -m pip install bandit
 
     # Run Bandit recursively, but omit _deps directory (with 3rd party code)
     - name: Run Bandit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -75,8 +75,13 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y cmake clang libhwloc-dev libnuma-dev libjemalloc-dev libtbb-dev
 
-    - name: Install pip packages
-      run: python3 -m pip install -r third_party/requirements.txt
+    # Latest distros do not allow global pip installation
+    - name: Install Python requirements in venv
+      run: |
+        python3 -m venv .venv
+        . .venv/bin/activate
+        echo "$PATH" >> $GITHUB_PATH
+        python3 -m pip install -r third_party/requirements.txt
 
     - name: Configure CMake
       run: >

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,8 +29,13 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y doxygen
 
-    - name: Install pip requirements
-      run: python3 -m pip install -r third_party/requirements.txt
+    # Latest distros do not allow global pip installation
+    - name: Install Python requirements in venv
+      run: |
+        python3 -m venv .venv
+        . .venv/bin/activate
+        echo "$PATH" >> $GITHUB_PATH
+        python3 -m pip install -r third_party/requirements.txt
 
     - name: Setup PATH for python
       run: echo "$HOME/.local/bin" >> $GITHUB_PATH

--- a/.github/workflows/pr_push.yml
+++ b/.github/workflows/pr_push.yml
@@ -66,8 +66,13 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y doxygen
 
-    - name: Install pip requirements
-      run: python3 -m pip install -r third_party/requirements.txt
+    # Latest distros do not allow global pip installation
+    - name: Install Python requirements in venv
+      run: |
+        python3 -m venv .venv
+        . .venv/bin/activate
+        echo "$PATH" >> $GITHUB_PATH
+        python3 -m pip install -r third_party/requirements.txt
 
     - name: Setup PATH for python
       run: echo "$HOME/.local/bin" >> $GITHUB_PATH

--- a/.github/workflows/qemu.yml
+++ b/.github/workflows/qemu.yml
@@ -29,7 +29,14 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y qemu-system genisoimage qemu-utils \
           libvirt-clients libvirt-daemon-system libvirt-daemon virtinst bridge-utils
-        pip install -r umf/scripts/qemu/requirements.txt
+
+    # Latest distros do not allow global pip installation
+    - name: Install Python requirements in venv
+      run: |
+        python3 -m venv .venv
+        . .venv/bin/activate
+        echo "$PATH" >> $GITHUB_PATH
+        python3 -m pip install -r umf/scripts/qemu/requirements.txt
 
     - name: Add user to kvm group
       run: sudo usermod -a -G kvm,libvirt $USER


### PR DESCRIPTION
### Description

Fix all pip installations.
Latest distros do not allow global pip installation.
Python packages have to be installed in `venv`.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [ ] CI workflows execute properly
