### PR TITLE
small fix for Coarse Provider html documentation

### DIFF
--- a/scripts/docs_config/api.rst
+++ b/scripts/docs_config/api.rst
@@ -84,9 +84,11 @@ Coarse Provider
 ------------------------------------------
 
 A memory provider that can provide memory from:
-1) a given pre-allocated buffer (the fixed-size memory provider option) or
-2) from an additional upstream provider (e.g. provider that does not support the free() operation
-   like the File memory provider or the DevDax memory provider - see below).
+
+1) A given pre-allocated buffer (the fixed-size memory provider option) or
+2) From an additional upstream provider (e.g. provider that does not support 
+   the free() operation like the File memory provider or the DevDax memory 
+   provider - see below).
 
 .. doxygenfile:: provider_coarse.h
     :sections: define enum typedef func var


### PR DESCRIPTION
Currently, the Coarse Provider section is badly formatted:

![image](https://github.com/user-attachments/assets/4da09477-c082-4048-acf1-a86708bd4631)

fixed version:
https://bratpiorka.github.io/unified-memory-framework/api.html#coarse-provider