### PR TITLE
Replace `MALLOC_PROVIDER_OPS` with `BA_GLOBAL_PROVIDER_OPS`

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -150,12 +150,20 @@ if(UMF_POOL_JEMALLOC_ENABLED)
     set(LIB_JEMALLOC_POOL jemalloc_pool)
 endif()
 
+if(UMF_BUILD_SHARED_LIBRARY)
+    # if build as shared library, ba symbols won't be visible in tests
+    set(BA_SOURCES_FOR_TEST ${BA_SOURCES})
+endif()
+
 add_umf_test(NAME base SRCS base.cpp)
 add_umf_test(
     NAME memoryPool
-    SRCS memoryPoolAPI.cpp malloc_compliance_tests.cpp
+    SRCS memoryPoolAPI.cpp malloc_compliance_tests.cpp ${BA_SOURCES_FOR_TEST}
     LIBS ${UMF_UTILS_FOR_TEST})
-add_umf_test(NAME memoryProvider SRCS memoryProviderAPI.cpp)
+add_umf_test(
+    NAME memoryProvider
+    SRCS memoryProviderAPI.cpp ${BA_SOURCES_FOR_TEST}
+    LIBS ${UMF_UTILS_FOR_TEST})
 add_umf_test(
     NAME logger
     SRCS utils/utils_log.cpp ${UMF_UTILS_SOURCES}
@@ -173,7 +181,10 @@ if(LINUX)
         LIBS ${UMF_UTILS_FOR_TEST})
 endif()
 
-add_umf_test(NAME provider_coarse SRCS provider_coarse.cpp)
+add_umf_test(
+    NAME provider_coarse
+    SRCS provider_coarse.cpp ${BA_SOURCES_FOR_TEST}
+    LIBS ${UMF_UTILS_FOR_TEST})
 
 if(UMF_BUILD_LIBUMF_POOL_DISJOINT)
     add_umf_test(
@@ -208,8 +219,11 @@ if(UMF_POOL_JEMALLOC_ENABLED AND (NOT UMF_DISABLE_HWLOC))
 endif()
 
 if(UMF_POOL_SCALABLE_ENABLED AND (NOT UMF_DISABLE_HWLOC))
-    add_umf_test(NAME scalable_pool SRCS pools/scalable_pool.cpp
-                                         malloc_compliance_tests.cpp)
+    add_umf_test(
+        NAME scalable_pool
+        SRCS pools/scalable_pool.cpp malloc_compliance_tests.cpp
+             ${BA_SOURCES_FOR_TEST}
+        LIBS ${UMF_UTILS_FOR_TEST})
 endif()
 
 if(LINUX AND (NOT UMF_DISABLE_HWLOC)) # OS-specific functions are implemented
@@ -223,7 +237,7 @@ if(LINUX AND (NOT UMF_DISABLE_HWLOC)) # OS-specific functions are implemented
 
     add_umf_test(
         NAME provider_os_memory
-        SRCS provider_os_memory.cpp
+        SRCS provider_os_memory.cpp ${BA_SOURCES_FOR_TEST}
         LIBS ${UMF_UTILS_FOR_TEST})
     if(UMF_BUILD_LIBUMF_POOL_DISJOINT)
         target_compile_definitions(umf_test-provider_os_memory
@@ -277,7 +291,7 @@ if(LINUX AND (NOT UMF_DISABLE_HWLOC)) # OS-specific functions are implemented
         LIBS ${UMF_UTILS_FOR_TEST})
     add_umf_test(
         NAME provider_devdax_memory_ipc
-        SRCS provider_devdax_memory_ipc.cpp
+        SRCS provider_devdax_memory_ipc.cpp ${BA_SOURCES_FOR_TEST}
         LIBS ${UMF_UTILS_FOR_TEST} ${LIB_JEMALLOC_POOL})
     add_umf_test(
         NAME provider_file_memory
@@ -299,11 +313,15 @@ if(LINUX AND (NOT UMF_DISABLE_HWLOC)) # OS-specific functions are implemented
     # This test requires Linux-only file memory provider
     if(UMF_POOL_SCALABLE_ENABLED)
         add_umf_test(
-            NAME scalable_coarse_file SRCS pools/scalable_coarse_file.cpp
-                                           malloc_compliance_tests.cpp)
+            NAME scalable_coarse_file
+            SRCS pools/scalable_coarse_file.cpp malloc_compliance_tests.cpp
+                 ${BA_SOURCES_FOR_TEST}
+            LIBS ${UMF_UTILS_FOR_TEST})
         add_umf_test(
-            NAME scalable_coarse_devdax SRCS pools/scalable_coarse_devdax.cpp
-                                             malloc_compliance_tests.cpp)
+            NAME scalable_coarse_devdax
+            SRCS pools/scalable_coarse_devdax.cpp malloc_compliance_tests.cpp
+                 ${BA_SOURCES_FOR_TEST}
+            LIBS ${UMF_UTILS_FOR_TEST})
     endif()
 
     if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND UMF_BUILD_FUZZTESTS)
