### PR TITLE
[main] Fix disabling of pci support in hwloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,7 @@ else()
             COMMAND
                 ./configure --prefix=${hwloc_targ_BINARY_DIR}
                 --enable-static=yes --enable-shared=no --disable-libxml2
-                --disable-pciaccess --disable-levelzero --disable-opencl
+                --disable-pci --disable-levelzero --disable-opencl
                 --disable-cuda --disable-nvml CFLAGS=-fPIC CXXFLAGS=-fPIC
             WORKING_DIRECTORY ${hwloc_targ_SOURCE_DIR}
             OUTPUT ${hwloc_targ_SOURCE_DIR}/Makefile


### PR DESCRIPTION
The flag that hwloc recognize is --disable-pci, not --disable-pciaccess.