### PR TITLE
Add DEVDAX and FSDAX tests with the proxy library

### DIFF
--- a/.github/workflows/reusable_dax.yml
+++ b/.github/workflows/reusable_dax.yml
@@ -101,10 +101,28 @@ jobs:
 
       - name: Run the FSDAX tests
         working-directory: ${{env.BUILD_DIR}}
-        run: |
-          UMF_TESTS_FSDAX_PATH=${{env.UMF_TESTS_FSDAX_PATH}} UMF_TESTS_FSDAX_PATH_2=${{env.UMF_TESTS_FSDAX_PATH_2}} ctest -C ${{matrix.build_type}} -R umf-provider_file_memory -V
-          UMF_TESTS_FSDAX_PATH=${{env.UMF_TESTS_FSDAX_PATH}} UMF_TESTS_FSDAX_PATH_2=${{env.UMF_TESTS_FSDAX_PATH_2}} ctest -C ${{matrix.build_type}} -R umf_example_dram_and_fsdax -V
-          UMF_TESTS_FSDAX_PATH=${{env.UMF_TESTS_FSDAX_PATH}} UMF_TESTS_FSDAX_PATH_2=${{env.UMF_TESTS_FSDAX_PATH_2}} ctest -C ${{matrix.build_type}} -R umf-ipc_file_prov_fsdax -V
+        run: >
+          UMF_TESTS_FSDAX_PATH=${{env.UMF_TESTS_FSDAX_PATH}}
+          UMF_TESTS_FSDAX_PATH_2=${{env.UMF_TESTS_FSDAX_PATH_2}}
+          ctest -C ${{matrix.build_type}} -V -R "umf-provider_file_memory|umf_example_dram_and_fsdax|umf-ipc_file_prov_fsdax"
+
+      # TODO: enable the provider_devdax_memory_ipc test when the IPC tests with the proxy library are fixed
+      # see the issue: https://github.com/oneapi-src/unified-memory-framework/issues/864
+      - name: Run the DEVDAX tests with the proxy library
+        working-directory: ${{env.BUILD_DIR}}
+        run: >
+          LD_PRELOAD=./lib/libumf_proxy.so
+          UMF_TESTS_DEVDAX_PATH="/dev/dax${{env.DEVDAX_NAMESPACE}}"
+          UMF_TESTS_DEVDAX_SIZE="$(ndctl list --namespace=namespace${{env.DEVDAX_NAMESPACE}} | grep size | cut -d':' -f2 | cut -d',' -f1)"
+          ctest -C ${{matrix.build_type}} -R devdax -E provider_devdax_memory_ipc -V
+
+      - name: Run the FSDAX tests with the proxy library
+        working-directory: ${{env.BUILD_DIR}}
+        run: >
+          LD_PRELOAD=./lib/libumf_proxy.so
+          UMF_TESTS_FSDAX_PATH=${{env.UMF_TESTS_FSDAX_PATH}}
+          UMF_TESTS_FSDAX_PATH_2=${{env.UMF_TESTS_FSDAX_PATH_2}}
+          ctest -C ${{matrix.build_type}} -V -R "umf-provider_file_memory|umf_example_dram_and_fsdax|umf-ipc_file_prov_fsdax"
 
       - name: Check coverage
         if:  ${{ matrix.build_type == 'Debug' }}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -274,6 +274,10 @@ if(LINUX AND (NOT UMF_DISABLE_HWLOC)) # OS-specific functions are implemented
     add_umf_test(
         NAME provider_devdax_memory
         SRCS provider_devdax_memory.cpp
+        LIBS ${UMF_UTILS_FOR_TEST})
+    add_umf_test(
+        NAME provider_devdax_memory_ipc
+        SRCS provider_devdax_memory_ipc.cpp
         LIBS ${UMF_UTILS_FOR_TEST} ${LIB_JEMALLOC_POOL})
     add_umf_test(
         NAME provider_file_memory

--- a/test/provider_devdax_memory.cpp
+++ b/test/provider_devdax_memory.cpp
@@ -12,17 +12,10 @@
 #include "base.hpp"
 
 #include "cpp_helpers.hpp"
-#include "ipcFixtures.hpp"
 #include "test_helpers.h"
 
 #include <umf/memory_provider.h>
 #include <umf/providers/provider_devdax_memory.h>
-#ifdef UMF_POOL_JEMALLOC_ENABLED
-#include <umf/pools/pool_jemalloc.h>
-#endif
-#ifdef UMF_POOL_SCALABLE_ENABLED
-#include <umf/pools/pool_scalable.h>
-#endif
 
 using umf_test::test;
 
@@ -357,41 +350,3 @@ TEST_F(test, create_wrong_size_0) {
     EXPECT_EQ(ret, UMF_RESULT_ERROR_INVALID_ARGUMENT);
     EXPECT_EQ(hProvider, nullptr);
 }
-
-HostMemoryAccessor hostAccessor;
-
-static std::vector<ipcTestParams> getIpcProxyPoolTestParamsList(void) {
-    std::vector<ipcTestParams> ipcProxyPoolTestParamsList = {};
-
-    char *path = getenv("UMF_TESTS_DEVDAX_PATH");
-    if (path == nullptr || path[0] == 0) {
-        // Test skipped, UMF_TESTS_DEVDAX_PATH is not set
-        return ipcProxyPoolTestParamsList;
-    }
-
-    char *size = getenv("UMF_TESTS_DEVDAX_SIZE");
-    if (size == nullptr || size[0] == 0) {
-        // Test skipped, UMF_TESTS_DEVDAX_PATH is not set
-        return ipcProxyPoolTestParamsList;
-    }
-
-    ipcProxyPoolTestParamsList = {
-        {umfProxyPoolOps(), nullptr, umfDevDaxMemoryProviderOps(),
-         &defaultDevDaxParams, &hostAccessor, true},
-#ifdef UMF_POOL_JEMALLOC_ENABLED
-        {umfJemallocPoolOps(), nullptr, umfDevDaxMemoryProviderOps(),
-         &defaultDevDaxParams, &hostAccessor, false},
-#endif
-#ifdef UMF_POOL_SCALABLE_ENABLED
-        {umfScalablePoolOps(), nullptr, umfDevDaxMemoryProviderOps(),
-         &defaultDevDaxParams, &hostAccessor, false},
-#endif
-    };
-
-    return ipcProxyPoolTestParamsList;
-}
-
-GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(umfIpcTest);
-
-INSTANTIATE_TEST_SUITE_P(DevDaxProviderDifferentPoolsTest, umfIpcTest,
-                         ::testing::ValuesIn(getIpcProxyPoolTestParamsList()));

--- a/test/provider_devdax_memory_ipc.cpp
+++ b/test/provider_devdax_memory_ipc.cpp
@@ -1,0 +1,59 @@
+// Copyright (C) 2024 Intel Corporation
+// Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <umf/memory_provider.h>
+#include <umf/providers/provider_devdax_memory.h>
+#ifdef UMF_POOL_JEMALLOC_ENABLED
+#include <umf/pools/pool_jemalloc.h>
+#endif
+#ifdef UMF_POOL_SCALABLE_ENABLED
+#include <umf/pools/pool_scalable.h>
+#endif
+
+#include "ipcFixtures.hpp"
+
+using umf_test::test;
+
+auto defaultDevDaxParams = umfDevDaxMemoryProviderParamsDefault(
+    getenv("UMF_TESTS_DEVDAX_PATH"),
+    atol(getenv("UMF_TESTS_DEVDAX_SIZE") ? getenv("UMF_TESTS_DEVDAX_SIZE")
+                                         : "0"));
+
+HostMemoryAccessor hostAccessor;
+
+static std::vector<ipcTestParams> getIpcProxyPoolTestParamsList(void) {
+    std::vector<ipcTestParams> ipcProxyPoolTestParamsList = {};
+
+    char *path = getenv("UMF_TESTS_DEVDAX_PATH");
+    if (path == nullptr || path[0] == 0) {
+        // skipping the test, UMF_TESTS_DEVDAX_PATH is not set
+        return ipcProxyPoolTestParamsList;
+    }
+
+    char *size = getenv("UMF_TESTS_DEVDAX_SIZE");
+    if (size == nullptr || size[0] == 0) {
+        // skipping the test, UMF_TESTS_DEVDAX_SIZE is not set
+        return ipcProxyPoolTestParamsList;
+    }
+
+    ipcProxyPoolTestParamsList = {
+        {umfProxyPoolOps(), nullptr, umfDevDaxMemoryProviderOps(),
+         &defaultDevDaxParams, &hostAccessor, true},
+#ifdef UMF_POOL_JEMALLOC_ENABLED
+        {umfJemallocPoolOps(), nullptr, umfDevDaxMemoryProviderOps(),
+         &defaultDevDaxParams, &hostAccessor, false},
+#endif
+#ifdef UMF_POOL_SCALABLE_ENABLED
+        {umfScalablePoolOps(), nullptr, umfDevDaxMemoryProviderOps(),
+         &defaultDevDaxParams, &hostAccessor, false},
+#endif
+    };
+
+    return ipcProxyPoolTestParamsList;
+}
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(umfIpcTest);
+
+INSTANTIATE_TEST_SUITE_P(DevDaxProviderDifferentPoolsTest, umfIpcTest,
+                         ::testing::ValuesIn(getIpcProxyPoolTestParamsList()));


### PR DESCRIPTION
### Description

Add DEVDAX and FSDAX tests with the proxy library.

The `umf-provider_devdax_memory_ipc` IPC test is commented out,
because it does not work with the proxy library.

Ref: #864

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
