### PR TITLE
Fix building the `provider_file_memory_ipc` test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -303,7 +303,7 @@ if(LINUX AND (NOT UMF_DISABLE_HWLOC)) # OS-specific functions are implemented
         LIBS ${UMF_UTILS_FOR_TEST})
     add_umf_test(
         NAME provider_file_memory_ipc
-        SRCS provider_file_memory_ipc.cpp
+        SRCS provider_file_memory_ipc.cpp ${BA_SOURCES_FOR_TEST}
         LIBS ${UMF_UTILS_FOR_TEST} ${LIB_JEMALLOC_POOL})
 
     # This test requires Linux-only file memory provider


### PR DESCRIPTION

### Description

Fix building the `provider_file_memory_ipc` test.

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
