### PR TITLE
Remove an unnecessary parameter in openHandlesFn lambda

### DIFF
--- a/test/ipcFixtures.hpp
+++ b/test/ipcFixtures.hpp
@@ -461,7 +461,7 @@ TEST_P(umfIpcTest, ConcurrentOpenCloseHandles) {
 
     umf_test::syncthreads_barrier syncthreads(NTHREADS);
 
-    auto openHandlesFn = [this, &ipcHandles, &openedIpcHandles, &syncthreads,
+    auto openHandlesFn = [&ipcHandles, &openedIpcHandles, &syncthreads,
                           &pool](size_t tid) {
         syncthreads();
         for (auto ipcHandle : ipcHandles) {


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description
Minor fix: Remove an unnecessary parameter in openHandlesFn lambda

### Checklist


- [x] Code compiles without errors locally
- [x] All tests pass locally
- [ ] CI workflows execute properly
