### PR TITLE
Fix: `getGlobalLruListSize()` is needed only in debug mode

### DIFF
--- a/src/ipc_cache.c
+++ b/src/ipc_cache.c
@@ -89,12 +89,14 @@ err_exit:
     return ret;
 }
 
+#ifndef NDEBUG
 static size_t getGlobalLruListSize(lru_list_t lru_list) {
     size_t size = 0;
     ipc_handle_cache_entry_t *tmp;
     DL_COUNT(lru_list, tmp, size);
     return size;
 }
+#endif /* NDEBUG */
 
 void umfIpcCacheGlobalTearDown(void) {
     ipc_mapped_handle_cache_global_t *cache_global = IPC_MAPPED_CACHE_GLOBAL;


### PR DESCRIPTION

### Description

Fix: `getGlobalLruListSize()` is needed only in debug mode.

Fix the warning:
```
warning : unused function 'getGlobalLruListSize' [-Wunused-function]
```

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
