### PR TITLE
Workflows clean up (part 2)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -175,3 +175,12 @@ jobs:
         call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
         call "C:\Program Files (x86)\Intel\oneAPI\setvars-vcvarsall.bat"
         ctest -C ${{matrix.build_type}} --output-on-failure --test-dir test
+
+  L0:
+    uses: ./.github/workflows/reusable_gpu.yml
+    with:
+      name: "LEVEL_ZERO"
+  CUDA:
+    uses: ./.github/workflows/reusable_gpu.yml
+    with:
+      name: "CUDA"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -184,3 +184,10 @@ jobs:
     uses: ./.github/workflows/reusable_gpu.yml
     with:
       name: "CUDA"
+
+  # Full exeuction of QEMU tests
+  QEMU:
+    uses: ./.github/workflows/reusable_qemu.yml
+    with:
+      short_run: false
+      os: "['ubuntu-23.04', 'ubuntu-24.04']"

--- a/.github/workflows/pr_push.yml
+++ b/.github/workflows/pr_push.yml
@@ -31,6 +31,9 @@ jobs:
   DevDax:
     needs: [FastBuild]
     uses: ./.github/workflows/reusable_dax.yml
+  MultiNuma:
+    needs: [FastBuild]
+    uses: ./.github/workflows/reusable_multi_numa.yml
   Sanitizers:
     needs: [FastBuild]
     uses: ./.github/workflows/reusable_sanitizers.yml
@@ -49,9 +52,6 @@ jobs:
   Valgrind:
     needs: [Build]
     uses: ./.github/workflows/reusable_valgrind.yml
-  MultiNuma:
-    needs: [Build]
-    uses: ./.github/workflows/reusable_multi_numa.yml
   Coverage:
     # total coverage (on upstream only)
     if: github.repository == 'oneapi-src/unified-memory-framework'

--- a/.github/workflows/pr_push.yml
+++ b/.github/workflows/pr_push.yml
@@ -34,6 +34,18 @@ jobs:
   MultiNuma:
     needs: [FastBuild]
     uses: ./.github/workflows/reusable_multi_numa.yml
+  L0:
+    needs: [Build]
+    uses: ./.github/workflows/reusable_gpu.yml
+    with:
+      name: "LEVEL_ZERO"
+      shared_lib: "['ON']"
+  CUDA:
+    needs: [Build]
+    uses: ./.github/workflows/reusable_gpu.yml
+    with:
+      name: "CUDA"
+      shared_lib: "['ON']"
   Sanitizers:
     needs: [FastBuild]
     uses: ./.github/workflows/reusable_sanitizers.yml
@@ -46,16 +58,13 @@ jobs:
   ProxyLib:
     needs: [Build]
     uses: ./.github/workflows/reusable_proxy_lib.yml
-  GPU:
-    needs: [Build]
-    uses: ./.github/workflows/reusable_gpu.yml
   Valgrind:
     needs: [Build]
     uses: ./.github/workflows/reusable_valgrind.yml
   Coverage:
     # total coverage (on upstream only)
     if: github.repository == 'oneapi-src/unified-memory-framework'
-    needs: [Build, DevDax, GPU, MultiNuma, Qemu, ProxyLib]
+    needs: [Build, DevDax, L0, CUDA, MultiNuma, Qemu, ProxyLib]
     uses: ./.github/workflows/reusable_coverage.yml
     secrets: inherit
     with:

--- a/.github/workflows/pr_push.yml
+++ b/.github/workflows/pr_push.yml
@@ -49,9 +49,11 @@ jobs:
   Sanitizers:
     needs: [FastBuild]
     uses: ./.github/workflows/reusable_sanitizers.yml
-  Qemu:
+  QEMU:
     needs: [FastBuild]
     uses: ./.github/workflows/reusable_qemu.yml
+    with:
+      short_run: true
   Benchmarks:
     needs: [Build]
     uses: ./.github/workflows/reusable_benchmarks.yml
@@ -64,7 +66,7 @@ jobs:
   Coverage:
     # total coverage (on upstream only)
     if: github.repository == 'oneapi-src/unified-memory-framework'
