### PR TITLE
Temporarily disable failing CI job with ICX compiler

### DIFF
--- a/.github/workflows/reusable_basic.yml
+++ b/.github/workflows/reusable_basic.yml
@@ -76,15 +76,15 @@ jobs:
             disable_hwloc: 'OFF'
             link_hwloc_statically: 'OFF'
           # test icx compiler
-          - os: 'ubuntu-22.04'
-            build_type: Release
-            compiler: {c: icx, cxx: icpx}
-            shared_library: 'ON'
-            level_zero_provider: 'ON'
-            cuda_provider: 'ON'
-            install_tbb: 'ON'
-            disable_hwloc: 'OFF'
-            link_hwloc_statically: 'OFF'
+          # - os: 'ubuntu-22.04'
+            # build_type: Release
+            # compiler: {c: icx, cxx: icpx}
+            # shared_library: 'ON'
+            # level_zero_provider: 'ON'
+            # cuda_provider: 'ON'
+            # install_tbb: 'ON'
+            # disable_hwloc: 'OFF'
+            # link_hwloc_statically: 'OFF'
           # test without installing TBB
           - os: 'ubuntu-22.04'
             build_type: Release


### PR DESCRIPTION
### Description

Disable temporarily failing CI job with ICX compiler.

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
