### PR TITLE
Do not run tests under proxy lib if libumf is not a shared lib

### DIFF
--- a/.github/workflows/reusable_dax.yml
+++ b/.github/workflows/reusable_dax.yml
@@ -109,6 +109,8 @@ jobs:
       # TODO: enable the provider_devdax_memory_ipc test when the IPC tests with the proxy library are fixed
       # see the issue: https://github.com/oneapi-src/unified-memory-framework/issues/864
       - name: Run the DEVDAX tests with the proxy library
+        # proxy library is built only if libumf is a shared library
+        if: ${{ matrix.shared_library == 'ON' }}
         working-directory: ${{env.BUILD_DIR}}
         run: >
           LD_PRELOAD=./lib/libumf_proxy.so
@@ -119,6 +121,8 @@ jobs:
       # TODO: enable the provider_file_memory_ipc test when the IPC tests with the proxy library are fixed
       # see the issue: https://github.com/oneapi-src/unified-memory-framework/issues/864
       - name: Run the FSDAX tests with the proxy library
+        # proxy library is built only if libumf is a shared library
+        if: ${{ matrix.shared_library == 'ON' }}
         working-directory: ${{env.BUILD_DIR}}
         run: >
           LD_PRELOAD=./lib/libumf_proxy.so


### PR DESCRIPTION
### Description

Do not run tests under the proxy library if libumf is not a shared library,
because the proxy library is built only if libumf is a shared library.

ref. #761

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
