### PR TITLE
Fix location of printing out error message in utils_mmap_file()

### DIFF
--- a/src/utils/utils_linux_common.c
+++ b/src/utils/utils_linux_common.c
@@ -86,10 +86,6 @@ void *utils_mmap_file(void *hint_addr, size_t length, int prot, int flags,
         return addr;
     }
 
-    LOG_PERR("mapping file with the MAP_SYNC flag failed (fd=%i, offset=%zu, "
-             "length=%zu, flags=%i)",
-             fd, fd_offset, length, sync_flags);
-
     /* try to mmap with MAP_SHARED flag (without MAP_SYNC) */
     if (errno == EINVAL || errno == ENOTSUP || errno == EOPNOTSUPP) {
         const int shared_flags = flags | MAP_SHARED;
@@ -104,6 +100,11 @@ void *utils_mmap_file(void *hint_addr, size_t length, int prot, int flags,
         LOG_PERR("mapping file with the MAP_SHARED flag failed (fd=%i, "
                  "offset=%zu, length=%zu, flags=%i)",
                  fd, fd_offset, length, shared_flags);
+    } else {
+        LOG_PERR(
+            "mapping file with the MAP_SYNC flag failed (fd=%i, offset=%zu, "
+            "length=%zu, flags=%i)",
+            fd, fd_offset, length, sync_flags);
     }
 
     return NULL;


### PR DESCRIPTION
### Description

Fix location of printing out error message in `utils_mmap_file()`.
It was printed out in a wrong place.

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
