### PR TITLE
Add parameter to destroy upstream_memory_provider in finalize()

### DIFF
--- a/include/umf/providers/provider_coarse.h
+++ b/include/umf/providers/provider_coarse.h
@@ -69,6 +69,9 @@ typedef struct coarse_memory_provider_params_t {
     /// the init_buffer is always used instead
     /// (regardless of the value of this parameter).
     bool immediate_init_from_upstream;
+
+    /// Destroy upstream_memory_provider in finalize().
+    bool destroy_upstream_memory_provider;
 } coarse_memory_provider_params_t;
 
 /// @brief Coarse Memory Provider stats (TODO move to CTL)

--- a/src/provider/provider_coarse.c
+++ b/src/provider/provider_coarse.c
@@ -34,6 +34,9 @@ typedef struct coarse_memory_provider_t {
     // memory allocation strategy
     coarse_memory_provider_strategy_t allocation_strategy;
 
+    // destroy upstream_memory_provider in finalize()
+    bool destroy_upstream_memory_provider;
+
     void *init_buffer;
 
     size_t used_size;
@@ -898,6 +901,13 @@ static umf_result_t coarse_memory_provider_initialize(void *params,
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
 
+    if (coarse_params->destroy_upstream_memory_provider &&
+        !coarse_params->upstream_memory_provider) {
+        LOG_ERR("destroy_upstream_memory_provider is true, but an upstream "
+                "provider is not provided");
+        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
     coarse_memory_provider_t *coarse_provider =
         umf_ba_global_alloc(sizeof(*coarse_provider));
     if (!coarse_provider) {
@@ -909,6 +919,8 @@ static umf_result_t coarse_memory_provider_initialize(void *params,
 
     coarse_provider->upstream_memory_provider =
         coarse_params->upstream_memory_provider;
+    coarse_provider->destroy_upstream_memory_provider =
+        coarse_params->destroy_upstream_memory_provider;
     coarse_provider->allocation_strategy = coarse_params->allocation_strategy;
     coarse_provider->init_buffer = coarse_params->init_buffer;
 
@@ -1080,6 +1092,11 @@ static void coarse_memory_provider_finalize(void *provider) {
     ravl_delete(coarse_provider->free_blocks);
 
     umf_ba_global_free(coarse_provider->name);
+
+    if (coarse_provider->destroy_upstream_memory_provider &&
+        coarse_provider->upstream_memory_provider) {
+        umfMemoryProviderDestroy(coarse_provider->upstream_memory_provider);
+    }
 
     umf_ba_global_free(coarse_provider);
 }

--- a/test/disjointCoarseMallocPool.cpp
+++ b/test/disjointCoarseMallocPool.cpp
@@ -760,6 +760,37 @@ TEST_P(CoarseWithMemoryStrategyTest, disjointCoarseMallocPool_wrong_params_4) {
     umfMemoryProviderDestroy(malloc_memory_provider);
 }
 
+// wrong parameters: destroy_upstream_memory_provider is true, but an upstream provider is not provided
+TEST_P(CoarseWithMemoryStrategyTest, disjointCoarseMallocPool_wrong_params_5) {
+    umf_result_t umf_result;
+
+    const size_t init_buffer_size = 20 * MB;
+
+    // Preallocate some memory
+    std::unique_ptr<char[]> buffer(new char[init_buffer_size]);
+    void *buf = buffer.get();
+    ASSERT_NE(buf, nullptr);
+    memset(buf, 0, init_buffer_size);
+
+    coarse_memory_provider_params_t coarse_memory_provider_params;
+    // make sure there are no undefined members - prevent a UB
+    memset(&coarse_memory_provider_params, 0,
+           sizeof(coarse_memory_provider_params));
+    coarse_memory_provider_params.allocation_strategy = allocation_strategy;
+    coarse_memory_provider_params.upstream_memory_provider = nullptr;
+    coarse_memory_provider_params.destroy_upstream_memory_provider = true;
+    coarse_memory_provider_params.immediate_init_from_upstream = false;
+    coarse_memory_provider_params.init_buffer = buf;
+    coarse_memory_provider_params.init_buffer_size = init_buffer_size;
+
+    umf_memory_provider_handle_t coarse_memory_provider = nullptr;
+    umf_result = umfMemoryProviderCreate(umfCoarseMemoryProviderOps(),
+                                         &coarse_memory_provider_params,
+                                         &coarse_memory_provider);
+    ASSERT_EQ(umf_result, UMF_RESULT_ERROR_INVALID_ARGUMENT);
+    ASSERT_EQ(coarse_memory_provider, nullptr);
+}
+
 TEST_P(CoarseWithMemoryStrategyTest, disjointCoarseMallocPool_split_merge) {
     umf_memory_provider_handle_t malloc_memory_provider;
     umf_result_t umf_result;


### PR DESCRIPTION
### Description

Add parameter to destroy `upstream_memory_provider` in `finalize()`.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
