### PR TITLE
Disable libudev in hwloc builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,7 +176,8 @@ else()
                 ./configure --prefix=${hwloc_targ_BINARY_DIR}
                 --enable-static=yes --enable-shared=no --disable-libxml2
                 --disable-pci --disable-levelzero --disable-opencl
-                --disable-cuda --disable-nvml CFLAGS=-fPIC CXXFLAGS=-fPIC
+                --disable-cuda --disable-nvml --disable-libudev CFLAGS=-fPIC
+                CXXFLAGS=-fPIC
             WORKING_DIRECTORY ${hwloc_targ_SOURCE_DIR}
             OUTPUT ${hwloc_targ_SOURCE_DIR}/Makefile
             DEPENDS ${hwloc_targ_SOURCE_DIR}/configure)


### PR DESCRIPTION
UMF does not link with libudev. Disable libudev support in hwloc builds.

Fixes the error on linking with a hwloc static library on systems with libudev installed:
`ld.lld: error: undefined symbol: udev_device_new_from_subsystem_sysname`