-    needs: [Build, DevDax, L0, CUDA, MultiNuma, Qemu, ProxyLib]
+    needs: [Build, DevDax, L0, CUDA, MultiNuma, QEMU, ProxyLib]
     uses: ./.github/workflows/reusable_coverage.yml
     secrets: inherit
     with:
@@ -72,7 +74,7 @@ jobs:
   Coverage_partial:
     # partial coverage (on forks)
     if: github.repository != 'oneapi-src/unified-memory-framework'
-    needs: [Build, Qemu, ProxyLib]
+    needs: [Build, QEMU, ProxyLib]
     uses: ./.github/workflows/reusable_coverage.yml
   CodeQL:
     needs: [Build]

--- a/.github/workflows/reusable_gpu.yml
+++ b/.github/workflows/reusable_gpu.yml
@@ -1,10 +1,26 @@
-# This workflow builds and tests providers using GPU memory. It requires 
-# appropriately labelled self-hosted runners installed on systems with the 
-# correct GPU and drivers
-
+# This workflow builds and tests providers using GPU memory. It requires properly
+# labelled self-hosted runners on systems with the correct GPU and drivers.
 name: GPU
 
-on: [workflow_call]
+on:
+  workflow_call:
+    inputs:
+      name:
+        description: Provider name
+        type: string
+        required: true
+      os:
+        description: A list of OSes
+        type: string
+        default: "['Ubuntu', 'Windows']"
+      build_type:
+        description: A list of build types
+        type: string
+        default: "['Debug', 'Release']"
+      shared_lib:
+        description: A list of options for building shared library
+        type: string
+        default: "['ON', 'OFF']"
 
 permissions:
   contents: read
@@ -15,18 +31,20 @@ env:
   COVERAGE_DIR : "${{github.workspace}}/coverage"
 
 jobs:
-  gpu-Level-Zero:
-    name: Level-Zero
+  gpu:
+    name: "${{matrix.os}}, ${{matrix.build_type}}, shared=${{matrix.shared_library}}"
     env:
-      VCPKG_PATH: "${{github.workspace}}/../../../../vcpkg/packages/hwloc_x64-windows;${{github.workspace}}/../../../../vcpkg/packages/tbb_x64-windows;${{github.workspace}}/../../../../vcpkg/packages/jemalloc_x64-windows"
-      COVERAGE_NAME : "exports-coverage-gpu-L0"
+      VCPKG_PATH: "${{github.workspace}}/build/vcpkg/packages/hwloc_x64-windows;${{github.workspace}}/build/vcpkg/packages/tbb_x64-windows;${{github.workspace}}/build/vcpkg/packages/jemalloc_x64-windows;"
+      CUDA_PATH: "C:/cuda"
+      COVERAGE_NAME : "exports-coverage-${{inputs.name}}"
     # run only on upstream; forks will not have the HW
     if: github.repository == 'oneapi-src/unified-memory-framework'
     strategy:
+      fail-fast: false
       matrix:
-        shared_library: ['ON', 'OFF']
-        os: ['Ubuntu', 'Windows']
-        build_type: ['Debug', 'Release']
+        shared_library: ${{ fromJSON(inputs.shared_lib)}}
+        os: ${{ fromJSON(inputs.os)}}
+        build_type: ${{ fromJSON(inputs.build_type)}}
         include:
           - os: 'Ubuntu'
             compiler: {c: gcc, cxx: g++}
@@ -34,11 +52,8 @@ jobs:
           - os: 'Windows'
             compiler: {c: cl, cxx: cl}
             number_of_processors: '$Env:NUMBER_OF_PROCESSORS'
-        exclude:
-          - os: 'Windows'
-            build_type: 'Debug'
 
-    runs-on: ["DSS-LEVEL_ZERO", "DSS-${{matrix.os}}"]
+    runs-on: ["DSS-${{inputs.name}}", "DSS-${{matrix.os}}"]
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -49,11 +64,23 @@ jobs:
         if: matrix.os == 'Ubuntu'
         run: .github/scripts/get_system_info.sh
 
-      - name: Configure build for Win
+      - name: "[Win] Initialize vcpkg"
         if: matrix.os == 'Windows'
