### PR TITLE
Align size of allocation to provider's page size in arena_extent_alloc()

### DIFF
--- a/src/pool/pool_jemalloc.c
+++ b/src/pool/pool_jemalloc.c
@@ -76,6 +76,9 @@ static void *arena_extent_alloc(extent_hooks_t *extent_hooks, void *new_addr,
 
     jemalloc_memory_pool_t *pool = get_pool_by_arena_index(arena_ind);
 
+    // align a size of the allocation to the provider's page size
+    size = ALIGN_UP(size, pool->page_size);
+
     void *ptr = new_addr;
     ret = umfMemoryProviderAlloc(pool->provider, size, alignment, &ptr);
     if (ret != UMF_RESULT_SUCCESS) {


### PR DESCRIPTION
### Description

Align size of allocation to provider's page size in `arena_extent_alloc()`.

Ref: https://github.com/oneapi-src/unified-memory-framework/pull/838

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
