### PR TITLE
Add test for `umfPoolMallocUsableSize` to improve coverage of `base_alloc_global.c`

### DIFF
--- a/test/poolFixtures.hpp
+++ b/test/poolFixtures.hpp
@@ -9,6 +9,7 @@
 #include "provider.hpp"
 #include "umf/providers/provider_coarse.h"
 #include "umf/providers/provider_devdax_memory.h"
+#include "utils/utils_sanitizers.h"
 
 #include <array>
 #include <cstring>
@@ -454,6 +455,28 @@ TEST_P(umfPoolTest, free_compliance) { free_compliance_test(pool.get()); }
 TEST_P(umfPoolTest, allocMaxSize) {
     auto *ptr = umfPoolMalloc(pool.get(), SIZE_MAX);
     ASSERT_EQ(ptr, nullptr);
+}
+
+TEST_P(umfPoolTest, mallocUsableSize) {
+#ifdef __SANITIZE_ADDRESS__
+    // Sanitizer replaces malloc_usable_size implementation with its own
+    GTEST_SKIP()
+        << "This test is invalid with AddressSanitizer instrumentation";
+#endif
+
+    for (size_t allocSize : {32, 48, 1024, 8192}) {
+        char *ptr = static_cast<char *>(umfPoolMalloc(pool.get(), allocSize));
+        ASSERT_NE(ptr, nullptr);
+        size_t result = umfPoolMallocUsableSize(pool.get(), ptr);
+        ASSERT_TRUE(result == 0 || result >= allocSize);
+
+        // Make sure we can write to this memory
+        for (size_t i = 0; i < result; i++) {
+            ptr[i] = 123;
+        }
+
+        umfPoolFree(pool.get(), ptr);
+    }
 }
 
 #endif /* UMF_TEST_POOL_FIXTURES_HPP */


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