+        uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5
+        with:
+          vcpkgGitCommitId: 3dd44b931481d7a8e9ba412621fa810232b66289
+          vcpkgDirectory: ${{env.BUILD_DIR}}/vcpkg
+          vcpkgJsonGlob: '**/vcpkg.json'
+
+      - name: "[Win] Install dependencies"
+        if: matrix.os == 'Windows'
+        run: vcpkg install
+
+      # note: disable all providers except the one being tested
+      - name: Configure build
         run: >
           cmake
-          -DCMAKE_PREFIX_PATH="${{env.VCPKG_PATH}}"
+          -DCMAKE_PREFIX_PATH="${{env.VCPKG_PATH}}${{env.CUDA_PATH}}"
           -B ${{env.BUILD_DIR}}
           -DCMAKE_INSTALL_PREFIX="${{env.INSTL_DIR}}"
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
@@ -64,36 +91,14 @@ jobs:
           -DUMF_BUILD_TESTS=ON
           -DUMF_BUILD_GPU_TESTS=ON
           -DUMF_BUILD_GPU_EXAMPLES=ON
-          -DUMF_FORMAT_CODE_STYLE=OFF
           -DUMF_DEVELOPER_MODE=ON
           -DUMF_BUILD_LIBUMF_POOL_DISJOINT=ON
           -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
-          -DUMF_BUILD_LEVEL_ZERO_PROVIDER=ON
           -DUMF_BUILD_CUDA_PROVIDER=OFF
+          -DUMF_BUILD_LEVEL_ZERO_PROVIDER=OFF
+          -DUMF_BUILD_${{inputs.name}}_PROVIDER=ON
           -DUMF_TESTS_FAIL_ON_SKIP=ON
-      
-      - name: Configure build for Ubuntu
-        if: matrix.os == 'Ubuntu'
-        run: >
-          cmake
-          -B ${{env.BUILD_DIR}}
-          -DCMAKE_INSTALL_PREFIX="${{env.INSTL_DIR}}"
-          -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
-          -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
-          -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
-          -DUMF_BUILD_SHARED_LIBRARY=${{matrix.shared_library}}
-          -DUMF_BUILD_BENCHMARKS=ON
-          -DUMF_BUILD_TESTS=ON
-          -DUMF_BUILD_GPU_TESTS=ON
-          -DUMF_BUILD_GPU_EXAMPLES=ON
-          -DUMF_FORMAT_CODE_STYLE=OFF
-          -DUMF_DEVELOPER_MODE=ON
-          -DUMF_BUILD_LIBUMF_POOL_DISJOINT=ON
-          -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
-          -DUMF_BUILD_LEVEL_ZERO_PROVIDER=ON
-          -DUMF_BUILD_CUDA_PROVIDER=OFF
-          -DUMF_TESTS_FAIL_ON_SKIP=ON
-          ${{ matrix.build_type == 'Debug' && '-DUMF_USE_COVERAGE=ON' || '' }}
+          ${{ matrix.os == 'Ubuntu' && matrix.build_type == 'Debug' && '-DUMF_USE_COVERAGE=ON' || '' }}
 
       - name: Build UMF
         run: cmake --build ${{env.BUILD_DIR}} --config ${{matrix.build_type}} -j ${{matrix.number_of_processors}}
@@ -111,7 +116,7 @@ jobs:
         run: ctest --output-on-failure --test-dir benchmark -C ${{matrix.build_type}} --exclude-regex umf-bench-multithreaded
 
       - name: Check coverage
-        if:  ${{ matrix.build_type == 'Debug' && matrix.os == 'Ubuntu' }}
+        if: ${{ matrix.build_type == 'Debug' && matrix.os == 'Ubuntu' }}
         working-directory: ${{env.BUILD_DIR}}
         run: |
           export COVERAGE_FILE_NAME=${{env.COVERAGE_NAME}}-shared-${{matrix.shared_library}}
@@ -121,133 +126,7 @@ jobs:
           mv ./$COVERAGE_FILE_NAME ${{env.COVERAGE_DIR}}
 
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
-        if:  ${{ matrix.build_type == 'Debug' && matrix.os == 'Ubuntu' }}
+        if: ${{ matrix.build_type == 'Debug' && matrix.os == 'Ubuntu' }}
         with:
