### PR TITLE
Change FILE_PATH of a test file from /tmp/ to a local one

### DIFF
--- a/test/pools/pool_coarse_file.hpp
+++ b/test/pools/pool_coarse_file.hpp
@@ -14,6 +14,6 @@
 using umf_test::test;
 using namespace umf_test;
 
-#define FILE_PATH ((char *)"/tmp/file_provider")
+#define FILE_PATH ((char *)"tmp_file_provider")
 
 #endif /* UMF_TEST_POOL_COARSE_FILE_HPP */


### PR DESCRIPTION
### Description

Change `FILE_PATH` from `/tmp/file_provider` to `./tmp_file_provider`,
because it is safer (`/tmp/` can be unavailable).

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
