### PR TITLE
[DRAFT] Load jemalloc library dynamically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,9 +396,9 @@ if(NOT TBB_FOUND)
     find_package(TBB OPTIONAL_COMPONENTS tbb)
 endif()
 if(TBB_FOUND OR TBB_LIBRARY_DIRS)
+    set(UMF_POOL_SCALABLE_ENABLED TRUE)
     # add PATH to DLL on Windows
     set(DLL_PATH_LIST "${DLL_PATH_LIST};PATH=path_list_append:${TBB_DLL_DIRS}")
-    set(UMF_POOL_SCALABLE_ENABLED TRUE)
 else()
     message(
         STATUS
@@ -417,6 +417,10 @@ if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
         # add PATH to DLL on Windows
         set(DLL_PATH_LIST
             "${DLL_PATH_LIST};PATH=path_list_append:${JEMALLOC_DLL_DIRS}")
+        # add LD_LIBRARY_PATH to libs on Linux
+        set(LIST_LD_LIBRARY
+            "${LIST_LD_LIBRARY};LD_LIBRARY_PATH=path_list_append:${JEMALLOC_LIBRARY_DIRS}"
+        )
     endif()
 endif()
 

--- a/src/pool/CMakeLists.txt
+++ b/src/pool/CMakeLists.txt
@@ -45,7 +45,7 @@ if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
         NAME jemalloc_pool
         TYPE STATIC
         SRCS pool_jemalloc.c ${POOL_EXTRA_SRCS}
-        LIBS jemalloc ${POOL_EXTRA_LIBS})
+        LIBS ${POOL_EXTRA_LIBS})
     target_include_directories(jemalloc_pool PRIVATE ${JEMALLOC_INCLUDE_DIRS})
     target_compile_definitions(jemalloc_pool
                                PRIVATE ${POOL_COMPILE_DEFINITIONS})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,7 +38,9 @@ function(build_umf_test)
     set(TEST_NAME umf-${ARG_NAME})
     set(TEST_TARGET_NAME umf_test-${ARG_NAME})
 
-    set(LIB_DIRS ${LIB_DIRS} ${LIBHWLOC_LIBRARY_DIRS})
+    if(NOT UMF_DISABLE_HWLOC)
+        set(LIB_DIRS ${LIB_DIRS} ${LIBHWLOC_LIBRARY_DIRS})
+    endif()
 
     if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
         set(LIB_DIRS ${LIB_DIRS} ${JEMALLOC_LIBRARY_DIRS})
@@ -126,6 +128,10 @@ function(add_umf_test)
         # append PATH to DLLs
         set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT_MODIFICATION
                                                 "${DLL_PATH_LIST}")
+    else()
+        # append LD_LIBRARY_PATH to libs
+        set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT_MODIFICATION
+                                                "${LIST_LD_LIBRARY}")
     endif()
 endfunction()
 


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

Load jemalloc library dynamically.
Do not link with the jemalloc library explicitly,
but load it dynamically (using `dlopen()`).

Ref: https://github.com/oneapi-src/unified-memory-framework/issues/891
Ref: #894

Blocked by the issue: https://github.com/jemalloc/jemalloc/issues/1237 (rebuilding jemalloc from sources is required)

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