-          name: ${{env.COVERAGE_NAME}}-shared-${{matrix.shared_library}}
+          name: ${{env.COVERAGE_NAME}}-${{matrix.os}}-${{matrix.build_type}}-shared-${{matrix.shared_library}}
           path: ${{env.COVERAGE_DIR}}
-
-  gpu-CUDA:
-    name: CUDA
-    env:
-      COVERAGE_NAME : "exports-coverage-gpu-CUDA"
-      VCPKG_PATH: "${{github.workspace}}/build/vcpkg/packages/hwloc_x64-windows;${{github.workspace}}/build/vcpkg/packages/tbb_x64-windows;${{github.workspace}}/build/vcpkg/packages/jemalloc_x64-windows;"
-      CUDA_PATH: "c:/cuda"
-
-    # run only on upstream; forks will not have the HW
-    if: github.repository == 'oneapi-src/unified-memory-framework'
-    strategy:
-      matrix:
-        shared_library: ['ON', 'OFF']
-        build_type: ['Debug', 'Release']
-        os: ['Ubuntu', 'Windows']
-        include:
-        - os: 'Windows'
-          compiler: {c: cl, cxx: cl}
-          number_of_processors: '$Env:NUMBER_OF_PROCESSORS'
-        - os: 'Ubuntu'
-          compiler: {c: gcc, cxx: g++}
-          number_of_processors: '$(nproc)'
-        exclude:
-        - os: 'Windows'
-          build_type: 'Debug'
-
-    runs-on: ["DSS-CUDA", "DSS-${{matrix.os}}"]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      with:
-        fetch-depth: 0
-
-    - name: Get information about platform
-      if: matrix.os == 'Ubuntu'
-      run: .github/scripts/get_system_info.sh
-
-    - name: Initialize vcpkg
-      if: matrix.os == 'Windows'
-      uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5
-      with:
-        vcpkgGitCommitId: 3dd44b931481d7a8e9ba412621fa810232b66289
-        vcpkgDirectory: ${{env.BUILD_DIR}}/vcpkg
-        vcpkgJsonGlob: '**/vcpkg.json'
-
-    - name: Install dependencies (windows-latest)
-      if: matrix.os == 'Windows'
-      run: vcpkg install
-      shell: pwsh # Specifies PowerShell as the shell for running the script.
-
-    - name: Configure build for Win
-      if: matrix.os == 'Windows'
-      run: >
-        cmake
-        -DCMAKE_PREFIX_PATH="${{env.VCPKG_PATH}}${{env.CUDA_PATH}}"
-        -B ${{env.BUILD_DIR}}
-        -DCMAKE_INSTALL_PREFIX="${{env.INSTL_DIR}}"
-        -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
-        -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
-        -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
-        -DUMF_BUILD_SHARED_LIBRARY=${{matrix.shared_library}}
-        -DUMF_BUILD_BENCHMARKS=ON
-        -DUMF_BUILD_TESTS=ON
-        -DUMF_BUILD_GPU_TESTS=ON
-        -DUMF_BUILD_GPU_EXAMPLES=ON
-        -DUMF_FORMAT_CODE_STYLE=OFF
-        -DUMF_DEVELOPER_MODE=ON
-        -DUMF_BUILD_LIBUMF_POOL_DISJOINT=ON
-        -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
-        -DUMF_BUILD_LEVEL_ZERO_PROVIDER=OFF
-        -DUMF_BUILD_CUDA_PROVIDER=ON
-        -DUMF_TESTS_FAIL_ON_SKIP=ON
-
-    - name: Configure build for Ubuntu
-      if: matrix.os == 'Ubuntu'
-      run: >
-        cmake 
-        -B ${{env.BUILD_DIR}}
-        -DCMAKE_INSTALL_PREFIX="${{env.INSTL_DIR}}"
-        -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
-        -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
-        -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
-        -DUMF_BUILD_SHARED_LIBRARY=${{matrix.shared_library}}
-        -DUMF_BUILD_BENCHMARKS=ON
-        -DUMF_BUILD_TESTS=ON
-        -DUMF_BUILD_GPU_TESTS=ON
-        -DUMF_BUILD_GPU_EXAMPLES=ON
-        -DUMF_FORMAT_CODE_STYLE=OFF
-        -DUMF_DEVELOPER_MODE=ON
-        -DUMF_BUILD_LIBUMF_POOL_DISJOINT=ON
-        -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
-        -DUMF_BUILD_LEVEL_ZERO_PROVIDER=OFF
-        -DUMF_BUILD_CUDA_PROVIDER=ON
-        -DUMF_TESTS_FAIL_ON_SKIP=ON
-        ${{ matrix.build_type == 'Debug' && '-DUMF_USE_COVERAGE=ON' || '' }}
-
-    - name: Build UMF
-      run: cmake --build ${{env.BUILD_DIR}} --config ${{matrix.build_type}} -j ${{matrix.number_of_processors}}
-
-    - name: Run tests
-      working-directory: ${{env.BUILD_DIR}}
-      run: ctest -C ${{matrix.build_type}} --output-on-failure --test-dir test
-
-    - name: Run examples
-      working-directory: ${{env.BUILD_DIR}}
-      run: ctest --output-on-failure --test-dir examples -C ${{matrix.build_type}}
-
-    - name: Run benchmarks
-      working-directory: ${{env.BUILD_DIR}}
-      run: ctest --output-on-failure --test-dir benchmark -C ${{matrix.build_type}} --exclude-regex umf-bench-multithreaded
-
-    - name: Check coverage
-      if:  ${{ matrix.build_type == 'Debug' && matrix.os == 'Ubuntu' }}
-      working-directory: ${{env.BUILD_DIR}}
-      run: |
-        export COVERAGE_FILE_NAME=${{env.COVERAGE_NAME}}-shared-${{matrix.shared_library}}
-        echo "COVERAGE_FILE_NAME: $COVERAGE_FILE_NAME"
-        ../scripts/coverage/coverage_capture.sh $COVERAGE_FILE_NAME
-        mkdir -p ${{env.COVERAGE_DIR}}
-        mv ./$COVERAGE_FILE_NAME ${{env.COVERAGE_DIR}}
-
-    - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
-      if:  ${{ matrix.build_type == 'Debug' && matrix.os == 'Ubuntu' }}
-      with:
-        name: ${{env.COVERAGE_NAME}}-shared-${{matrix.shared_library}}
-        path: ${{env.COVERAGE_DIR}}

