### PR TITLE
Print dlerror in utils_open_library() and utils_get_symbol_addr()

### DIFF
--- a/src/utils/utils_load_library.c
+++ b/src/utils/utils_load_library.c
@@ -66,7 +66,13 @@ void *utils_open_library(const char *filename, int userFlags) {
     if (userFlags & UMF_UTIL_OPEN_LIBRARY_GLOBAL) {
         dlopenFlags |= RTLD_GLOBAL;
     }
-    return dlopen(filename, dlopenFlags);
+
+    void *handle = dlopen(filename, dlopenFlags);
+    if (handle == NULL) {
+        LOG_FATAL("dlopen(%s) failed with error: %s", filename, dlerror());
+    }
+
+    return handle;
 }
 
 int utils_close_library(void *handle) { return dlclose(handle); }
@@ -80,7 +86,7 @@ void *utils_get_symbol_addr(void *handle, const char *symbol,
 
     void *addr = dlsym(handle, symbol);
     if (addr == NULL) {
-        LOG_ERR("Required symbol not found: %s", symbol);
+        LOG_ERR("required symbol not found: %s (error: %s)", symbol, dlerror());
     }
 
     return addr;


### PR DESCRIPTION
### Description

Print `dlerror()` in `utils_open_library()` and `utils_get_symbol_addr()`.

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
