### PR TITLE
Disable temporarily failing CI job with ICX compiler

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -58,12 +58,15 @@ jobs:
             level_zero_provider: 'OFF'
             install_tbb: 'ON'
           # test icx compiler
-          - os: 'ubuntu-22.04'
-            build_type: Release
-            compiler: {c: icx, cxx: icpx}
-            shared_library: 'ON'
-            level_zero_provider: 'ON'
-            install_tbb: 'ON' 
+          # - os: 'ubuntu-22.04'
+            # build_type: Release
+            # compiler: {c: icx, cxx: icpx}
+            # shared_library: 'ON'
+            # level_zero_provider: 'ON'
+            # cuda_provider: 'ON'
+            # install_tbb: 'ON'
+            # disable_hwloc: 'OFF'
+            # link_hwloc_statically: 'OFF'
           # test without installing TBB
           - os: 'ubuntu-22.04'
             build_type: Release


### PR DESCRIPTION
Disable temporarily failing CI job with ICX compiler

ref https://github.com/oneapi-src/unified-memory-framework/pull/842