--- a/.github/workflows/reusable_multi_numa.yml
+++ b/.github/workflows/reusable_multi_numa.yml
@@ -13,13 +13,15 @@ env:
 
 jobs:
   multi_numa:
-    name: ${{matrix.os}}
+    name: "${{matrix.os}}, ${{matrix.build_type}}, shared=${{matrix.shared_library}}"
     # run only on upstream; forks will not have the HW
     if: github.repository == 'oneapi-src/unified-memory-framework'
 
     strategy:
       matrix:
         os: [ubuntu-22.04, rhel-9.1]
+        build_type: [Debug, Release]
+        shared_library: ['ON', 'OFF']
     runs-on:  ["DSS-MULTI-NUMA", "DSS-${{matrix.os}}"]
 
     steps:
@@ -35,17 +37,17 @@ jobs:
         run: >
           cmake
           -B ${{github.workspace}}/build
-          -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
           -DCMAKE_C_COMPILER=gcc
           -DCMAKE_CXX_COMPILER=g++
-          -DUMF_BUILD_SHARED_LIBRARY=OFF
+          -DUMF_BUILD_SHARED_LIBRARY=${{matrix.shared_library}}
           -DUMF_BUILD_BENCHMARKS=OFF
           -DUMF_BUILD_TESTS=ON
           -DUMF_DEVELOPER_MODE=ON
           -DUMF_BUILD_LIBUMF_POOL_DISJOINT=ON
           -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
           -DUMF_TESTS_FAIL_ON_SKIP=ON
-          ${{ matrix.os == 'ubuntu-22.04' && '-DUMF_USE_COVERAGE=ON' || '' }}
+          ${{ matrix.build_type == 'Debug' && matrix.os == 'ubuntu-22.04' && '-DUMF_USE_COVERAGE=ON' || '' }}
 
       - name: Build UMF
         run: cmake --build ${{github.workspace}}/build -j $(nproc)
