### PR TITLE
[v0.9.x] Fix disabling of pci support in hwloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,7 +189,7 @@ elseif(NOT UMF_DISABLE_HWLOC)
     add_custom_command(
         COMMAND
             ./configure --prefix=${hwloc_targ_BINARY_DIR} --enable-static=yes
-            --enable-shared=no --disable-libxml2 --disable-pciaccess
+            --enable-shared=no --disable-libxml2 --disable-pci
             --disable-levelzero --disable-opencl --disable-cuda --disable-nvml
             CFLAGS=-fPIC CXXFLAGS=-fPIC
         WORKING_DIRECTORY ${hwloc_targ_SOURCE_DIR}


### PR DESCRIPTION
The flag that hwloc recognize is --disable-pci, not --disable-pciaccess.