@@ -318,6 +336,7 @@ if(UMF_BUILD_GPU_TESTS AND UMF_BUILD_LEVEL_ZERO_PROVIDER)
     add_umf_test(
         NAME provider_level_zero
         SRCS providers/provider_level_zero.cpp providers/level_zero_helpers.cpp
+             ${BA_SOURCES_FOR_TEST}
         LIBS ${UMF_UTILS_FOR_TEST} ze_loader)
     target_include_directories(umf_test-provider_level_zero
                                PRIVATE ${LEVEL_ZERO_INCLUDE_DIRS})
@@ -325,6 +344,7 @@ if(UMF_BUILD_GPU_TESTS AND UMF_BUILD_LEVEL_ZERO_PROVIDER)
     add_umf_test(
         NAME provider_level_zero_dlopen
         SRCS providers/provider_level_zero.cpp providers/level_zero_helpers.cpp
+             ${BA_SOURCES_FOR_TEST}
         LIBS ${UMF_UTILS_FOR_TEST})
     target_compile_definitions(umf_test-provider_level_zero_dlopen
                                PUBLIC USE_DLOPEN=1)
@@ -340,6 +360,7 @@ if(UMF_BUILD_GPU_TESTS AND UMF_BUILD_CUDA_PROVIDER)
         add_umf_test(
             NAME provider_cuda
             SRCS providers/provider_cuda.cpp providers/cuda_helpers.cpp
+                 ${BA_SOURCES_FOR_TEST}
             LIBS ${UMF_UTILS_FOR_TEST} cuda)
         target_include_directories(umf_test-provider_cuda
                                    PRIVATE ${CUDA_INCLUDE_DIRS})
@@ -349,6 +370,7 @@ if(UMF_BUILD_GPU_TESTS AND UMF_BUILD_CUDA_PROVIDER)
         add_umf_test(
             NAME provider_cuda_dlopen
             SRCS providers/provider_cuda.cpp providers/cuda_helpers.cpp
+                 ${BA_SOURCES_FOR_TEST}
             LIBS ${UMF_UTILS_FOR_TEST})
         target_compile_definitions(umf_test-provider_cuda_dlopen
                                    PUBLIC USE_DLOPEN=1)
@@ -360,11 +382,6 @@ if(UMF_BUILD_GPU_TESTS AND UMF_BUILD_CUDA_PROVIDER)
                 "CUDA provdier tests requires CUDA libraries to be installed and added to the default library search path - skipping"
         )
     endif()