@@ -70,7 +72,7 @@ jobs:
         if: matrix.os == 'ubuntu-22.04'
         working-directory: ${{env.BUILD_DIR}}
         run: |
-          export COVERAGE_FILE_NAME=${{env.COVERAGE_NAME}}-os-${{matrix.os}}
+          export COVERAGE_FILE_NAME=${{env.COVERAGE_NAME}}-${{matrix.os}}-shared-${{matrix.shared_library}}
           echo "COVERAGE_FILE_NAME: $COVERAGE_FILE_NAME"
           ../scripts/coverage/coverage_capture.sh $COVERAGE_FILE_NAME
           mkdir -p ${{env.COVERAGE_DIR}}
@@ -79,5 +81,5 @@ jobs:
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: matrix.os == 'ubuntu-22.04'
         with:
-          name: ${{env.COVERAGE_NAME}}-os-${{matrix.os}}
+          name: ${{env.COVERAGE_NAME}}-${{matrix.os}}-${{matrix.build_type}}-shared-${{matrix.shared_library}}
           path: ${{env.COVERAGE_DIR}}

--- a/.github/workflows/reusable_qemu.yml
+++ b/.github/workflows/reusable_qemu.yml
@@ -1,14 +1,29 @@
 # Builds project on qemu with custom hmat settings
 name: Qemu
 
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      short_run:
+        description: Should the workflow run only basic tests?
+        type: boolean
+        default: false
+      os:
+        description: List of OSes
+        type: string
+        default: '["ubuntu-23.04"]'
 
 permissions:
   contents: read
 
 jobs:
   qemu-build:
-    name: Qemu
+    name: QEMU
+    strategy:
+      matrix:
+        os: ${{ fromJson(inputs.os) }}
+
+    # Host QEMU on any Linux platform
     runs-on: ubuntu-22.04
 
     steps:
@@ -79,11 +94,26 @@ jobs:
 
         sudo -Sk genisoimage -output ubuntu-cloud-init.iso -volid cidata -joliet -rock ./user-data ./meta-data
 
-    - name: Download ubuntu image
-      run: wget https://cloud-images.ubuntu.com/releases/lunar/release/ubuntu-23.04-server-cloudimg-amd64.img
+    - name: Set vars if short run
+      if: ${{ inputs.short_run == true }}
+      run: |
+        echo "SHORT_RUN=true" >> $GITHUB_ENV
+        declare -a short_configs=("default.xml" "sock_2_var3.xml" "sock_4_var1_hmat.xml")
+        echo "CONFIG_OPTIONS=${short_configs[@]}" >> $GITHUB_ENV
+
+    - name: Set vars if long run
+      if: ${{ inputs.short_run == false }}
+      run: |
+        echo "SHORT_RUN=false" >> $GITHUB_ENV
+        echo "CONFIG_OPTIONS=umf/scripts/qemu/configs/*.xml" >> $GITHUB_ENV
+
+    - name: Download Ubuntu image
+      run: |
+        OS_VER=$(echo ${{matrix.os}} | cut -d'-' -f2)
+        wget https://cloud-images.ubuntu.com/releases/${OS_VER}/release/${{matrix.os}}-server-cloudimg-amd64.img -O qemu_image.img
 
     - name: Resize image
-      run: qemu-img resize ./ubuntu-23.04-server-cloudimg-amd64.img +4G
+      run: qemu-img resize ./qemu_image.img +4G
 
     - name: Build UMF in QEMU
       run: |
@@ -98,7 +128,9 @@ jobs:
 
     - name: Run tests in QEMU
       run: |
