### PR TITLE
Make debug messages in utils_mmap_file() more verbose

### DIFF
--- a/src/utils/utils_linux_common.c
+++ b/src/utils/utils_linux_common.c
@@ -60,7 +60,10 @@ void *utils_mmap_file(void *hint_addr, size_t length, int prot, int flags,
             return NULL;
         }
 
-        LOG_DEBUG("file mapped with the MAP_PRIVATE flag");
+        LOG_DEBUG("file mapped with the MAP_PRIVATE flag (fd=%i, offset=%zu, "
+                  "length=%zu)",
+                  fd, fd_offset, length);
+
         return addr;
     }
 
@@ -72,7 +75,9 @@ void *utils_mmap_file(void *hint_addr, size_t length, int prot, int flags,
         addr = utils_mmap(hint_addr, length, prot, flags | sync_flags, fd,
                           fd_offset);
         if (addr) {
-            LOG_DEBUG("file mapped with the MAP_SYNC flag");
+            LOG_DEBUG("file mapped with the MAP_SYNC flag (fd=%i, offset=%zu, "
+                      "length=%zu)",
+                      fd, fd_offset, length);
             return addr;
         }
 
@@ -85,7 +90,9 @@ void *utils_mmap_file(void *hint_addr, size_t length, int prot, int flags,
         const int shared_flags = (flags & (~MAP_SYNC)) | MAP_SHARED;
         addr = utils_mmap(hint_addr, length, prot, shared_flags, fd, fd_offset);
         if (addr) {
-            LOG_DEBUG("file mapped with the MAP_SHARED flag");
+            LOG_DEBUG("file mapped with the MAP_SHARED flag (fd=%i, "
+                      "offset=%zu, length=%zu)",
+                      fd, fd_offset, length);
             return addr;
         }
 


### PR DESCRIPTION

### Description

Make debug messages in `utils_mmap_file()` more verbose.
It is very useful during debugging.

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
