### PR TITLE
Add optional coarse provider to `umfPoolTest` fixture

### DIFF
--- a/test/memoryPoolAPI.cpp
+++ b/test/memoryPoolAPI.cpp
@@ -181,14 +181,16 @@ TEST_F(test, BasicPoolByPtrTest) {
 INSTANTIATE_TEST_SUITE_P(
     mallocPoolTest, umfPoolTest,
     ::testing::Values(poolCreateExtParams{&MALLOC_POOL_OPS, nullptr,
-                                          &UMF_NULL_PROVIDER_OPS, nullptr},
+                                          &UMF_NULL_PROVIDER_OPS, nullptr,
+                                          nullptr},
                       poolCreateExtParams{umfProxyPoolOps(), nullptr,
-                                          &MALLOC_PROVIDER_OPS, nullptr}));
+                                          &MALLOC_PROVIDER_OPS, nullptr,
+                                          nullptr}));
 
 INSTANTIATE_TEST_SUITE_P(mallocMultiPoolTest, umfMultiPoolTest,
                          ::testing::Values(poolCreateExtParams{
                              umfProxyPoolOps(), nullptr, &MALLOC_PROVIDER_OPS,
-                             nullptr}));
+                             nullptr, nullptr}));
 
 INSTANTIATE_TEST_SUITE_P(umfPoolWithCreateFlagsTest, umfPoolWithCreateFlagsTest,
                          ::testing::Values(0,

--- a/test/pools/disjoint_pool.cpp
+++ b/test/pools/disjoint_pool.cpp
@@ -148,17 +148,17 @@ auto defaultPoolConfig = poolConfig();
 INSTANTIATE_TEST_SUITE_P(disjointPoolTests, umfPoolTest,
                          ::testing::Values(poolCreateExtParams{
                              umfDisjointPoolOps(), (void *)&defaultPoolConfig,
-                             &MALLOC_PROVIDER_OPS, nullptr}));
+                             &MALLOC_PROVIDER_OPS, nullptr, nullptr}));
 
 INSTANTIATE_TEST_SUITE_P(
     disjointPoolTests, umfMemTest,
     ::testing::Values(std::make_tuple(
         poolCreateExtParams{umfDisjointPoolOps(), (void *)&defaultPoolConfig,
                             &MOCK_OUT_OF_MEM_PROVIDER_OPS,
-                            (void *)&defaultPoolConfig.Capacity},
+                            (void *)&defaultPoolConfig.Capacity, nullptr},
         static_cast<int>(defaultPoolConfig.Capacity) / 2)));
 
 INSTANTIATE_TEST_SUITE_P(disjointMultiPoolTests, umfMultiPoolTest,
                          ::testing::Values(poolCreateExtParams{
                              umfDisjointPoolOps(), (void *)&defaultPoolConfig,
-                             &MALLOC_PROVIDER_OPS, nullptr}));
+                             &MALLOC_PROVIDER_OPS, nullptr, nullptr}));

--- a/test/pools/jemalloc_pool.cpp
+++ b/test/pools/jemalloc_pool.cpp
@@ -15,7 +15,8 @@ auto defaultParams = umfOsMemoryProviderParamsDefault();
 INSTANTIATE_TEST_SUITE_P(jemallocPoolTest, umfPoolTest,
                          ::testing::Values(poolCreateExtParams{
                              umfJemallocPoolOps(), nullptr,
-                             umfOsMemoryProviderOps(), &defaultParams}));
+                             umfOsMemoryProviderOps(), &defaultParams,
+                             nullptr}));
 
 // this test makes sure that jemalloc does not use
 // memory provider to allocate metadata (and hence
@@ -30,8 +31,9 @@ TEST_F(test, metadataNotAllocatedUsingProvider) {
     auto params = umfOsMemoryProviderParamsDefault();
     params.protection = UMF_PROTECTION_NONE;
 
-    auto pool = poolCreateExtUnique(
-        {umfJemallocPoolOps(), nullptr, umfOsMemoryProviderOps(), &params});
+    auto pool =
+        poolCreateExtUnique({umfJemallocPoolOps(), nullptr,
+                             umfOsMemoryProviderOps(), &params, nullptr});
 
     std::vector<std::shared_ptr<void>> allocs;
     for (size_t i = 0; i < numAllocs; i++) {

--- a/test/pools/pool_base_alloc.cpp
+++ b/test/pools/pool_base_alloc.cpp
@@ -48,4 +48,4 @@ umf_memory_pool_ops_t BA_POOL_OPS = umf::poolMakeCOps<base_alloc_pool, void>();
 INSTANTIATE_TEST_SUITE_P(baPool, umfPoolTest,
                          ::testing::Values(poolCreateExtParams{
                              &BA_POOL_OPS, nullptr,
-                             &umf_test::BASE_PROVIDER_OPS, nullptr}));
+                             &umf_test::BASE_PROVIDER_OPS, nullptr, nullptr}));

--- a/test/pools/scalable_pool.cpp
+++ b/test/pools/scalable_pool.cpp
@@ -12,4 +12,5 @@ auto defaultParams = umfOsMemoryProviderParamsDefault();
 INSTANTIATE_TEST_SUITE_P(scalablePoolTest, umfPoolTest,
                          ::testing::Values(poolCreateExtParams{
                              umfScalablePoolOps(), nullptr,
-                             umfOsMemoryProviderOps(), &defaultParams}));
+                             umfOsMemoryProviderOps(), &defaultParams,
+                             nullptr}));


### PR DESCRIPTION
### Description

Add optional coarse provider to `umfPoolTest` fixture.
Add 5th argument (`coarse_memory_provider_params_t *`)
to the `poolCreateExtParams` tuple (can be `nullptr`).
If it is `non-nullptr`, coarse provider is created
with the given provider as the upstream provider.

It will be used to test the following providers:
- file provider
- devdax provider

as the upstream providers with the coarse provider
and different pool managers.

Requires:
- [x] #806 

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
