### PR TITLE
Use `std::vector<char>` instead of `std::unique_ptr<char[]>`

### DIFF
--- a/test/disjointCoarseMallocPool.cpp
+++ b/test/disjointCoarseMallocPool.cpp
@@ -395,11 +395,10 @@ TEST_P(CoarseWithMemoryStrategyTest, disjointCoarseMMapPool_random) {
 
     const size_t init_buffer_size = 200 * MB;
 
-    // Preallocate some memory
-    std::unique_ptr<char[]> buffer(new char[init_buffer_size]);
-    void *buf = buffer.get();
+    // preallocate some memory and initialize the vector with zeros
+    std::vector<char> buffer(init_buffer_size, 0);
+    void *buf = (void *)buffer.data();
     ASSERT_NE(buf, nullptr);
-    memset(buf, 0, init_buffer_size);
 
     const unsigned char alloc_check_val = 11;
 

--- a/test/provider_coarse.cpp
+++ b/test/provider_coarse.cpp
@@ -85,11 +85,10 @@ TEST_F(test, coarseProvider_name_no_upstream) {
 
     const size_t init_buffer_size = 20 * MB;
 
-    // Preallocate some memory
-    std::unique_ptr<char[]> buffer(new char[init_buffer_size]);
-    void *buf = buffer.get();
+    // preallocate some memory and initialize the vector with zeros
+    std::vector<char> buffer(init_buffer_size, 0);
+    void *buf = (void *)buffer.data();
     ASSERT_NE(buf, nullptr);
-    memset(buf, 0, init_buffer_size);
 
     coarse_memory_provider_params_t coarse_memory_provider_params;
     // make sure there are no undefined members - prevent a UB
@@ -159,11 +158,10 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseProvider_wrong_params_1) {
 
     const size_t init_buffer_size = 20 * MB;
 
-    // Preallocate some memory
-    std::unique_ptr<char[]> buffer(new char[init_buffer_size]);
-    void *buf = buffer.get();
+    // preallocate some memory and initialize the vector with zeros
+    std::vector<char> buffer(init_buffer_size, 0);
+    void *buf = (void *)buffer.data();
     ASSERT_NE(buf, nullptr);
-    memset(buf, 0, init_buffer_size);
 
     coarse_memory_provider_params_t coarse_memory_provider_params;
     // make sure there are no undefined members - prevent a UB
@@ -223,11 +221,10 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseProvider_wrong_params_3) {
 
     const size_t init_buffer_size = 20 * MB;
 
-    // Preallocate some memory
-    std::unique_ptr<char[]> buffer(new char[init_buffer_size]);
-    void *buf = buffer.get();
+    // preallocate some memory and initialize the vector with zeros
+    std::vector<char> buffer(init_buffer_size, 0);
+    void *buf = (void *)buffer.data();
     ASSERT_NE(buf, nullptr);
-    memset(buf, 0, init_buffer_size);
 
     coarse_memory_provider_params_t coarse_memory_provider_params;
     // make sure there are no undefined members - prevent a UB
@@ -284,11 +281,10 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseProvider_wrong_params_5) {
 
     const size_t init_buffer_size = 20 * MB;
 
-    // Preallocate some memory
-    std::unique_ptr<char[]> buffer(new char[init_buffer_size]);
-    void *buf = buffer.get();
+    // preallocate some memory and initialize the vector with zeros
+    std::vector<char> buffer(init_buffer_size, 0);
+    void *buf = (void *)buffer.data();
     ASSERT_NE(buf, nullptr);
-    memset(buf, 0, init_buffer_size);
 
     coarse_memory_provider_params_t coarse_memory_provider_params;
     // make sure there are no undefined members - prevent a UB
@@ -521,11 +517,10 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseProvider_purge_no_upstream) {
 
     const size_t init_buffer_size = 20 * MB;
 
-    // Preallocate some memory
-    std::unique_ptr<char[]> buffer(new char[init_buffer_size]);
-    void *buf = buffer.get();
+    // preallocate some memory and initialize the vector with zeros
+    std::vector<char> buffer(init_buffer_size, 0);
+    void *buf = (void *)buffer.data();
     ASSERT_NE(buf, nullptr);
-    memset(buf, 0, init_buffer_size);
 
     coarse_memory_provider_params_t coarse_memory_provider_params;
     // make sure there are no undefined members - prevent a UB


### PR DESCRIPTION

### Description

Use `std::vector<char>` instead of `std::unique_ptr<char[]>`
because we do not need to use memset(0) in this case.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
