### PR TITLE
Temporarily disable failing windows-2022 clang CI job

### DIFF
--- a/.github/workflows/reusable_basic.yml
+++ b/.github/workflows/reusable_basic.yml
@@ -227,13 +227,14 @@ jobs:
         level_zero_provider: ['ON']
         cuda_provider: ['ON']
         include:
-          - os: 'windows-2022'
-            build_type: Release
-            compiler: {c: clang-cl, cxx: clang-cl}
-            shared_library: 'ON'
-            level_zero_provider: 'ON'
-            cuda_provider: 'ON'
-            toolset: "-T ClangCL"
+          # temporarily disable failing CI job
+          #- os: 'windows-2022'
+          #  build_type: Release
+          #  compiler: {c: clang-cl, cxx: clang-cl}
+          #  shared_library: 'ON'
+          #  level_zero_provider: 'ON'
+          #  cuda_provider: 'ON'
+          #  toolset: "-T ClangCL"
           - os: 'windows-2022'
             build_type: Release
             compiler: {c: cl, cxx: cl}


### PR DESCRIPTION
### Description

Temporarily disable failing windows-2022 clang CI job, because of the error:
```
Error: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\Llvm\x64\lib\clang\18\include\__stddef_ptrdiff_t.h(15): fatal error RC1012: mismatched parenthesis : missing ' [D:\a\unified-memory-framework\unified-memory-framework\build\src\umf.vcxproj]
```

See: 
https://github.com/oneapi-src/unified-memory-framework/actions/runs/11892350813/job/33136923719
https://github.com/oneapi-src/unified-memory-framework/actions/runs/11893427436/job/33141053575

Ref: https://github.com/oneapi-src/unified-memory-framework/issues/910

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
