### PR TITLE
Enable IPC tests with the proxy library

### DIFF
--- a/.github/workflows/reusable_dax.yml
+++ b/.github/workflows/reusable_dax.yml
@@ -106,8 +106,6 @@ jobs:
           UMF_TESTS_FSDAX_PATH_2=${{env.UMF_TESTS_FSDAX_PATH_2}}
           ctest -C ${{matrix.build_type}} -V -R "file|fsdax"
 
-      # TODO: enable the provider_devdax_memory_ipc test when the IPC tests with the proxy library are fixed
-      # see the issue: https://github.com/oneapi-src/unified-memory-framework/issues/864
       - name: Run the DEVDAX tests with the proxy library
         # proxy library is built only if libumf is a shared library
         if: ${{ matrix.shared_library == 'ON' }}
@@ -116,10 +114,8 @@ jobs:
           LD_PRELOAD=./lib/libumf_proxy.so
           UMF_TESTS_DEVDAX_PATH="/dev/dax${{env.DEVDAX_NAMESPACE}}"
           UMF_TESTS_DEVDAX_SIZE="$(ndctl list --namespace=namespace${{env.DEVDAX_NAMESPACE}} | grep size | cut -d':' -f2 | cut -d',' -f1)"
-          ctest -C ${{matrix.build_type}} -V -R devdax -E provider_devdax_memory_ipc
+          ctest -C ${{matrix.build_type}} -V -R devdax
 
-      # TODO: enable the provider_file_memory_ipc test when the IPC tests with the proxy library are fixed
-      # see the issue: https://github.com/oneapi-src/unified-memory-framework/issues/864
       - name: Run the FSDAX tests with the proxy library
         # proxy library is built only if libumf is a shared library
         if: ${{ matrix.shared_library == 'ON' }}
@@ -128,7 +124,7 @@ jobs:
           LD_PRELOAD=./lib/libumf_proxy.so
           UMF_TESTS_FSDAX_PATH=${{env.UMF_TESTS_FSDAX_PATH}}
           UMF_TESTS_FSDAX_PATH_2=${{env.UMF_TESTS_FSDAX_PATH_2}}
-          ctest -C ${{matrix.build_type}} -V -R "file|fsdax" -E provider_file_memory_ipc
+          ctest -C ${{matrix.build_type}} -V -R "file|fsdax"
 
       - name: Check coverage
         if:  ${{ matrix.build_type == 'Debug' }}

--- a/.github/workflows/reusable_proxy_lib.yml
+++ b/.github/workflows/reusable_proxy_lib.yml
@@ -59,11 +59,9 @@ jobs:
       - name: Build UMF
         run: cmake --build ${{env.BUILD_DIR}} -j $(nproc)
 
-      # TODO enable the provider_file_memory_ipc test when the IPC tests with the proxy library are fixed
-      # see the issue: https://github.com/oneapi-src/unified-memory-framework/issues/864
       - name: Run "ctest --output-on-failure" with proxy library
         working-directory: ${{env.BUILD_DIR}}
-        run: LD_PRELOAD=./lib/libumf_proxy.so ctest --output-on-failure -E provider_file_memory_ipc
+        run: LD_PRELOAD=./lib/libumf_proxy.so ctest --output-on-failure
 
       - name: Run "./test/umf_test-memoryPool" with proxy library
         working-directory: ${{env.BUILD_DIR}}
@@ -77,14 +75,12 @@ jobs:
         working-directory: ${{env.BUILD_DIR}}
         run: UMF_PROXY="page.disposition=shared-shm" LD_PRELOAD=./lib/libumf_proxy.so /usr/bin/date
 
-      # TODO enable the provider_file_memory_ipc test when the IPC tests with the proxy library are fixed
-      # see the issue: https://github.com/oneapi-src/unified-memory-framework/issues/864
       - name: Run "ctest --output-on-failure" with proxy library and size.threshold=128
         working-directory: ${{env.BUILD_DIR}}
         run: >
           UMF_PROXY="page.disposition=shared-shm;size.threshold=128"
           LD_PRELOAD=./lib/libumf_proxy.so
-          ctest --output-on-failure -E provider_file_memory_ipc
+          ctest --output-on-failure
 
       - name: Check coverage
         if:  ${{ matrix.build_type == 'Debug' }}


### PR DESCRIPTION
### Description

Enable IPC tests with the proxy library which were disabled, because of the issue: https://github.com/oneapi-src/unified-memory-framework/issues/864

Fixes: #864

Requires:
- [x] #931 
- [x] #932 

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
