### PR TITLE
Add internal IPC-consumer-only mode to the devdax provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,21 @@ so it should be used with a pool manager that will take over
 the managing of the provided memory - for example the jemalloc pool
 with the `disable_provider_free` parameter set to true.
 
+When the DevDax provider is started with `path == NULL` and `size == 0` input parameters
+(`umf_devdax_memory_provider_params_t`) it is working in the **IPC-consumer-only** mode
+with limited functionality. The following API is **unsupported** in IPC-consumer-only mode
+(always return `UMF_RESULT_ERROR_NOT_SUPPORTED`):
+- `umfMemoryProviderAlloc()`
+- `umfMemoryProviderFree()` (always unsupported)
+- `umfMemoryProviderPurgeLazy()` (always unsupported)
+- `umfMemoryProviderPurgeForce()`
+- `umfMemoryProviderAllocationSplit()`
+- `umfMemoryProviderAllocationMerge()`
+- `umfMemoryProviderGetIPCHandle()`
+- `umfMemoryProviderPutIPCHandle()`
+
+The rest of the API works normally.
+
 ##### Requirements
 
 1) Linux OS

--- a/src/base_alloc/base_alloc.c
+++ b/src/base_alloc/base_alloc.c
@@ -168,7 +168,8 @@ umf_ba_pool_t *umf_ba_create(size_t size) {
     char *data_ptr = (char *)&pool->data;
     size_t size_left = pool_size - offsetof(umf_ba_pool_t, data);
 
-    utils_align_ptr_size((void **)&data_ptr, &size_left, MEMORY_ALIGNMENT);
+    utils_align_ptr_up_size_down((void **)&data_ptr, &size_left,
+                                 MEMORY_ALIGNMENT);
 
     // init free_lock
     utils_mutex_t *mutex = utils_mutex_init(&pool->metadata.free_lock);
@@ -209,7 +210,8 @@ void *umf_ba_alloc(umf_ba_pool_t *pool) {
         size_t size_left =
             pool->metadata.pool_size - offsetof(umf_ba_next_pool_t, data);
 
-        utils_align_ptr_size((void **)&data_ptr, &size_left, MEMORY_ALIGNMENT);
+        utils_align_ptr_up_size_down((void **)&data_ptr, &size_left,
+                                     MEMORY_ALIGNMENT);
         ba_divide_memory_into_chunks(pool, data_ptr, size_left);
     }
 

--- a/src/base_alloc/base_alloc_linear.c
+++ b/src/base_alloc/base_alloc_linear.c
@@ -98,7 +98,7 @@ umf_ba_linear_pool_t *umf_ba_linear_create(size_t pool_size) {
     void *data_ptr = &pool->data;
     size_t size_left = pool_size - offsetof(umf_ba_linear_pool_t, data);
 
-    utils_align_ptr_size(&data_ptr, &size_left, MEMORY_ALIGNMENT);
+    utils_align_ptr_up_size_down(&data_ptr, &size_left, MEMORY_ALIGNMENT);
 
     pool->metadata.pool_size = pool_size;
     pool->metadata.data_ptr = data_ptr;
@@ -149,7 +149,7 @@ void *umf_ba_linear_alloc(umf_ba_linear_pool_t *pool, size_t size) {
         void *data_ptr = &new_pool->data;
         size_t size_left =
             new_pool->pool_size - offsetof(umf_ba_next_linear_pool_t, data);
-        utils_align_ptr_size(&data_ptr, &size_left, MEMORY_ALIGNMENT);
+        utils_align_ptr_up_size_down(&data_ptr, &size_left, MEMORY_ALIGNMENT);
 
         pool->metadata.data_ptr = data_ptr;
         pool->metadata.size_left = size_left;

--- a/src/provider/provider_devdax_memory.c
+++ b/src/provider/provider_devdax_memory.c
@@ -31,7 +31,7 @@ umf_memory_provider_ops_t *umfDevDaxMemoryProviderOps(void) {
 #include "utils_concurrency.h"
 #include "utils_log.h"
 
-#define NODESET_STR_BUF_LEN 1024
+#define DEVDAX_ALIGNMENT_2MB (2 * 1024 * 1024) // == 2 MB
 
 #define TLS_MSG_BUF_LEN 1024
 
@@ -369,9 +369,11 @@ static umf_result_t devdax_allocation_merge(void *provider, void *lowPtr,
 }
 
 typedef struct devdax_ipc_data_t {
-    char dd_path[PATH_MAX]; // path to the /dev/dax
-    size_t dd_size;         // size of the /dev/dax
-    size_t offset;          // offset of the data
+    char path[PATH_MAX]; // path to the /dev/dax
+    unsigned protection; // combination of OS-specific memory protection flags
+    // offset of the data (from the beginning of the devdax mapping) - see devdax_get_ipc_handle()
+    size_t offset;
+    size_t length; // length of the data
 } devdax_ipc_data_t;
 
 static umf_result_t devdax_get_ipc_handle_size(void *provider, size_t *size) {
@@ -386,8 +388,6 @@ static umf_result_t devdax_get_ipc_handle_size(void *provider, size_t *size) {
 
 static umf_result_t devdax_get_ipc_handle(void *provider, const void *ptr,
                                           size_t size, void *providerIpcData) {
-    (void)size; // unused
-
     if (provider == NULL || ptr == NULL || providerIpcData == NULL) {
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
@@ -396,11 +396,12 @@ static umf_result_t devdax_get_ipc_handle(void *provider, const void *ptr,
         (devdax_memory_provider_t *)provider;
 
     devdax_ipc_data_t *devdax_ipc_data = (devdax_ipc_data_t *)providerIpcData;
+    strncpy(devdax_ipc_data->path, devdax_provider->path, PATH_MAX - 1);
+    devdax_ipc_data->path[PATH_MAX - 1] = '\0';
+    devdax_ipc_data->protection = devdax_provider->protection;
     devdax_ipc_data->offset =
         (size_t)((uintptr_t)ptr - (uintptr_t)devdax_provider->base);
-    strncpy(devdax_ipc_data->dd_path, devdax_provider->path, PATH_MAX - 1);
-    devdax_ipc_data->dd_path[PATH_MAX - 1] = '\0';
-    devdax_ipc_data->dd_size = devdax_provider->size;
+    devdax_ipc_data->length = size;
 
     return UMF_RESULT_SUCCESS;
 }
@@ -416,16 +417,9 @@ static umf_result_t devdax_put_ipc_handle(void *provider,
     devdax_ipc_data_t *devdax_ipc_data = (devdax_ipc_data_t *)providerIpcData;
 
     // verify the path of the /dev/dax
-    if (strncmp(devdax_ipc_data->dd_path, devdax_provider->path, PATH_MAX)) {
+    if (strncmp(devdax_ipc_data->path, devdax_provider->path, PATH_MAX)) {
         LOG_ERR("devdax path mismatch (local: %s, ipc: %s)",
-                devdax_provider->path, devdax_ipc_data->dd_path);
-        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
-    }
-
-    // verify the size of the /dev/dax
-    if (devdax_ipc_data->dd_size != devdax_provider->size) {
-        LOG_ERR("devdax size mismatch (local: %zu, ipc: %zu)",
-                devdax_provider->size, devdax_ipc_data->dd_size);
+                devdax_provider->path, devdax_ipc_data->path);
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
 
@@ -438,58 +432,51 @@ static umf_result_t devdax_open_ipc_handle(void *provider,
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
 
-    devdax_memory_provider_t *devdax_provider =
-        (devdax_memory_provider_t *)provider;
     devdax_ipc_data_t *devdax_ipc_data = (devdax_ipc_data_t *)providerIpcData;
 
-    // verify it is the same devdax - first verify the path
-    if (strncmp(devdax_ipc_data->dd_path, devdax_provider->path, PATH_MAX)) {
-        LOG_ERR("devdax path mismatch (local: %s, ipc: %s)",
-                devdax_provider->path, devdax_ipc_data->dd_path);
-        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
-    }
-
-    // verify the size of the /dev/dax
-    if (devdax_ipc_data->dd_size != devdax_provider->size) {
-        LOG_ERR("devdax size mismatch (local: %zu, ipc: %zu)",
-                devdax_provider->size, devdax_ipc_data->dd_size);
-        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
-    }
-
-    umf_result_t ret = UMF_RESULT_SUCCESS;
-    int fd = utils_devdax_open(devdax_provider->path);
+    int fd = utils_devdax_open(devdax_ipc_data->path);
     if (fd == -1) {
-        LOG_PERR("opening a devdax (%s) failed", devdax_provider->path);
+        LOG_PERR("opening the devdax (%s) failed", devdax_ipc_data->path);
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
 
     unsigned map_sync_flag = 0;
     utils_translate_mem_visibility_flag(UMF_MEM_MAP_SYNC, &map_sync_flag);
 
+    // length and offset passed to mmap() have to be 2MB-aligned in case of /dev/dax device
+    size_t offset_aligned = devdax_ipc_data->offset;
+    size_t length_aligned = devdax_ipc_data->length;
+    utils_align_ptr_down_size_up((void **)&offset_aligned, &length_aligned,
+                                 DEVDAX_ALIGNMENT_2MB);
+
     // mmap /dev/dax with the MAP_SYNC xor MAP_SHARED flag (if MAP_SYNC fails)
-    char *base = utils_mmap_file(NULL, devdax_provider->size,
-                                 devdax_provider->protection, map_sync_flag, fd,
-                                 0 /* offset */);
-    if (base == NULL) {
+    char *addr =
+        utils_mmap_file(NULL, length_aligned, devdax_ipc_data->protection,
+                        map_sync_flag, fd, offset_aligned);
+    if (addr == NULL) {
         devdax_store_last_native_error(UMF_DEVDAX_RESULT_ERROR_ALLOC_FAILED,
                                        errno);
         LOG_PERR("devdax mapping failed (path: %s, size: %zu, protection: %i, "
-                 "fd: %i)",
-                 devdax_provider->path, devdax_provider->size,
-                 devdax_provider->protection, fd);
-        ret = UMF_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC;
+                 "fd: %i, offset: %zu)",
+                 devdax_ipc_data->path, length_aligned,
+                 devdax_ipc_data->protection, fd, offset_aligned);
+
+        *ptr = NULL;
+        (void)utils_close_fd(fd);
+
+        return UMF_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC;
     }
 
     LOG_DEBUG("devdax mapped (path: %s, size: %zu, protection: %i, fd: %i, "
               "offset: %zu)",
-              devdax_provider->path, devdax_provider->size,
-              devdax_provider->protection, fd, devdax_ipc_data->offset);
+              devdax_ipc_data->path, length_aligned,
+              devdax_ipc_data->protection, fd, offset_aligned);
+
+    *ptr = addr + (devdax_ipc_data->offset - offset_aligned);
 
     (void)utils_close_fd(fd);
 
-    *ptr = base + devdax_ipc_data->offset;
-
-    return ret;
+    return UMF_RESULT_SUCCESS;
 }
 
 static umf_result_t devdax_close_ipc_handle(void *provider, void *ptr,
@@ -498,11 +485,11 @@ static umf_result_t devdax_close_ipc_handle(void *provider, void *ptr,
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
 
-    devdax_memory_provider_t *devdax_provider =
-        (devdax_memory_provider_t *)provider;
+    // ptr and size passed to munmap() have to be 2MB-aligned in case of /dev/dax device
+    utils_align_ptr_down_size_up(&ptr, &size, DEVDAX_ALIGNMENT_2MB);
 
     errno = 0;
-    int ret = utils_munmap(devdax_provider->base, devdax_provider->size);
+    int ret = utils_munmap(ptr, size);
     // ignore error when size == 0
     if (ret && (size > 0)) {
         devdax_store_last_native_error(UMF_DEVDAX_RESULT_ERROR_FREE_FAILED,

--- a/src/utils/utils_common.c
+++ b/src/utils/utils_common.c
@@ -17,15 +17,37 @@ void utils_align_ptr_up_size_down(void **ptr, size_t *size, size_t alignment) {
     uintptr_t p = (uintptr_t)*ptr;
     size_t s = *size;
 
-    // align pointer to 'alignment' bytes and adjust the size
+    // align the pointer up to 'alignment' bytes and adjust the size down
     size_t rest = p & (alignment - 1);
     if (rest) {
-        p += alignment - rest;
+        p = ALIGN_UP(p, alignment);
         s -= alignment - rest;
     }
 
-    ASSERT((p & (alignment - 1)) == 0);
-    ASSERT((s & (alignment - 1)) == 0);
+    ASSERT(IS_ALIGNED(p, alignment));
+    ASSERT(IS_ALIGNED(s, alignment));
+
+    *ptr = (void *)p;
+    *size = s;
+}
+
+// align a pointer down and a size up (for mmap()/munmap())
+void utils_align_ptr_down_size_up(void **ptr, size_t *size, size_t alignment) {
+    uintptr_t p = (uintptr_t)*ptr;
+    size_t s = *size;
+
+    // align the pointer down to 'alignment' bytes and adjust the size up
+    size_t rest = p & (alignment - 1);
+    if (rest) {
+        p = ALIGN_DOWN(p, alignment);
+        s += rest;
+    }
+
+    // align the size up to 'alignment' bytes
+    s = ALIGN_UP(s, alignment);
+
+    ASSERT(IS_ALIGNED(p, alignment));
+    ASSERT(IS_ALIGNED(s, alignment));
 
     *ptr = (void *)p;
     *size = s;

--- a/src/utils/utils_common.c
+++ b/src/utils/utils_common.c
@@ -12,8 +12,8 @@
 #include "utils_assert.h"
 #include "utils_common.h"
 
-// align a pointer and a size
-void utils_align_ptr_size(void **ptr, size_t *size, size_t alignment) {
+// align a pointer up and a size down
+void utils_align_ptr_up_size_down(void **ptr, size_t *size, size_t alignment) {
     uintptr_t p = (uintptr_t)*ptr;
     size_t s = *size;
 

--- a/src/utils/utils_common.h
+++ b/src/utils/utils_common.h
@@ -85,6 +85,9 @@ size_t utils_get_page_size(void);
 // align a pointer up and a size down
 void utils_align_ptr_up_size_down(void **ptr, size_t *size, size_t alignment);
 
+// align a pointer down and a size up (for mmap()/munmap())
+void utils_align_ptr_down_size_up(void **ptr, size_t *size, size_t alignment);
+
 // get the current process ID
 int utils_getpid(void);
 

--- a/src/utils/utils_common.h
+++ b/src/utils/utils_common.h
@@ -82,8 +82,8 @@ int utils_is_running_in_proxy_lib(void);
 
 size_t utils_get_page_size(void);
 
-// align a pointer and a size
-void utils_align_ptr_size(void **ptr, size_t *size, size_t alignment);
+// align a pointer up and a size down
+void utils_align_ptr_up_size_down(void **ptr, size_t *size, size_t alignment);
 
 // get the current process ID
 int utils_getpid(void);

--- a/test/ipc_devdax_prov.sh
+++ b/test/ipc_devdax_prov.sh
@@ -31,4 +31,4 @@ echo "Waiting 1 sec ..."
 sleep 1
 
 echo "Starting ipc_devdax_prov PRODUCER on port $PORT ..."
-UMF_LOG=$UMF_LOG_VAL ./umf_test-ipc_devdax_prov_producer $PORT
+UMF_LOG=$UMF_LOG_VAL ./umf_test-ipc_devdax_prov_producer $PORT $UMF_TESTS_DEVDAX_PATH $UMF_TESTS_DEVDAX_SIZE

--- a/test/ipc_devdax_prov_consumer.c
+++ b/test/ipc_devdax_prov_consumer.c
@@ -14,23 +14,24 @@
 #include "ipc_os_prov_common.h"
 
 int main(int argc, char *argv[]) {
-    if (argc < 2) {
-        fprintf(stderr, "usage: %s <port>\n", argv[0]);
+    if (argc < 2 || argc == 3) {
+        fprintf(stderr, "usage: %s <port> [path_devdax] [size_devdax]\n",
+                argv[0]);
+        if (argc == 3) {
+            fprintf(stderr, "error: both [path_devdax] and [size_devdax] have "
+                            "to be provided, not only one of them\n");
+        }
+
         return -1;
     }
 
     int port = atoi(argv[1]);
+    char *path = NULL;
+    char *size = "0";
 
-    char *path = getenv("UMF_TESTS_DEVDAX_PATH");
-    if (path == NULL || path[0] == 0) {
-        fprintf(stderr, "Test skipped, UMF_TESTS_DEVDAX_PATH is not set\n");
-        return 0;
-    }
-
-    char *size = getenv("UMF_TESTS_DEVDAX_SIZE");
-    if (size == NULL || size[0] == 0) {
-        fprintf(stderr, "Test skipped, UMF_TESTS_DEVDAX_SIZE is not set\n");
-        return 0;
+    if (argc >= 4) {
+        path = argv[2];
+        size = argv[3];
     }
 
     umf_devdax_memory_provider_params_t devdax_params =

--- a/test/ipc_devdax_prov_producer.c
+++ b/test/ipc_devdax_prov_producer.c
@@ -14,23 +14,24 @@
 #include "ipc_os_prov_common.h"
 
 int main(int argc, char *argv[]) {
-    if (argc < 2) {
-        fprintf(stderr, "usage: %s <port>\n", argv[0]);
+    if (argc < 2 || argc == 3) {
+        fprintf(stderr, "usage: %s <port> [path_devdax] [size_devdax]\n",
+                argv[0]);
+        if (argc == 3) {
+            fprintf(stderr, "error: both [path_devdax] and [size_devdax] have "
+                            "to be provided, not only one of them\n");
+        }
+
         return -1;
     }
 
     int port = atoi(argv[1]);
+    char *path = NULL;
+    char *size = "0";
 
-    char *path = getenv("UMF_TESTS_DEVDAX_PATH");
-    if (path == NULL || path[0] == 0) {
-        fprintf(stderr, "Test skipped, UMF_TESTS_DEVDAX_PATH is not set\n");
-        return 0;
-    }
-
-    char *size = getenv("UMF_TESTS_DEVDAX_SIZE");
-    if (size == NULL || size[0] == 0) {
-        fprintf(stderr, "Test skipped, UMF_TESTS_DEVDAX_SIZE is not set\n");
-        return 0;
+    if (argc >= 4) {
+        path = argv[2];
+        size = argv[3];
     }
 
     umf_devdax_memory_provider_params_t devdax_params =


### PR DESCRIPTION
### Description

Add IPC-consumer-only mode to devdax provider.

Requires:
- [ ] #838 

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
