### PR TITLE
Fix umf_ba_free() - do not assert on unknown pointer

### DIFF
--- a/src/base_alloc/base_alloc.c
+++ b/src/base_alloc/base_alloc.c
@@ -278,7 +278,11 @@ void umf_ba_free(umf_ba_pool_t *pool, void *ptr) {
     umf_ba_chunk_t *chunk = (umf_ba_chunk_t *)ptr;
 
     utils_mutex_lock(&pool->metadata.free_lock);
-    assert(pool_contains_pointer(pool, ptr));
+    if (!pool_contains_pointer(pool, ptr)) {
+        utils_mutex_unlock(&pool->metadata.free_lock);
+        return;
+    }
+
     chunk->next = pool->metadata.free_list;
     pool->metadata.free_list = chunk;
     pool->metadata.n_allocs--;


### PR DESCRIPTION
### Description

Fix `umf_ba_free()` - do not assert on unknown pointer.

Ref: #903

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