-endif()
-
-if(UMF_BUILD_SHARED_LIBRARY)
-    # if build as shared library, ba symbols won't be visible in tests
-    set(BA_SOURCES_FOR_TEST ${BA_SOURCES})
 endif()
 
 add_umf_test(
@@ -402,7 +419,10 @@ if(UMF_PROXY_LIB_ENABLED
                                PUBLIC UMF_PROXY_LIB_ENABLED=1)
 endif()
 
-add_umf_test(NAME ipc SRCS ipcAPI.cpp)
+add_umf_test(
+    NAME ipc
+    SRCS ipcAPI.cpp ${BA_SOURCES_FOR_TEST}
+    LIBS ${UMF_UTILS_FOR_TEST})
 
 add_umf_test(NAME ipc_negative SRCS ipc_negative.cpp)
 

--- a/test/common/provider.hpp
+++ b/test/common/provider.hpp
@@ -123,7 +123,7 @@ struct provider_ba_global : public provider_base_t {
     const char *get_name() noexcept { return "umf_ba_global"; }
 };
 
-umf_memory_provider_ops_t MALLOC_PROVIDER_OPS =
+umf_memory_provider_ops_t BA_GLOBAL_PROVIDER_OPS =
     umf::providerMakeCOps<provider_ba_global, void>();
 
 struct provider_mock_out_of_mem : public provider_base_t {

--- a/test/common/provider.hpp
+++ b/test/common/provider.hpp
@@ -14,6 +14,7 @@
 #include <umf/memory_provider.h>
 
 #include "base.hpp"
+#include "base_alloc_global.h"
 #include "cpp_helpers.hpp"
 #include "test_helpers.h"
 
@@ -110,24 +111,16 @@ struct provider_malloc : public provider_base_t {
         // error because of this issue.
         size_t aligned_size = ALIGN_UP(size, align);
 
-#ifdef _WIN32
-        *ptr = _aligned_malloc(aligned_size, align);
-#else
-        *ptr = ::aligned_alloc(align, aligned_size);
-#endif
+        *ptr = umf_ba_global_aligned_alloc(aligned_size, align);
 
         return (*ptr) ? UMF_RESULT_SUCCESS
                       : UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
     umf_result_t free(void *ptr, size_t) noexcept {
-#ifdef _WIN32
-        _aligned_free(ptr);
-#else
-        ::free(ptr);
-#endif
+        umf_ba_global_free(ptr);
         return UMF_RESULT_SUCCESS;
     }
-    const char *get_name() noexcept { return "malloc"; }
+    const char *get_name() noexcept { return "umf_ba_global"; }
 };
 
 umf_memory_provider_ops_t MALLOC_PROVIDER_OPS =

--- a/test/common/provider.hpp
+++ b/test/common/provider.hpp
@@ -99,7 +99,7 @@ typedef struct provider_base_t {
 umf_memory_provider_ops_t BASE_PROVIDER_OPS =
     umf::providerMakeCOps<provider_base_t, void>();
 
-struct provider_malloc : public provider_base_t {
+struct provider_ba_global : public provider_base_t {
     umf_result_t alloc(size_t size, size_t align, void **ptr) noexcept {
         if (!align) {
             align = 8;
@@ -124,10 +124,10 @@ struct provider_malloc : public provider_base_t {
 };
 
 umf_memory_provider_ops_t MALLOC_PROVIDER_OPS =
-    umf::providerMakeCOps<provider_malloc, void>();
+    umf::providerMakeCOps<provider_ba_global, void>();
 
 struct provider_mock_out_of_mem : public provider_base_t {
-    provider_malloc helper_prov;
+    provider_ba_global helper_prov;
     int allocNum = 0;
     umf_result_t initialize(int *inAllocNum) noexcept {
         allocNum = *inAllocNum;

--- a/test/disjointCoarseMallocPool.cpp
+++ b/test/disjointCoarseMallocPool.cpp
@@ -19,7 +19,7 @@ using umf_test::test;
 #define GetStats umfCoarseMemoryProviderGetStats
 
 umf_memory_provider_ops_t UMF_MALLOC_MEMORY_PROVIDER_OPS =
-    umf::providerMakeCOps<umf_test::provider_malloc, void>();
+    umf::providerMakeCOps<umf_test::provider_ba_global, void>();
 
 struct CoarseWithMemoryStrategyTest
     : umf_test::test,

--- a/test/ipcAPI.cpp
+++ b/test/ipcAPI.cpp
@@ -24,7 +24,7 @@ struct provider_mock_ipc : public umf_test::provider_base_t {
         size_t size;
     };
 
-    umf_test::provider_malloc helper_prov;
+    umf_test::provider_ba_global helper_prov;
     static allocations_mutex_type alloc_mutex;
     static allocations_map_type allocations;
 

--- a/test/memoryPoolAPI.cpp
+++ b/test/memoryPoolAPI.cpp
@@ -156,7 +156,7 @@ TEST_F(test, BasicPoolByPtrTest) {
 
     umf_memory_provider_handle_t provider;
     umf_result_t ret =
-        umfMemoryProviderCreate(&MALLOC_PROVIDER_OPS, NULL, &provider);
+        umfMemoryProviderCreate(&BA_GLOBAL_PROVIDER_OPS, NULL, &provider);
     ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
     auto pool =
         wrapPoolUnique(createPoolChecked(umfProxyPoolOps(), provider, nullptr,
@@ -184,13 +184,13 @@ INSTANTIATE_TEST_SUITE_P(
                                           &UMF_NULL_PROVIDER_OPS, nullptr,
                                           nullptr},
                       poolCreateExtParams{umfProxyPoolOps(), nullptr,
-                                          &MALLOC_PROVIDER_OPS, nullptr,
+                                          &BA_GLOBAL_PROVIDER_OPS, nullptr,
                                           nullptr}));
 
 INSTANTIATE_TEST_SUITE_P(mallocMultiPoolTest, umfMultiPoolTest,
                          ::testing::Values(poolCreateExtParams{
-                             umfProxyPoolOps(), nullptr, &MALLOC_PROVIDER_OPS,
-                             nullptr, nullptr}));
+                             umfProxyPoolOps(), nullptr,
+                             &BA_GLOBAL_PROVIDER_OPS, nullptr, nullptr}));
 
 INSTANTIATE_TEST_SUITE_P(umfPoolWithCreateFlagsTest, umfPoolWithCreateFlagsTest,
                          ::testing::Values(0,

--- a/test/pools/disjoint_pool.cpp
+++ b/test/pools/disjoint_pool.cpp
@@ -148,7 +148,7 @@ auto defaultPoolConfig = poolConfig();
 INSTANTIATE_TEST_SUITE_P(disjointPoolTests, umfPoolTest,
                          ::testing::Values(poolCreateExtParams{
                              umfDisjointPoolOps(), (void *)&defaultPoolConfig,
-                             &MALLOC_PROVIDER_OPS, nullptr, nullptr}));
+                             &BA_GLOBAL_PROVIDER_OPS, nullptr, nullptr}));
 
 INSTANTIATE_TEST_SUITE_P(
     disjointPoolTests, umfMemTest,
@@ -161,4 +161,4 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(disjointMultiPoolTests, umfMultiPoolTest,
                          ::testing::Values(poolCreateExtParams{
                              umfDisjointPoolOps(), (void *)&defaultPoolConfig,
-                             &MALLOC_PROVIDER_OPS, nullptr, nullptr}));
+                             &BA_GLOBAL_PROVIDER_OPS, nullptr, nullptr}));

--- a/test/provider_coarse.cpp
+++ b/test/provider_coarse.cpp
@@ -22,7 +22,7 @@ using umf_test::test;
 #define COARSE_NAME BASE_NAME " (" UPSTREAM_NAME ")"
 
 umf_memory_provider_ops_t UMF_MALLOC_MEMORY_PROVIDER_OPS =
-    umf::providerMakeCOps<umf_test::provider_malloc, void>();
+    umf::providerMakeCOps<umf_test::provider_ba_global, void>();
 
 struct CoarseWithMemoryStrategyTest
     : umf_test::test,

--- a/test/provider_coarse.cpp
+++ b/test/provider_coarse.cpp
@@ -17,7 +17,7 @@ using umf_test::test;
 
 #define GetStats umfCoarseMemoryProviderGetStats
 
-#define UPSTREAM_NAME "malloc"
+#define UPSTREAM_NAME "umf_ba_global"
 #define BASE_NAME "coarse"
 #define COARSE_NAME BASE_NAME " (" UPSTREAM_NAME ")"
 

--- a/test/providers/ipc_cuda_prov_common.c
+++ b/test/providers/ipc_cuda_prov_common.c
@@ -16,7 +16,7 @@ void memcopy(void *dst, const void *src, size_t size, void *context) {
     cuda_memory_provider_params_t *cu_params =
         (cuda_memory_provider_params_t *)context;
     int ret = cuda_copy(cu_params->cuda_context_handle,
-                        cu_params->cuda_device_handle, dst, src, size);
+                        cu_params->cuda_device_handle, dst, (void *)src, size);
     if (ret != 0) {
         fprintf(stderr, "cuda_copy failed with error %d\n", ret);
     }

--- a/test/test_valgrind.sh
+++ b/test/test_valgrind.sh
@@ -84,6 +84,14 @@ for test in $(ls -1 umf_test-*); do
 	# skip tests incompatible with valgrind
 	FILTER=""
 	case $test in
+	umf_test-disjointPool)
+		if [ "$TOOL" = "helgrind" ]; then
+			# skip because of the assert in helgrind:
+			# Helgrind: hg_main.c:308 (lockN_acquire_reader): Assertion 'lk->kind == LK_rdwr' failed.
+			echo "- SKIPPED (helgrind only)"
+			continue;
+		fi
+		;;
 	umf_test-ipc_os_prov_*)
 		echo "- SKIPPED"
 		continue; # skip testing helper binaries used by the ipc_os_prov_* tests


### PR DESCRIPTION
### Description

Replace `MALLOC_PROVIDER_OPS` with `BA_GLOBAL_PROVIDER_OPS`:
1) Use `umf_ba_global_*()` API in `MALLOC_PROVIDER_OPS`,
2) Rename `provider_malloc` to `provider_ba_global`,
3) Rename `MALLOC_PROVIDER_OPS` to `BA_GLOBAL_PROVIDER_OPS`.

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
