### PR TITLE
Fix CMake warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,11 +149,7 @@ else()
             GIT_TAG ${UMF_HWLOC_TAG}
             PATCH_COMMAND ${HWLOC_PATCH} SOURCE_SUBDIR contrib/windows-cmake/
                           FIND_PACKAGE_ARGS)
-
-        FetchContent_GetProperties(hwloc_targ)
-        if(NOT hwloc_targ_POPULATED)
-            FetchContent_MakeAvailable(hwloc_targ)
-        endif()
+        FetchContent_MakeAvailable(hwloc_targ)
 
         set(LIBHWLOC_INCLUDE_DIRS
             ${hwloc_targ_SOURCE_DIR}/include;${hwloc_targ_BINARY_DIR}/include)
@@ -178,11 +174,7 @@ else()
             GIT_REPOSITORY ${UMF_HWLOC_REPO}
             GIT_TAG ${UMF_HWLOC_TAG}
             PATCH_COMMAND ${HWLOC_PATCH})
-
-        FetchContent_GetProperties(hwloc_targ)
-        if(NOT hwloc_targ_POPULATED)
-            FetchContent_MakeAvailable(hwloc_targ)
-        endif()
+        FetchContent_MakeAvailable(hwloc_targ)
 
         add_custom_command(
             COMMAND ./autogen.sh

--- a/examples/cuda_shared_memory/CMakeLists.txt
+++ b/examples/cuda_shared_memory/CMakeLists.txt
@@ -35,11 +35,7 @@ FetchContent_Declare(
     GIT_REPOSITORY ${CUDA_REPO}
     GIT_TAG ${CUDA_TAG}
     EXCLUDE_FROM_ALL)
-
-FetchContent_GetProperties(cuda-headers)
-if(NOT cuda-headers_POPULATED)
-    FetchContent_MakeAvailable(cuda-headers)
-endif()
+FetchContent_MakeAvailable(cuda-headers)
 
 set(CUDA_INCLUDE_DIRS
     ${cuda-headers_SOURCE_DIR}

--- a/examples/cuda_shared_memory/CMakeLists.txt
+++ b/examples/cuda_shared_memory/CMakeLists.txt
@@ -38,7 +38,7 @@ FetchContent_Declare(
 
 FetchContent_GetProperties(cuda-headers)
 if(NOT cuda-headers_POPULATED)
-    FetchContent_Populate(cuda-headers)
+    FetchContent_MakeAvailable(cuda-headers)
 endif()
 
 set(CUDA_INCLUDE_DIRS

--- a/examples/ipc_level_zero/CMakeLists.txt
+++ b/examples/ipc_level_zero/CMakeLists.txt
@@ -36,11 +36,7 @@ FetchContent_Declare(
     GIT_REPOSITORY ${LEVEL_ZERO_LOADER_REPO}
     GIT_TAG ${LEVEL_ZERO_LOADER_TAG}
     EXCLUDE_FROM_ALL)
-
-FetchContent_GetProperties(level-zero-loader)
-if(NOT level-zero-loader_POPULATED)
-    FetchContent_MakeAvailable(level-zero-loader)
-endif()
+FetchContent_MakeAvailable(level-zero-loader)
 
 set(LEVEL_ZERO_INCLUDE_DIRS
     ${level-zero-loader_SOURCE_DIR}/include

--- a/examples/ipc_level_zero/CMakeLists.txt
+++ b/examples/ipc_level_zero/CMakeLists.txt
@@ -39,7 +39,7 @@ FetchContent_Declare(
 
 FetchContent_GetProperties(level-zero-loader)
 if(NOT level-zero-loader_POPULATED)
-    FetchContent_Populate(level-zero-loader)
+    FetchContent_MakeAvailable(level-zero-loader)
 endif()
 
 set(LEVEL_ZERO_INCLUDE_DIRS

--- a/examples/level_zero_shared_memory/CMakeLists.txt
+++ b/examples/level_zero_shared_memory/CMakeLists.txt
@@ -36,11 +36,7 @@ FetchContent_Declare(
     GIT_REPOSITORY ${LEVEL_ZERO_LOADER_REPO}
     GIT_TAG ${LEVEL_ZERO_LOADER_TAG}
     EXCLUDE_FROM_ALL)
-
-FetchContent_GetProperties(level-zero-loader)
-if(NOT level-zero-loader_POPULATED)
-    FetchContent_MakeAvailable(level-zero-loader)
-endif()
+FetchContent_MakeAvailable(level-zero-loader)
 
 set(LEVEL_ZERO_INCLUDE_DIRS
     ${level-zero-loader_SOURCE_DIR}/include

--- a/examples/level_zero_shared_memory/CMakeLists.txt
+++ b/examples/level_zero_shared_memory/CMakeLists.txt
@@ -39,7 +39,7 @@ FetchContent_Declare(
 
 FetchContent_GetProperties(level-zero-loader)
 if(NOT level-zero-loader_POPULATED)
-    FetchContent_Populate(level-zero-loader)
+    FetchContent_MakeAvailable(level-zero-loader)
 endif()
 
 set(LEVEL_ZERO_INCLUDE_DIRS

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,11 +32,7 @@ if(UMF_BUILD_LEVEL_ZERO_PROVIDER AND (UMF_BUILD_GPU_TESTS
         GIT_REPOSITORY ${LEVEL_ZERO_LOADER_REPO}
         GIT_TAG ${LEVEL_ZERO_LOADER_TAG}
         EXCLUDE_FROM_ALL)
-
-    FetchContent_GetProperties(level-zero-loader)
-    if(NOT level-zero-loader_POPULATED)
-        FetchContent_MakeAvailable(level-zero-loader)
-    endif()
+    FetchContent_MakeAvailable(level-zero-loader)
 
     set(LEVEL_ZERO_INCLUDE_DIRS
         ${level-zero-loader_SOURCE_DIR}/include
@@ -62,11 +58,7 @@ if(UMF_BUILD_CUDA_PROVIDER)
         GIT_REPOSITORY ${CUDA_REPO}
         GIT_TAG ${CUDA_TAG}
         EXCLUDE_FROM_ALL)
-
-    FetchContent_GetProperties(cuda-headers)
-    if(NOT cuda-headers_POPULATED)
-        FetchContent_MakeAvailable(cuda-headers)
-    endif()
+    FetchContent_MakeAvailable(cuda-headers)
 
     set(CUDA_INCLUDE_DIRS
         ${cuda-headers_SOURCE_DIR}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,7 +35,7 @@ if(UMF_BUILD_LEVEL_ZERO_PROVIDER AND (UMF_BUILD_GPU_TESTS
 
     FetchContent_GetProperties(level-zero-loader)
     if(NOT level-zero-loader_POPULATED)
-        FetchContent_Populate(level-zero-loader)
+        FetchContent_MakeAvailable(level-zero-loader)
     endif()
 
     set(LEVEL_ZERO_INCLUDE_DIRS
@@ -65,7 +65,7 @@ if(UMF_BUILD_CUDA_PROVIDER)
 
     FetchContent_GetProperties(cuda-headers)
     if(NOT cuda-headers_POPULATED)
-        FetchContent_Populate(cuda-headers)
+        FetchContent_MakeAvailable(cuda-headers)
     endif()
 
     set(CUDA_INCLUDE_DIRS

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,7 +9,7 @@ include(FetchContent)
 FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG release-1.12.1)
+    GIT_TAG v1.15.2)
 
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt


### PR DESCRIPTION
2 changes to avoid CMake warnings:
- ref. https://github.com/oneapi-src/unified-memory-framework/issues/734
- bump GTEST version - it was pretty old and had some warnings

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly