### PR TITLE
Update Ubuntu versions in CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -190,4 +190,4 @@ jobs:
     uses: ./.github/workflows/reusable_qemu.yml
     with:
       short_run: false
-      os: "['ubuntu-23.04', 'ubuntu-24.04']"
+      os: "['ubuntu-22.04', 'ubuntu-24.04']"

--- a/.github/workflows/reusable_qemu.yml
+++ b/.github/workflows/reusable_qemu.yml
@@ -11,7 +11,7 @@ on:
       os:
         description: List of OSes
         type: string
-        default: '["ubuntu-23.04"]'
+        default: '["ubuntu-24.04"]'
 
 permissions:
   contents: read


### PR DESCRIPTION

### Description

End of Life of Ubuntu 24.04 LTS (Noble Numbat) is April 2036.
End of Life of Ubuntu 22.04 LTS (Jammy Jellyfish) is April 2034.

End of Life of Ubuntu 23.04 (Lunar Lobster) was January 25, 2024.

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