-        for config_file in umf/scripts/qemu/configs/*.xml; do
+        echo "Running tests for: ${CONFIG_OPTIONS}"
+
+        for config_file in ${CONFIG_OPTIONS}; do
           config_name=$(basename $config_file)
 
           while ps -aux | grep qemu-system-x86_64 | grep -q -v grep; do
@@ -106,10 +138,10 @@ jobs:
             sleep 5
           done
 
-          echo "\n ### Testing ${config_name} ###"
+          echo "### Testing ${config_name} ###"
           umf/scripts/qemu/start_qemu.sh ${config_name}
 
-          ssh testuser@127.0.0.1 -p 2222 -t "bash /home/testuser/scripts/qemu/run-tests.sh COVERAGE ${config_name}"
+          ssh testuser@127.0.0.1 -p 2222 -t "export SHORT_RUN=${SHORT_RUN} OS_FULL_NAME=${{matrix.os}} && /home/testuser/scripts/qemu/run-tests.sh COVERAGE ${config_name}"
           scp -r -P 2222 testuser@127.0.0.1:/home/testuser/coverage ./
           ssh testuser@127.0.0.1 -p 2222 -t "sudo shutdown -h now"
         done
@@ -117,5 +149,5 @@ jobs:
 
     - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
-        name: exports-coverage-qemu-all
+        name: exports-coverage-qemu-${{matrix.os}}
         path: coverage

--- a/scripts/qemu/run-tests.sh
+++ b/scripts/qemu/run-tests.sh
@@ -3,6 +3,9 @@
 # Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+# If env var SHORT_RUN is set to true, part of the tests are skipped here.
+# For coverage, OS_FULL_NAME env variable has to be set to the name of the OS.
+
 set -e
 
 COVERAGE=$1
@@ -26,19 +29,22 @@ echo password | sudo bash -c "echo 0 > /proc/sys/kernel/yama/ptrace_scope"
 numactl -H
 
 cd build
+echo "## Running all tests ..."
 ctest --verbose
 
-# run tests bound to a numa node
+echo "## Running tests bound to a numa node 0 and node 1 ..."
 numactl -N 0 ctest --output-on-failure
 numactl -N 1 ctest --output-on-failure
 
 if [ "$COVERAGE" = "COVERAGE" ]; then
-	COVERAGE_FILE_NAME=exports-coverage-qemu-$CONFIG_NAME
+	COVERAGE_FILE_NAME=exports-coverage-qemu-${OS_FULL_NAME}-${CONFIG_NAME}
 	echo "COVERAGE_FILE_NAME: $COVERAGE_FILE_NAME"
 	../scripts/coverage/coverage_capture.sh $COVERAGE_FILE_NAME
 	mv ./$COVERAGE_FILE_NAME $COVERAGE_DIR
 fi
 
-# run tests under valgrind
-echo "Running tests under valgrind memcheck ..."
-../test/test_valgrind.sh .. . memcheck
+# run tests under valgrind only on long run or for default configuration
+if [ "${SHORT_RUN}" != "true" ] || [ "${CONFIG_NAME}" == "default" ]; then
+	echo "## Running tests under valgrind memcheck ..."
+	../test/test_valgrind.sh .. . memcheck
+fi

--- a/scripts/qemu/start_qemu.sh
+++ b/scripts/qemu/start_qemu.sh
@@ -14,7 +14,7 @@ parsed_config=$(python3 "$(dirname $0)/parse_config.py" "$(dirname $0)/configs/$
 set -x
 
 sudo qemu-system-x86_64 \
-    -drive file=./ubuntu-23.04-server-cloudimg-amd64.img,format=qcow2,index=0,media=disk,id=hd \
+    -drive file=./qemu_image.img,format=qcow2,index=0,media=disk,id=hd \
     -cdrom ./ubuntu-cloud-init.iso \
     -enable-kvm \
     -net nic -net user,hostfwd=tcp::2222-:22 \


### PR DESCRIPTION
Each commit should be checked separately.

QEMU build is split, to only run selected jobs per PR and the whole suite (with extra OS) on nightly. QEMU in short run executes only 3 configs and valgrind is executed only on `default`.
// nightly qemu (long) run was executed on my fork: https://github.com/lukaszstolarczuk/unified-memory-framework/actions/runs/11722236706/job/32651339247

CUDA and L0 - similarly - only a few jobs on PR, the rest during the nigth.

Multi Numa workflow is extended, because it's executed very quickly.

### Checklist
- [x] CI workflows execute properly
- [x] CI workflows, not executed per PR (e.g. Nightly), execute properly