### PR TITLE
fix for the apply of the HWLOC security patch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,12 +131,6 @@ else()
         set(HWLOC_ENABLE_TESTING OFF)
         set(HWLOC_SKIP_LSTOPO ON)
         set(HWLOC_SKIP_TOOLS ON)
-        set(HWLOC_PATCH
-            git
-            apply
-            ${PROJECT_SOURCE_DIR}/cmake/fix_coverity_issues.patch
-            ||
-            (exit 0))
 
         message(
             STATUS
@@ -147,8 +141,7 @@ else()
             hwloc_targ
             GIT_REPOSITORY ${UMF_HWLOC_REPO}
             GIT_TAG ${UMF_HWLOC_TAG}
-            PATCH_COMMAND ${HWLOC_PATCH} SOURCE_SUBDIR contrib/windows-cmake/
-                          FIND_PACKAGE_ARGS)
+            SOURCE_SUBDIR contrib/windows-cmake/ FIND_PACKAGE_ARGS)
         FetchContent_MakeAvailable(hwloc_targ)
 
         set(LIBHWLOC_INCLUDE_DIRS
@@ -157,13 +150,6 @@ else()
             ${hwloc_targ_BINARY_DIR}/Release;${hwloc_targ_BINARY_DIR}/Debug)
     else()
         include(FetchContent)
-        set(HWLOC_PATCH
-            git
-            apply
-            ${PROJECT_SOURCE_DIR}/cmake/fix_coverity_issues.patch
-            ||
-            (exit 0))
-
         message(
             STATUS
                 "Will fetch hwloc from ${UMF_HWLOC_REPO} (tag: ${UMF_HWLOC_TAG})"
@@ -172,8 +158,7 @@ else()
         FetchContent_Declare(
             hwloc_targ
             GIT_REPOSITORY ${UMF_HWLOC_REPO}
-            GIT_TAG ${UMF_HWLOC_TAG}
-            PATCH_COMMAND ${HWLOC_PATCH})
+            GIT_TAG ${UMF_HWLOC_TAG})
         FetchContent_MakeAvailable(hwloc_targ)
 
         add_custom_command(
@@ -215,6 +200,22 @@ else()
     message(STATUS "    LIBHWLOC_LIBRARIES = ${LIBHWLOC_LIBRARIES}")
     message(STATUS "    LIBHWLOC_INCLUDE_DIRS = ${LIBHWLOC_INCLUDE_DIRS}")
     message(STATUS "    LIBHWLOC_LIBRARY_DIRS = ${LIBHWLOC_LIBRARY_DIRS}")
+endif()
+
+if(hwloc_targ_SOURCE_DIR)
+    # apply security patch for HWLOC
+    execute_process(
+        COMMAND git apply ${PROJECT_SOURCE_DIR}/cmake/fix_coverity_issues.patch
+        WORKING_DIRECTORY ${hwloc_targ_SOURCE_DIR}
+        OUTPUT_VARIABLE UMF_HWLOC_PATCH_OUTPUT
+        ERROR_VARIABLE UMF_HWLOC_PATCH_ERROR)
+
+    if(UMF_HWLOC_PATCH_OUTPUT)
+        message(STATUS "HWLOC patch command output:\n${UMF_HWLOC_PATCH_OUTPUT}")
+    endif()
+    if(UMF_HWLOC_PATCH_ERROR)
+        message(WARNING "HWLOC patch command output:\n${UMF_HWLOC_PATCH_ERROR}")
+    endif()
 endif()
 
 # This build type check is not possible on Windows when CMAKE_BUILD_TYPE is not


### PR DESCRIPTION
fix for the apply of the HWLOC security patch

This is a fix for a scenario where the user runs the cmake configuration with the UMF_LINK_HWLOC_STATICALLY setting multiple times for the same build directory. On the first run, cmake downloads the HWLOC sources and successfully applies the required security patch, but the patching fails the second time (the patch has already been applied). This PR fixes this error.