### PR TITLE
Add the jemalloc_coarse_devdax and scalable_coarse_devdax tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -263,6 +263,10 @@ if(LINUX AND (NOT UMF_DISABLE_HWLOC)) # OS-specific functions are implemented
             NAME jemalloc_coarse_file
             SRCS pools/jemalloc_coarse_file.cpp malloc_compliance_tests.cpp
             LIBS jemalloc_pool)
+        add_umf_test(
+            NAME jemalloc_coarse_devdax
+            SRCS pools/jemalloc_coarse_devdax.cpp malloc_compliance_tests.cpp
+            LIBS jemalloc_pool)
     endif()
 
     # This test requires Linux-only file memory provider
@@ -270,6 +274,9 @@ if(LINUX AND (NOT UMF_DISABLE_HWLOC)) # OS-specific functions are implemented
         add_umf_test(
             NAME scalable_coarse_file SRCS pools/scalable_coarse_file.cpp
                                            malloc_compliance_tests.cpp)
+        add_umf_test(
+            NAME scalable_coarse_devdax SRCS pools/scalable_coarse_devdax.cpp
+                                             malloc_compliance_tests.cpp)
     endif()
 
     if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND UMF_BUILD_FUZZTESTS)

--- a/test/malloc_compliance_tests.cpp
+++ b/test/malloc_compliance_tests.cpp
@@ -85,12 +85,11 @@ void calloc_compliance_test(umf_memory_pool_handle_t hPool) {
     // Checking that the memory returned by calloc is zero filled
     for (int i = 0; i < ITERATIONS; i++) {
         alloc_size = rand_alloc_size(MAX_ALLOC_SIZE);
-        alloc_ptr[i] = umfPoolCalloc(hPool, i + 1, alloc_size);
+        alloc_ptr[i] = umfPoolCalloc(hPool, 2, alloc_size);
 
         ASSERT_NE(alloc_ptr[i], nullptr)
             << "calloc returned NULL, couldn't allocate much memory";
-        ASSERT_NE(bufferIsFilledWithChar(alloc_ptr[i], alloc_size * (i + 1), 0),
-                  0)
+        ASSERT_NE(bufferIsFilledWithChar(alloc_ptr[i], 2 * alloc_size, 0), 0)
             << "Memory returned by calloc was not zeroed";
     }
     free_memory(hPool, alloc_ptr);

--- a/test/poolFixtures.hpp
+++ b/test/poolFixtures.hpp
@@ -8,6 +8,7 @@
 #include "pool.hpp"
 #include "provider.hpp"
 #include "umf/providers/provider_coarse.h"
+#include "umf/providers/provider_devdax_memory.h"
 
 #include <array>
 #include <cstring>
@@ -66,6 +67,23 @@ struct umfPoolTest : umf_test::test,
                      ::testing::WithParamInterface<poolCreateExtParams> {
     void SetUp() override {
         test::SetUp();
+
+        auto [pool_ops, pool_params, provider_ops, provider_params,
+              coarse_params] = this->GetParam();
+        if (provider_ops == umfDevDaxMemoryProviderOps()) {
+            char *path = getenv("UMF_TESTS_DEVDAX_PATH");
+            if (path == nullptr || path[0] == 0) {
+                GTEST_SKIP()
+                    << "Test skipped, UMF_TESTS_DEVDAX_PATH is not set";
+            }
+
+            char *size = getenv("UMF_TESTS_DEVDAX_SIZE");
+            if (size == nullptr || size[0] == 0) {
+                GTEST_SKIP()
+                    << "Test skipped, UMF_TESTS_DEVDAX_SIZE is not set";
+            }
+        }
+
         pool = poolCreateExtUnique(this->GetParam());
     }
 

--- a/test/pools/jemalloc_coarse_devdax.cpp
+++ b/test/pools/jemalloc_coarse_devdax.cpp
@@ -3,15 +3,18 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "umf/pools/pool_jemalloc.h"
-#include "umf/providers/provider_file_memory.h"
+#include "umf/providers/provider_devdax_memory.h"
 
 #include "pool_coarse.hpp"
 
 auto coarseParams = umfCoarseMemoryProviderParamsDefault();
-auto fileParams = umfFileMemoryProviderParamsDefault(FILE_PATH);
+auto devdaxParams = umfDevDaxMemoryProviderParamsDefault(
+    getenv("UMF_TESTS_DEVDAX_PATH"), getenv("UMF_TESTS_DEVDAX_SIZE")
+                                         ? atol(getenv("UMF_TESTS_DEVDAX_SIZE"))
+                                         : 0);
 
-INSTANTIATE_TEST_SUITE_P(jemallocCoarseFileTest, umfPoolTest,
+INSTANTIATE_TEST_SUITE_P(jemallocCoarseDevDaxTest, umfPoolTest,
                          ::testing::Values(poolCreateExtParams{
                              umfJemallocPoolOps(), nullptr,
-                             umfFileMemoryProviderOps(), &fileParams,
+                             umfDevDaxMemoryProviderOps(), &devdaxParams,
                              &coarseParams}));

--- a/test/pools/pool_coarse.hpp
+++ b/test/pools/pool_coarse.hpp
@@ -2,11 +2,10 @@
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef UMF_TEST_POOL_COARSE_FILE_HPP
-#define UMF_TEST_POOL_COARSE_FILE_HPP 1
+#ifndef UMF_TEST_POOL_COARSE_HPP
+#define UMF_TEST_POOL_COARSE_HPP 1
 
 #include "umf/providers/provider_coarse.h"
-#include "umf/providers/provider_file_memory.h"
 
 #include "pool.hpp"
 #include "poolFixtures.hpp"
@@ -16,4 +15,4 @@ using namespace umf_test;
 
 #define FILE_PATH ((char *)"tmp_file_provider")
 
-#endif /* UMF_TEST_POOL_COARSE_FILE_HPP */
+#endif /* UMF_TEST_POOL_COARSE_HPP */

--- a/test/pools/pool_coarse_file.hpp
+++ b/test/pools/pool_coarse_file.hpp
@@ -14,6 +14,6 @@
 using umf_test::test;
 using namespace umf_test;
 
-#define FILE_PATH ((char *)"/tmp/file_provider")
+#define FILE_PATH ((char *)"tmp_file_provider")
 
 #endif /* UMF_TEST_POOL_COARSE_FILE_HPP */

--- a/test/pools/scalable_coarse_devdax.cpp
+++ b/test/pools/scalable_coarse_devdax.cpp
@@ -3,15 +3,18 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "umf/pools/pool_scalable.h"
-#include "umf/providers/provider_file_memory.h"
+#include "umf/providers/provider_devdax_memory.h"
 
 #include "pool_coarse.hpp"
 
 auto coarseParams = umfCoarseMemoryProviderParamsDefault();
-auto fileParams = umfFileMemoryProviderParamsDefault(FILE_PATH);
+auto devdaxParams = umfDevDaxMemoryProviderParamsDefault(
+    getenv("UMF_TESTS_DEVDAX_PATH"), getenv("UMF_TESTS_DEVDAX_SIZE")
+                                         ? atol(getenv("UMF_TESTS_DEVDAX_SIZE"))
+                                         : 0);
 
-INSTANTIATE_TEST_SUITE_P(scalableCoarseFileTest, umfPoolTest,
+INSTANTIATE_TEST_SUITE_P(scalableCoarseDevDaxTest, umfPoolTest,
                          ::testing::Values(poolCreateExtParams{
                              umfScalablePoolOps(), nullptr,
-                             umfFileMemoryProviderOps(), &fileParams,
+                             umfDevDaxMemoryProviderOps(), &devdaxParams,
                              &coarseParams}));

--- a/test/supp/drd-umf_test-jemalloc_coarse_devdax.supp
+++ b/test/supp/drd-umf_test-jemalloc_coarse_devdax.supp
@@ -1,0 +1,34 @@
+{
+   False-positive ConflictingAccess in libjemalloc.so
+   drd:ConflictingAccess
+   obj:*/libjemalloc.so*
+   ...
+   fun:mallocx
+   ...
+}
+
+{
+   False-positive ConflictingAccess in libjemalloc.so
+   drd:ConflictingAccess
+   obj:*/libjemalloc.so*
+   ...
+   fun:op_free
+   ...
+}
+
+{
+   False-positive ConflictingAccess in libjemalloc.so
+   drd:ConflictingAccess
+   obj:*/libjemalloc.so*
+   ...
+   fun:__nptl_deallocate_tsd
+   ...
+}
+
+{
+   False-positive ConflictingAccess in critnib_insert
+   drd:ConflictingAccess
+   fun:store
+   fun:critnib_insert
+   ...
+}

--- a/test/supp/drd-umf_test-scalable_coarse_devdax.supp
+++ b/test/supp/drd-umf_test-scalable_coarse_devdax.supp
@@ -1,0 +1,49 @@
+{
+   False-positive ConflictingAccess in libtbbmalloc.so
+   drd:ConflictingAccess
+   obj:*/libtbbmalloc.so*
+}
+
+{
+   False-positive ConflictingAccess in libtbbmalloc.so
+   drd:ConflictingAccess
+   obj:*/libtbbmalloc.so*
+   ...
+   fun:tbb_malloc
+   ...
+}
+
+{
+   False-positive ConflictingAccess in libtbbmalloc.so
+   drd:ConflictingAccess
+   obj:*/libtbbmalloc.so*
+   ...
+   fun:tbb_aligned_malloc
+   ...
+}
+
+{
+   False-positive ConflictingAccess in libtbbmalloc.so
+   drd:ConflictingAccess
+   obj:*/libtbbmalloc.so*
+   ...
+   fun:tbb_free
+   ...
+}
+
+{
+   False-positive ConflictingAccess in libtbbmalloc.so
+   drd:ConflictingAccess
+   obj:*/libtbbmalloc.so*
+   ...
+   fun:__nptl_deallocate_tsd
+   ...
+}
+
+{
+   False-positive ConflictingAccess in _Z22pow2AlignedAllocHelperP17umf_memory_pool_t
+   drd:ConflictingAccess
+   fun:memset
+   fun:_Z22pow2AlignedAllocHelperP17umf_memory_pool_t
+   ...
+}

--- a/test/supp/helgrind-umf_test-jemalloc_coarse_devdax.supp
+++ b/test/supp/helgrind-umf_test-jemalloc_coarse_devdax.supp
@@ -1,0 +1,34 @@
+{
+   False-positive Race in libjemalloc.so
+   Helgrind:Race
+   obj:*/libjemalloc.so*
+   ...
+   fun:mallocx
+   ...
+}
+
+{
+   False-positive Race in libjemalloc.so
+   Helgrind:Race
+   obj:*/libjemalloc.so*
+   ...
+   fun:op_free
+   ...
+}
+
+{
+   False-positive Race in libjemalloc.so
+   Helgrind:Race
+   obj:*/libjemalloc.so*
+   ...
+   fun:__nptl_deallocate_tsd
+   ...
+}
+
+{
+   False-positive Race in critnib_insert
+   Helgrind:Race
+   fun:store
+   fun:critnib_insert
+   ...
+}

--- a/test/supp/helgrind-umf_test-scalable_coarse_devdax.supp
+++ b/test/supp/helgrind-umf_test-scalable_coarse_devdax.supp
@@ -1,0 +1,49 @@
+{
+   False-positive Race in libtbbmalloc.so
+   Helgrind:Race
+   obj:*/libtbbmalloc.so*
+}
+
+{
+   False-positive Race in libtbbmalloc.so
+   Helgrind:Race
+   obj:*/libtbbmalloc.so*
+   ...
+   fun:tbb_malloc
+   ...
+}
+
+{
+   False-positive Race in libtbbmalloc.so
+   Helgrind:Race
+   obj:*/libtbbmalloc.so*
+   ...
+   fun:tbb_aligned_malloc
+   ...
+}
+
+{
+   False-positive Race in libtbbmalloc.so
+   Helgrind:Race
+   obj:*/libtbbmalloc.so*
+   ...
+   fun:tbb_free
+   ...
+}
+
+{
+   False-positive Race in libtbbmalloc.so
+   Helgrind:Race
+   obj:*/libtbbmalloc.so*
+   ...
+   fun:__nptl_deallocate_tsd
+   ...
+}
+
+{
+   False-positive Race in _Z22pow2AlignedAllocHelperP17umf_memory_pool_t
+   Helgrind:Race
+   fun:memset
+   fun:_Z22pow2AlignedAllocHelperP17umf_memory_pool_t
+   ...
+}


### PR DESCRIPTION
### Description

Add the jemalloc_coarse_devdax and scalable_coarse_devdax tests
that test the coarse provider with upstream devdax provider
and two pool managers: jemalloc and scalable pool.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
