### PR TITLE
Add IPC tests for using an allocation after `umfCloseIPCHandle()`

### DIFF
--- a/test/ipcFixtures.hpp
+++ b/test/ipcFixtures.hpp
@@ -313,6 +313,10 @@ TEST_P(umfIpcTest, AllocFreeAllocTest) {
     ptr = umfPoolMalloc(pool.get(), SIZE);
     ASSERT_NE(ptr, nullptr);
 
+    // test if the allocated memory is usable - fill it with the 0xAB pattern.
+    const uint32_t pattern = 0xAB;
+    memAccessor->fill(ptr, SIZE, &pattern, sizeof(pattern));
+
     ret = umfGetIPCHandle(ptr, &ipcHandle, &handleSize);
     ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
 


### PR DESCRIPTION
### Description

Add IPC tests for using an allocation after `umfCloseIPCHandle()`.
Test if `umfPoolMalloc()` returns a usable pointer after `umfCloseIPCHandle()`.

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
