### PR TITLE
Fix failure with destructor order in CUDA params

### DIFF
--- a/src/pool/pool_scalable.c
+++ b/src/pool/pool_scalable.c
@@ -19,6 +19,7 @@
 #include <umf/pools/pool_scalable.h>
 
 #include "base_alloc_global.h"
+#include "libumf.h"
 #include "utils_common.h"
 #include "utils_concurrency.h"
 #include "utils_load_library.h"
@@ -175,6 +176,7 @@ static void tbb_raw_free_wrapper(intptr_t pool_id, void *ptr, size_t bytes) {
 
 umf_result_t
 umfScalablePoolParamsCreate(umf_scalable_pool_params_handle_t *hParams) {
+    libumfInit();
     if (!hParams) {
         LOG_ERR("scalable pool params handle is NULL");
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;

--- a/src/provider/provider_cuda.c
+++ b/src/provider/provider_cuda.c
@@ -68,6 +68,7 @@ umf_memory_provider_ops_t *umfCUDAMemoryProviderOps(void) {
 #endif // _MSC_VER
 
 #include "base_alloc_global.h"
+#include "libumf.h"
 #include "utils_assert.h"
 #include "utils_common.h"
 #include "utils_concurrency.h"
@@ -201,6 +202,7 @@ static void init_cu_global_state(void) {
 
 umf_result_t umfCUDAMemoryProviderParamsCreate(
     umf_cuda_memory_provider_params_handle_t *hParams) {
+    libumfInit();
     if (!hParams) {
         LOG_ERR("CUDA Memory Provider params handle is NULL");
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

This should fix the following failure: https://github.com/oneapi-src/unified-memory-framework/actions/runs/12041220655/job/33590212027

### Checklist

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly

