### PR TITLE
Link statically with custom jemalloc with disabled initial TLS

### DIFF
--- a/.github/docker/ubuntu-20.04.Dockerfile
+++ b/.github/docker/ubuntu-20.04.Dockerfile
@@ -24,7 +24,6 @@ ARG BASE_DEPS="\
 
 # UMF's dependencies
 ARG UMF_DEPS="\
-	libjemalloc-dev \
 	libhwloc-dev \
 	libtbb-dev"
 
@@ -34,6 +33,7 @@ ARG TEST_DEPS="\
 
 # Miscellaneous for our builds/CI (optional)
 ARG MISC_DEPS="\
+	automake \
 	clang \
 	g++-7 \
 	python3-pip \

--- a/.github/docker/ubuntu-22.04.Dockerfile
+++ b/.github/docker/ubuntu-22.04.Dockerfile
@@ -24,7 +24,6 @@ ARG BASE_DEPS="\
 
 # UMF's dependencies
 ARG UMF_DEPS="\
-	libjemalloc-dev \
 	libhwloc-dev \
 	libtbb-dev"
 
@@ -34,6 +33,7 @@ ARG TEST_DEPS="\
 
 # Miscellaneous for our builds/CI (optional)
 ARG MISC_DEPS="\
+	automake \
 	clang \
 	python3-pip \
 	sudo \

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install apt packages
       run: |
         sudo apt-get update
-        sudo apt-get install -y cmake hwloc libhwloc-dev libjemalloc-dev libnuma-dev libtbb-dev
+        sudo apt-get install -y cmake hwloc libhwloc-dev libnuma-dev libtbb-dev
 
     - name: Download Coverity
       run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Install apt packages
       run: |
         sudo apt-get update
-        sudo apt-get install -y cmake hwloc libhwloc-dev libjemalloc-dev libnuma-dev libtbb-dev valgrind
+        sudo apt-get install -y cmake hwloc libhwloc-dev libnuma-dev libtbb-dev valgrind
 
     - name: Configure CMake
       run: >

--- a/.github/workflows/reusable_basic.yml
+++ b/.github/workflows/reusable_basic.yml
@@ -209,7 +209,6 @@ jobs:
         --install-dir ${{env.INSTL_DIR}}
         --build-type ${{matrix.build_type}}
         --disjoint-pool
-        --jemalloc-pool
         ${{ matrix.install_tbb == 'ON' && matrix.disable_hwloc != 'ON' && matrix.shared_library == 'ON' && '--proxy' || '' }}
         --umf-version ${{env.UMF_VERSION}}
         ${{ matrix.shared_library == 'ON' && '--shared-library' || '' }}
@@ -300,7 +299,6 @@ jobs:
         --install-dir ${{env.INSTL_DIR}}
         --build-type ${{matrix.build_type}}
         --disjoint-pool
-        --jemalloc-pool
         ${{matrix.shared_library == 'ON' && '--proxy' || '' }}
         --umf-version ${{env.UMF_VERSION}}
         ${{ matrix.shared_library == 'ON' && '--shared-library' || ''}}
@@ -495,7 +493,6 @@ jobs:
         --install-dir ${{env.INSTL_DIR}}
         --build-type ${{env.BUILD_TYPE}}
         --disjoint-pool
-        --jemalloc-pool
         --proxy
         --umf-version ${{env.UMF_VERSION}}
         --shared-library

--- a/.github/workflows/reusable_basic.yml
+++ b/.github/workflows/reusable_basic.yml
@@ -124,7 +124,7 @@ jobs:
     - name: Install apt packages
       run: |
         sudo apt-get update
-        sudo apt-get install -y clang cmake libnuma-dev libjemalloc-dev lcov
+        sudo apt-get install -y clang cmake libnuma-dev lcov
 
     - name: Install TBB apt package
       if: matrix.install_tbb == 'ON'
@@ -469,7 +469,7 @@ jobs:
         python3 -m pip install -r third_party/requirements.txt
 
     - name: Install hwloc
-      run: brew install hwloc jemalloc tbb
+      run: brew install hwloc tbb automake
 
     - name: Configure build
       run: >

--- a/.github/workflows/reusable_benchmarks.yml
+++ b/.github/workflows/reusable_benchmarks.yml
@@ -34,7 +34,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake libhwloc-dev libnuma-dev libjemalloc-dev libtbb-dev
+          sudo apt-get install -y cmake libhwloc-dev libnuma-dev libtbb-dev
 
       - name: Initialize vcpkg
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/reusable_codeql.yml
+++ b/.github/workflows/reusable_codeql.yml
@@ -62,7 +62,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update
-        sudo apt-get install -y cmake clang libhwloc-dev libnuma-dev libjemalloc-dev libtbb-dev
+        sudo apt-get install -y cmake clang libhwloc-dev libnuma-dev libtbb-dev
 
     # Latest distros do not allow global pip installation
     - name: "[Lin] Install Python requirements in venv"

--- a/.github/workflows/reusable_fast.yml
+++ b/.github/workflows/reusable_fast.yml
@@ -79,13 +79,13 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update
-        sudo apt-get install -y cmake libjemalloc-dev libhwloc-dev libnuma-dev libtbb-dev
+        sudo apt-get install -y cmake libhwloc-dev libnuma-dev libtbb-dev
 
     - name: Install dependencies (ubuntu-20.04)
       if: matrix.os == 'ubuntu-20.04'
       run: |
         sudo apt-get update
-        sudo apt-get install -y cmake libjemalloc-dev libnuma-dev libtbb-dev
+        sudo apt-get install -y cmake libnuma-dev libtbb-dev
         .github/scripts/install_hwloc.sh # install hwloc-2.3.0 instead of hwloc-2.1.0 present in the OS package
 
     - name: Set ptrace value for IPC test (on Linux only)

--- a/.github/workflows/reusable_multi_numa.yml
+++ b/.github/workflows/reusable_multi_numa.yml
@@ -45,7 +45,7 @@ jobs:
           -DUMF_BUILD_TESTS=ON
           -DUMF_DEVELOPER_MODE=ON
           -DUMF_BUILD_LIBUMF_POOL_DISJOINT=ON
-          -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
+          -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=${{ matrix.os == 'rhel-9.1' && 'OFF' || 'ON' }}
           -DUMF_TESTS_FAIL_ON_SKIP=ON
           ${{ matrix.build_type == 'Debug' && matrix.os == 'ubuntu-22.04' && '-DUMF_USE_COVERAGE=ON' || '' }}
 

--- a/.github/workflows/reusable_proxy_lib.yml
+++ b/.github/workflows/reusable_proxy_lib.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install apt packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake libhwloc-dev libjemalloc-dev libtbb-dev lcov
+          sudo apt-get install -y cmake libhwloc-dev libtbb-dev lcov
 
       - name: Set ptrace value for IPC test
         run: sudo bash -c "echo 0 > /proc/sys/kernel/yama/ptrace_scope"

--- a/.github/workflows/reusable_sanitizers.yml
+++ b/.github/workflows/reusable_sanitizers.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install apt packages
       run: |
         sudo apt-get update
-        sudo apt-get install -y clang cmake libhwloc-dev libnuma-dev libjemalloc-dev libtbb-dev
+        sudo apt-get install -y clang cmake libhwloc-dev libnuma-dev libtbb-dev
 
     - name: Install oneAPI basekit
       if: matrix.compiler.cxx == 'icpx'

--- a/.github/workflows/reusable_valgrind.yml
+++ b/.github/workflows/reusable_valgrind.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install apt packages
       run: |
         sudo apt-get update
-        sudo apt-get install -y cmake hwloc libhwloc-dev libjemalloc-dev libnuma-dev libtbb-dev valgrind
+        sudo apt-get install -y cmake hwloc libhwloc-dev libnuma-dev libtbb-dev valgrind
 
     - name: Configure CMake
       run: >

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,87 @@ else()
     message(FATAL_ERROR "Unknown OS type")
 endif()
 
+if(NOT UMF_BUILD_LIBUMF_POOL_JEMALLOC)
+    set(UMF_POOL_JEMALLOC_ENABLED FALSE)
+elseif(WINDOWS)
+    pkg_check_modules(JEMALLOC jemalloc)
+    if(NOT JEMALLOC_FOUND)
+        find_package(JEMALLOC REQUIRED jemalloc)
+    endif()
+else()
+    if(NOT DEFINED UMF_JEMALLOC_REPO)
+        set(UMF_JEMALLOC_REPO "https://github.com/jemalloc/jemalloc.git")
+    endif()
+
+    if(NOT DEFINED UMF_JEMALLOC_TAG)
+        set(UMF_JEMALLOC_TAG 5.3.0)
+    endif()
+
+    include(FetchContent)
+    message(
+        STATUS
+            "Will fetch jemalloc from ${UMF_JEMALLOC_REPO} (tag: ${UMF_JEMALLOC_TAG})"
+    )
+
+    FetchContent_Declare(
+        jemalloc_targ
+        GIT_REPOSITORY ${UMF_JEMALLOC_REPO}
+        GIT_TAG ${UMF_JEMALLOC_TAG})
+    FetchContent_MakeAvailable(jemalloc_targ)
+
+    add_custom_command(
+        COMMAND ./autogen.sh
+        WORKING_DIRECTORY ${jemalloc_targ_SOURCE_DIR}
+        OUTPUT ${jemalloc_targ_SOURCE_DIR}/configure)
+    add_custom_command(
+        # Custom jemalloc build. Non-default options used:
+        # --with-jemalloc-prefix=je_ - add je_ prefix to all public APIs
+        # --disable-cxx - Disable C++ integration. This will cause new and
+        # delete operators implementations to be omitted.
+        # --disable-initial-exec-tls - Disable the initial-exec TLS model for
+        # jemalloc's internal thread-local storage (on those platforms that
+        # support explicit settings). This can allow jemalloc to be dynamically
+        # loaded after program startup (e.g. using dlopen).
+        COMMAND
+            ./configure --prefix=${jemalloc_targ_BINARY_DIR}
+            --with-jemalloc-prefix=je_ --disable-cxx --disable-initial-exec-tls
+            CFLAGS=-fPIC
+        WORKING_DIRECTORY ${jemalloc_targ_SOURCE_DIR}
+        OUTPUT ${jemalloc_targ_SOURCE_DIR}/Makefile
+        DEPENDS ${jemalloc_targ_SOURCE_DIR}/configure)
+    add_custom_command(
+        COMMAND make
+        WORKING_DIRECTORY ${jemalloc_targ_SOURCE_DIR}
+        OUTPUT ${jemalloc_targ_SOURCE_DIR}/lib/libjemalloc.la
+        DEPENDS ${jemalloc_targ_SOURCE_DIR}/Makefile)
+    add_custom_command(
+        COMMAND make install
+        WORKING_DIRECTORY ${jemalloc_targ_SOURCE_DIR}
+        OUTPUT ${jemalloc_targ_BINARY_DIR}/lib/libjemalloc.a
+        DEPENDS ${jemalloc_targ_SOURCE_DIR}/lib/libjemalloc.la)
+
+    add_custom_target(jemalloc_prod
+                      DEPENDS ${jemalloc_targ_BINARY_DIR}/lib/libjemalloc.a)
+    add_library(jemalloc INTERFACE)
+    target_link_libraries(
+        jemalloc INTERFACE ${jemalloc_targ_BINARY_DIR}/lib/libjemalloc.a)
+    add_dependencies(jemalloc jemalloc_prod)
+
+    set(JEMALLOC_LIBRARY_DIRS ${jemalloc_targ_BINARY_DIR}/lib)
+    set(JEMALLOC_INCLUDE_DIRS ${jemalloc_targ_BINARY_DIR}/include)
+    set(JEMALLOC_LIBRARIES ${jemalloc_targ_BINARY_DIR}/lib/libjemalloc.a)
+endif()
+
+if(JEMALLOC_FOUND OR JEMALLOC_LIBRARIES)
+    set(UMF_POOL_JEMALLOC_ENABLED TRUE)
+    # add PATH to DLL on Windows
+    set(DLL_PATH_LIST
+        "${DLL_PATH_LIST};PATH=path_list_append:${JEMALLOC_DLL_DIRS}")
+    message(STATUS "    JEMALLOC_LIBRARIES = ${JEMALLOC_LIBRARIES}")
+    message(STATUS "    JEMALLOC_INCLUDE_DIRS = ${JEMALLOC_INCLUDE_DIRS}")
+    message(STATUS "    JEMALLOC_LIBRARY_DIRS = ${JEMALLOC_LIBRARY_DIRS}")
+endif()
+
 if(UMF_DISABLE_HWLOC)
     message(STATUS "hwloc is disabled, hence OS provider, memtargets, "
                    "topology discovery, examples won't be available!")
@@ -400,19 +481,6 @@ else()
             "Disabling tests and benchmarks that use the Scalable Pool because the TBB they require was not found."
     )
     set(UMF_POOL_SCALABLE_ENABLED FALSE)
-endif()
-
-if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
-    pkg_check_modules(JEMALLOC jemalloc)
-    if(NOT JEMALLOC_FOUND)
-        find_package(JEMALLOC REQUIRED jemalloc)
-    endif()
-    if(JEMALLOC_FOUND OR JEMALLOC_LIBRARIES)
-        set(UMF_POOL_JEMALLOC_ENABLED TRUE)
-        # add PATH to DLL on Windows
-        set(DLL_PATH_LIST
-            "${DLL_PATH_LIST};PATH=path_list_append:${JEMALLOC_DLL_DIRS}")
-    endif()
 endif()
 
 if(WINDOWS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,8 @@ endif()
 
 if(NOT UMF_BUILD_LIBUMF_POOL_JEMALLOC)
     set(UMF_POOL_JEMALLOC_ENABLED FALSE)
+    set(JEMALLOC_FOUND FALSE)
+    set(JEMALLOC_LIBRARIES FALSE)
 elseif(WINDOWS)
     pkg_check_modules(JEMALLOC jemalloc)
     if(NOT JEMALLOC_FOUND)
@@ -190,6 +192,12 @@ if(JEMALLOC_FOUND OR JEMALLOC_LIBRARIES)
     message(STATUS "    JEMALLOC_LIBRARIES = ${JEMALLOC_LIBRARIES}")
     message(STATUS "    JEMALLOC_INCLUDE_DIRS = ${JEMALLOC_INCLUDE_DIRS}")
     message(STATUS "    JEMALLOC_LIBRARY_DIRS = ${JEMALLOC_LIBRARY_DIRS}")
+else()
+    set(UMF_POOL_JEMALLOC_ENABLED FALSE)
+    message(
+        STATUS
+            "Disabling the Jemalloc Pool and tests and benchmarks that use it because jemalloc was not built/found."
+    )
 endif()
 
 if(UMF_DISABLE_HWLOC)
@@ -523,14 +531,14 @@ elseif(UMF_PROXY_LIB_BASED_ON_POOL STREQUAL SCALABLE)
         )
     endif()
 elseif(UMF_PROXY_LIB_BASED_ON_POOL STREQUAL JEMALLOC)
-    if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
+    if(UMF_POOL_JEMALLOC_ENABLED)
         set(UMF_PROXY_LIB_ENABLED ON)
         set(PROXY_LIB_USES_JEMALLOC_POOL ON)
-        set(PROXY_LIBS jemalloc_pool umf)
+        set(PROXY_LIBS umf)
     else()
         message(
             STATUS
-                "Disabling the proxy library, because UMF_PROXY_LIB_BASED_ON_POOL==JEMALLOC but UMF_BUILD_LIBUMF_POOL_JEMALLOC is OFF"
+                "Disabling the proxy library, because UMF_PROXY_LIB_BASED_ON_POOL==JEMALLOC but the jemalloc pool is disabled"
         )
     endif()
 else()

--- a/README.md
+++ b/README.md
@@ -298,8 +298,9 @@ The default jemalloc package is required on Windows.
 ##### Requirements
 
 1) The `UMF_BUILD_LIBUMF_POOL_JEMALLOC` option turned `ON`
-2) Required packages:
-   - jemalloc (Windows only)
+2) jemalloc is required:
+- on Linux and MacOS: jemalloc is fetched and built from sources (a custom build),
+- on Windows: the default jemalloc package is required
 
 #### Scalable Pool (part of libumf)
 

--- a/README.md
+++ b/README.md
@@ -281,11 +281,25 @@ pool manager built as a separate static library: libjemalloc_pool.a on Linux and
 jemalloc_pool.lib on Windows.
 The `UMF_BUILD_LIBUMF_POOL_JEMALLOC` option has to be turned `ON` to build this library.
 
+[jemalloc](https://github.com/jemalloc/jemalloc) is required to build the jemalloc pool.
+
+In case of Linux OS jemalloc is built from the (fetched) sources with the following
+non-default options enabled:
+- `--with-jemalloc-prefix=je_` - adds the `je_` prefix to all public APIs,
+- `--disable-cxx` - disables C++ integration, it will cause the `new` and the `delete`
+                    operators implementations to be omitted.
+- `--disable-initial-exec-tls` - disables the initial-exec TLS model for jemalloc's
+                    internal thread-local storage (on those platforms that support
+                    explicit settings), it can allow jemalloc to be dynamically
+                    loaded after program startup (e.g. using `dlopen()`).
+
+The default jemalloc package is required on Windows.
+
 ##### Requirements
 
 1) The `UMF_BUILD_LIBUMF_POOL_JEMALLOC` option turned `ON`
 2) Required packages:
-   - libjemalloc-dev (Linux) or jemalloc (Windows)
+   - jemalloc (Windows only)
 
 #### Scalable Pool (part of libumf)
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -51,7 +51,7 @@ function(add_umf_benchmark)
 
     set(BENCH_NAME umf-${ARG_NAME})
 
-    set(BENCH_LIBS ${ARG_LIBS} umf)
+    set(BENCH_LIBS ${ARG_LIBS} umf umf_utils)
 
     add_umf_executable(
         NAME ${BENCH_NAME}
@@ -121,8 +121,7 @@ set(LIB_DIRS ${LIBHWLOC_LIBRARY_DIRS})
 if(UMF_BUILD_LIBUMF_POOL_DISJOINT)
     set(LIBS_OPTIONAL ${LIBS_OPTIONAL} disjoint_pool)
 endif()
-if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
-    set(LIBS_OPTIONAL ${LIBS_OPTIONAL} jemalloc_pool ${JEMALLOC_LIBRARIES})
+if(UMF_POOL_JEMALLOC_ENABLED)
     set(LIB_DIRS ${LIB_DIRS} ${JEMALLOC_LIBRARY_DIRS})
 endif()
 if(LINUX)

--- a/benchmark/multithread.cpp
+++ b/benchmark/multithread.cpp
@@ -139,11 +139,13 @@ int main() {
     // ctest looks for "PASSED" in the output
     std::cout << "PASSED" << std::endl;
 
+#if defined(UMF_POOL_DISJOINT_ENABLED)
     ret = umfDisjointPoolParamsDestroy(hDisjointParams);
     if (ret != UMF_RESULT_SUCCESS) {
         std::cerr << "disjoint pool params destroy failed" << std::endl;
         return -1;
     }
+#endif
 
     return 0;
 }

--- a/benchmark/ubench.c
+++ b/benchmark/ubench.c
@@ -445,8 +445,8 @@ static void do_ipc_get_put_benchmark(alloc_t *allocs, size_t num_allocs,
     }
 }
 
-int create_level_zero_params(ze_context_handle_t *context,
-                             ze_device_handle_t *device) {
+static int create_level_zero_params(ze_context_handle_t *context,
+                                    ze_device_handle_t *device) {
     uint32_t driver_idx = 0;
     ze_driver_handle_t driver = NULL;
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -284,8 +284,11 @@ if(LINUX)
             SRCS dram_and_fsdax/dram_and_fsdax.c
             LIBS umf jemalloc_pool)
 
-        target_link_directories(${EXAMPLE_NAME} PRIVATE
-                                ${LIBHWLOC_LIBRARY_DIRS})
+        target_link_options(${EXAMPLE_NAME} PRIVATE "-Wl,--no-as-needed,-ldl")
+
+        target_link_directories(
+            ${EXAMPLE_NAME} PRIVATE ${LIBHWLOC_LIBRARY_DIRS}
+            ${JEMALLOC_LIBRARY_DIRS})
 
         add_test(
             NAME ${EXAMPLE_NAME}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -282,7 +282,7 @@ if(LINUX)
         add_umf_executable(
             NAME ${EXAMPLE_NAME}
             SRCS dram_and_fsdax/dram_and_fsdax.c
-            LIBS umf jemalloc_pool)
+            LIBS umf)
 
         target_link_options(${EXAMPLE_NAME} PRIVATE "-Wl,--no-as-needed,-ldl")
 

--- a/examples/cmake/FindJEMALLOC.cmake
+++ b/examples/cmake/FindJEMALLOC.cmake
@@ -2,9 +2,11 @@
 # Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-message(STATUS "Checking for module 'jemalloc' using find_library()")
+message(
+    STATUS "Looking for the static 'libjemalloc.a' library using find_library()"
+)
 
-find_library(JEMALLOC_LIBRARY NAMES libjemalloc jemalloc)
+find_library(JEMALLOC_LIBRARY NAMES libjemalloc.a jemalloc.a)
 set(JEMALLOC_LIBRARIES ${JEMALLOC_LIBRARY})
 
 get_filename_component(JEMALLOC_LIB_DIR ${JEMALLOC_LIBRARIES} DIRECTORY)

--- a/examples/dram_and_fsdax/CMakeLists.txt
+++ b/examples/dram_and_fsdax/CMakeLists.txt
@@ -21,24 +21,15 @@ if(NOT LIBHWLOC_FOUND)
     find_package(LIBHWLOC 2.3.0 REQUIRED hwloc)
 endif()
 
-# find the custom jemalloc pointed by CMAKE_PREFIX_PATH
-find_package(JEMALLOC REQUIRED jemalloc)
-
 # build the example
 set(EXAMPLE_NAME umf_example_dram_and_fsdax)
 add_executable(${EXAMPLE_NAME} dram_and_fsdax.c)
 target_include_directories(${EXAMPLE_NAME} PRIVATE ${LIBUMF_INCLUDE_DIRS})
 
-target_link_directories(
-    ${EXAMPLE_NAME}
-    PRIVATE
-    ${LIBUMF_LIBRARY_DIRS}
-    ${LIBHWLOC_LIBRARY_DIRS}
-    ${JEMALLOC_LIBRARY_DIRS})
+target_link_directories(${EXAMPLE_NAME} PRIVATE ${LIBUMF_LIBRARY_DIRS}
+                        ${LIBHWLOC_LIBRARY_DIRS})
 
-target_link_libraries(
-    ${EXAMPLE_NAME} PRIVATE hwloc jemalloc_pool ${JEMALLOC_LIBRARIES}
-                            ${LIBUMF_LIBRARIES})
+target_link_libraries(${EXAMPLE_NAME} PRIVATE hwloc ${LIBUMF_LIBRARIES})
 
 # an optional part - adds a test of this example
 add_test(
@@ -54,6 +45,6 @@ if(LINUX)
         TEST ${EXAMPLE_NAME}
         PROPERTY
             ENVIRONMENT_MODIFICATION
-            "LD_LIBRARY_PATH=path_list_append:${LIBUMF_LIBRARY_DIRS};LD_LIBRARY_PATH=path_list_append:${LIBHWLOC_LIBRARY_DIRS};LD_LIBRARY_PATH=path_list_append:${JEMALLOC_LIBRARY_DIRS}"
+            "LD_LIBRARY_PATH=path_list_append:${LIBUMF_LIBRARY_DIRS};LD_LIBRARY_PATH=path_list_append:${LIBHWLOC_LIBRARY_DIRS}"
     )
 endif()

--- a/examples/dram_and_fsdax/CMakeLists.txt
+++ b/examples/dram_and_fsdax/CMakeLists.txt
@@ -21,10 +21,8 @@ if(NOT LIBHWLOC_FOUND)
     find_package(LIBHWLOC 2.3.0 REQUIRED hwloc)
 endif()
 
-pkg_check_modules(JEMALLOC jemalloc)
-if(NOT JEMALLOC_FOUND)
-    find_package(JEMALLOC REQUIRED jemalloc)
-endif()
+# find the custom jemalloc pointed by CMAKE_PREFIX_PATH
+find_package(JEMALLOC REQUIRED jemalloc)
 
 # build the example
 set(EXAMPLE_NAME umf_example_dram_and_fsdax)

--- a/scripts/qemu/run-build.sh
+++ b/scripts/qemu/run-build.sh
@@ -14,7 +14,7 @@ pwd
 
 echo password | sudo -Sk apt-get update
 echo password | sudo -Sk apt-get install -y git cmake gcc g++ pkg-config \
-    numactl libnuma-dev hwloc libhwloc-dev libjemalloc-dev libtbb-dev valgrind lcov
+    numactl libnuma-dev hwloc libhwloc-dev libtbb-dev valgrind lcov
 
 mkdir build
 cd build

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,7 +69,18 @@ set(UMF_SOURCES
     critnib/critnib.c
     ravl/ravl.c
     pool/pool_proxy.c
+    pool/pool_jemalloc.c
     pool/pool_scalable.c)
+
+if(UMF_POOL_JEMALLOC_ENABLED)
+    set(UMF_LIBS ${UMF_LIBS} ${JEMALLOC_LIBRARIES})
+    set(UMF_PRIVATE_LIBRARY_DIRS ${UMF_PRIVATE_LIBRARY_DIRS}
+                                 ${JEMALLOC_LIBRARY_DIRS})
+    set(UMF_PRIVATE_INCLUDE_DIRS ${UMF_PRIVATE_INCLUDE_DIRS}
+                                 ${JEMALLOC_INCLUDE_DIRS})
+    set(UMF_COMMON_COMPILE_DEFINITIONS ${UMF_COMMON_COMPILE_DEFINITIONS}
+                                       "UMF_POOL_JEMALLOC_ENABLED=1")
+endif()
 
 if(NOT UMF_DISABLE_HWLOC)
     set(UMF_SOURCES ${UMF_SOURCES} ${HWLOC_DEPENDENT_SOURCES}
@@ -146,15 +157,19 @@ else()
         LIBS ${UMF_LIBS})
 endif()
 
+target_include_directories(umf PRIVATE ${UMF_PRIVATE_INCLUDE_DIRS})
+target_link_directories(umf PRIVATE ${UMF_PRIVATE_LIBRARY_DIRS})
+target_compile_definitions(umf PRIVATE ${UMF_COMMON_COMPILE_DEFINITIONS})
+
 add_dependencies(umf coarse)
 
 if(UMF_LINK_HWLOC_STATICALLY)
     add_dependencies(umf ${UMF_HWLOC_NAME})
 endif()
 
-target_link_directories(umf PRIVATE ${UMF_PRIVATE_LIBRARY_DIRS})
-
-target_compile_definitions(umf PRIVATE ${UMF_COMMON_COMPILE_DEFINITIONS})
+if(NOT WINDOWS AND UMF_POOL_JEMALLOC_ENABLED)
+    add_dependencies(umf jemalloc)
+endif()
 
 if(UMF_BUILD_LEVEL_ZERO_PROVIDER)
     if(LINUX)

--- a/src/libumf.def
+++ b/src/libumf.def
@@ -36,6 +36,10 @@ EXPORTS
     umfFileMemoryProviderParamsSetVisibility
     umfGetIPCHandle
     umfGetLastFailedMemoryProvider
+    umfJemallocPoolOps
+    umfJemallocPoolParamsCreate
+    umfJemallocPoolParamsDestroy
+    umfJemallocPoolParamsSetKeepAllMemory
     umfLevelZeroMemoryProviderOps
     umfLevelZeroMemoryProviderParamsCreate
     umfLevelZeroMemoryProviderParamsDestroy

--- a/src/libumf.map
+++ b/src/libumf.map
@@ -30,6 +30,10 @@ UMF_1.0 {
         umfFileMemoryProviderParamsSetVisibility;
         umfGetIPCHandle;
         umfGetLastFailedMemoryProvider;
+        umfJemallocPoolOps;
+        umfJemallocPoolParamsCreate;
+        umfJemallocPoolParamsDestroy;
+        umfJemallocPoolParamsSetKeepAllMemory;
         umfLevelZeroMemoryProviderOps;
         umfLevelZeroMemoryProviderParamsCreate;
         umfLevelZeroMemoryProviderParamsDestroy;

--- a/src/pool/CMakeLists.txt
+++ b/src/pool/CMakeLists.txt
@@ -45,10 +45,13 @@ if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
         NAME jemalloc_pool
         TYPE STATIC
         SRCS pool_jemalloc.c ${POOL_EXTRA_SRCS}
-        LIBS jemalloc ${POOL_EXTRA_LIBS})
+        LIBS ${JEMALLOC_LIBRARIES} ${POOL_EXTRA_LIBS})
     target_include_directories(jemalloc_pool PRIVATE ${JEMALLOC_INCLUDE_DIRS})
     target_compile_definitions(jemalloc_pool
                                PRIVATE ${POOL_COMPILE_DEFINITIONS})
     add_library(${PROJECT_NAME}::jemalloc_pool ALIAS jemalloc_pool)
+    if(NOT WINDOWS)
+        add_dependencies(jemalloc_pool jemalloc)
+    endif()
     install(TARGETS jemalloc_pool EXPORT ${PROJECT_NAME}-targets)
 endif()

--- a/src/pool/CMakeLists.txt
+++ b/src/pool/CMakeLists.txt
@@ -38,20 +38,3 @@ if(UMF_BUILD_LIBUMF_POOL_DISJOINT)
 
     install(TARGETS disjoint_pool EXPORT ${PROJECT_NAME}-targets)
 endif()
-
-# libumf_pool_jemalloc
-if(UMF_BUILD_LIBUMF_POOL_JEMALLOC)
-    add_umf_library(
-        NAME jemalloc_pool
-        TYPE STATIC
-        SRCS pool_jemalloc.c ${POOL_EXTRA_SRCS}
-        LIBS ${JEMALLOC_LIBRARIES} ${POOL_EXTRA_LIBS})
-    target_include_directories(jemalloc_pool PRIVATE ${JEMALLOC_INCLUDE_DIRS})
-    target_compile_definitions(jemalloc_pool
-                               PRIVATE ${POOL_COMPILE_DEFINITIONS})
-    add_library(${PROJECT_NAME}::jemalloc_pool ALIAS jemalloc_pool)
-    if(NOT WINDOWS)
-        add_dependencies(jemalloc_pool jemalloc)
-    endif()
-    install(TARGETS jemalloc_pool EXPORT ${PROJECT_NAME}-targets)
-endif()

--- a/src/pool/pool_jemalloc.c
+++ b/src/pool/pool_jemalloc.c
@@ -20,6 +20,32 @@
 #include <umf/memory_pool_ops.h>
 #include <umf/pools/pool_jemalloc.h>
 
+#ifndef UMF_POOL_JEMALLOC_ENABLED
+
+umf_memory_pool_ops_t *umfJemallocPoolOps(void) { return NULL; }
+
+umf_result_t
+umfJemallocPoolParamsCreate(umf_jemalloc_pool_params_handle_t *hParams) {
+    (void)hParams; // unused
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+}
+
+umf_result_t
+umfJemallocPoolParamsDestroy(umf_jemalloc_pool_params_handle_t hParams) {
+    (void)hParams; // unused
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+}
+
+umf_result_t
+umfJemallocPoolParamsSetKeepAllMemory(umf_jemalloc_pool_params_handle_t hParams,
+                                      bool keepAllMemory) {
+    (void)hParams;       // unused
+    (void)keepAllMemory; // unused
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+}
+
+#else
+
 #include <jemalloc/jemalloc.h>
 
 #define MALLOCX_ARENA_MAX (MALLCTL_ARENAS_ALL - 1)
@@ -535,3 +561,4 @@ static umf_memory_pool_ops_t UMF_JEMALLOC_POOL_OPS = {
 umf_memory_pool_ops_t *umfJemallocPoolOps(void) {
     return &UMF_JEMALLOC_POOL_OPS;
 }
+#endif /* UMF_POOL_JEMALLOC_ENABLED */

--- a/src/pool/pool_jemalloc.c
+++ b/src/pool/pool_jemalloc.c
@@ -22,16 +22,6 @@
 
 #include <jemalloc/jemalloc.h>
 
-// The Windows version of jemalloc uses API with je_ prefix,
-// while the Linux one does not.
-#ifndef _WIN32
-#define je_mallocx mallocx
-#define je_dallocx dallocx
-#define je_rallocx rallocx
-#define je_mallctl mallctl
-#define je_malloc_usable_size malloc_usable_size
-#endif
-
 #define MALLOCX_ARENA_MAX (MALLCTL_ARENAS_ALL - 1)
 
 typedef struct jemalloc_memory_pool_t {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -165,10 +165,6 @@ if(UMF_BUILD_SHARED_LIBRARY)
     endif()
 endif()
 
-if(UMF_POOL_JEMALLOC_ENABLED)
-    set(LIB_JEMALLOC_POOL jemalloc_pool)
-endif()
-
 if(UMF_BUILD_LIBUMF_POOL_DISJOINT)
     set(LIB_DISJOINT_POOL disjoint_pool)
 endif()
@@ -236,14 +232,15 @@ if(UMF_BUILD_LIBUMF_POOL_DISJOINT
     add_umf_test(
         NAME c_api_multi_pool
         SRCS c_api/multi_pool.c
-        LIBS disjoint_pool jemalloc_pool ${JEMALLOC_LIBRARIES})
+        LIBS disjoint_pool)
 endif()
 
 if(UMF_POOL_JEMALLOC_ENABLED AND (NOT UMF_DISABLE_HWLOC))
     add_umf_test(
         NAME jemalloc_pool
         SRCS pools/jemalloc_pool.cpp malloc_compliance_tests.cpp
-        LIBS jemalloc_pool)
+             ${BA_SOURCES_FOR_TEST}
+        LIBS ${UMF_UTILS_FOR_TEST})
 endif()
 
 if(UMF_POOL_SCALABLE_ENABLED AND (NOT UMF_DISABLE_HWLOC))
@@ -266,7 +263,7 @@ if(LINUX AND (NOT UMF_DISABLE_HWLOC)) # OS-specific functions are implemented
     add_umf_test(
         NAME provider_os_memory
         SRCS provider_os_memory.cpp ${BA_SOURCES_FOR_TEST}
-        LIBS ${UMF_UTILS_FOR_TEST} ${LIB_JEMALLOC_POOL} ${LIB_DISJOINT_POOL})
+        LIBS ${UMF_UTILS_FOR_TEST} ${LIB_DISJOINT_POOL})
     add_umf_test(
         NAME provider_os_memory_multiple_numa_nodes
         SRCS provider_os_memory_multiple_numa_nodes.cpp
@@ -314,7 +311,7 @@ if(LINUX AND (NOT UMF_DISABLE_HWLOC)) # OS-specific functions are implemented
     add_umf_test(
         NAME provider_devdax_memory_ipc
         SRCS provider_devdax_memory_ipc.cpp ${BA_SOURCES_FOR_TEST}
-        LIBS ${UMF_UTILS_FOR_TEST} ${LIB_JEMALLOC_POOL})
+        LIBS ${UMF_UTILS_FOR_TEST})
     add_umf_test(
         NAME provider_file_memory
         SRCS provider_file_memory.cpp
@@ -322,18 +319,20 @@ if(LINUX AND (NOT UMF_DISABLE_HWLOC)) # OS-specific functions are implemented
     add_umf_test(
         NAME provider_file_memory_ipc
         SRCS provider_file_memory_ipc.cpp ${BA_SOURCES_FOR_TEST}
-        LIBS ${UMF_UTILS_FOR_TEST} ${LIB_JEMALLOC_POOL})
+        LIBS ${UMF_UTILS_FOR_TEST})
 
     # This test requires Linux-only file memory provider
     if(UMF_POOL_JEMALLOC_ENABLED)
         add_umf_test(
             NAME jemalloc_coarse_file
             SRCS pools/jemalloc_coarse_file.cpp malloc_compliance_tests.cpp
-            LIBS jemalloc_pool)
+                 ${BA_SOURCES_FOR_TEST}
+            LIBS ${UMF_UTILS_FOR_TEST})
         add_umf_test(
             NAME jemalloc_coarse_devdax
             SRCS pools/jemalloc_coarse_devdax.cpp malloc_compliance_tests.cpp
-            LIBS jemalloc_pool)
+                 ${BA_SOURCES_FOR_TEST}
+            LIBS ${UMF_UTILS_FOR_TEST})
     endif()
 
     # This test requires Linux-only file memory provider
@@ -739,7 +738,7 @@ if(LINUX
     else()
         message(
             STATUS
-                "The dram_and_fsdax example is supported on Linux only and requires UMF_BUILD_LIBUMF_POOL_JEMALLOC to be turned ON - skipping"
+                "The dram_and_fsdax example is supported on Linux only and requires the jemalloc pool, but it is disabled - skipping"
         )
     endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -747,6 +747,13 @@ if(LINUX
         set(STANDALONE_CMAKE_OPTIONS
             "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
         )
+        if(JEMALLOC_INCLUDE_DIRS)
+            # add custom jemalloc installation
+            set(STANDALONE_CMAKE_OPTIONS
+                "${STANDALONE_CMAKE_OPTIONS} -DCMAKE_PREFIX_PATH=${JEMALLOC_INCLUDE_DIRS}/../"
+            )
+        endif()
+
         add_test(
             NAME umf-standalone_examples
             COMMAND

--- a/test/supp/drd-umf_test-jemalloc_coarse_devdax.supp
+++ b/test/supp/drd-umf_test-jemalloc_coarse_devdax.supp
@@ -1,27 +1,8 @@
 {
-   False-positive ConflictingAccess in libjemalloc.so
+   False-positive ConflictingAccess in jemalloc
    drd:ConflictingAccess
-   obj:*/libjemalloc.so*
    ...
-   fun:mallocx
-   ...
-}
-
-{
-   False-positive ConflictingAccess in libjemalloc.so
-   drd:ConflictingAccess
-   obj:*/libjemalloc.so*
-   ...
-   fun:op_free
-   ...
-}
-
-{
-   False-positive ConflictingAccess in libjemalloc.so
-   drd:ConflictingAccess
-   obj:*/libjemalloc.so*
-   ...
-   fun:__nptl_deallocate_tsd
+   fun:je_*
    ...
 }
 

--- a/test/supp/drd-umf_test-jemalloc_coarse_file.supp
+++ b/test/supp/drd-umf_test-jemalloc_coarse_file.supp
@@ -1,27 +1,8 @@
 {
-   False-positive ConflictingAccess in libjemalloc.so
+   False-positive ConflictingAccess in jemalloc
    drd:ConflictingAccess
-   obj:*/libjemalloc.so*
    ...
-   fun:mallocx
-   ...
-}
-
-{
-   False-positive ConflictingAccess in libjemalloc.so
-   drd:ConflictingAccess
-   obj:*/libjemalloc.so*
-   ...
-   fun:op_free
-   ...
-}
-
-{
-   False-positive ConflictingAccess in libjemalloc.so
-   drd:ConflictingAccess
-   obj:*/libjemalloc.so*
-   ...
-   fun:__nptl_deallocate_tsd
+   fun:je_*
    ...
 }
 

--- a/test/supp/drd-umf_test-jemalloc_pool.supp
+++ b/test/supp/drd-umf_test-jemalloc_pool.supp
@@ -1,6 +1,7 @@
 {
-   Conflicting Access in libjemalloc.so - internal issue of libjemalloc
+   False-positive ConflictingAccess in jemalloc
    drd:ConflictingAccess
-   obj:*libjemalloc.so*
+   ...
+   fun:je_*
    ...
 }

--- a/test/supp/helgrind-umf_test-jemalloc_coarse_devdax.supp
+++ b/test/supp/helgrind-umf_test-jemalloc_coarse_devdax.supp
@@ -1,27 +1,8 @@
 {
-   False-positive Race in libjemalloc.so
+   False-positive Race in jemalloc
    Helgrind:Race
-   obj:*/libjemalloc.so*
    ...
-   fun:mallocx
-   ...
-}
-
-{
-   False-positive Race in libjemalloc.so
-   Helgrind:Race
-   obj:*/libjemalloc.so*
-   ...
-   fun:op_free
-   ...
-}
-
-{
-   False-positive Race in libjemalloc.so
-   Helgrind:Race
-   obj:*/libjemalloc.so*
-   ...
-   fun:__nptl_deallocate_tsd
+   fun:je_*
    ...
 }
 

--- a/test/supp/helgrind-umf_test-jemalloc_coarse_file.supp
+++ b/test/supp/helgrind-umf_test-jemalloc_coarse_file.supp
@@ -1,27 +1,8 @@
 {
-   False-positive Race in libjemalloc.so
+   False-positive Race in jemalloc
    Helgrind:Race
-   obj:*/libjemalloc.so*
    ...
-   fun:mallocx
-   ...
-}
-
-{
-   False-positive Race in libjemalloc.so
-   Helgrind:Race
-   obj:*/libjemalloc.so*
-   ...
-   fun:op_free
-   ...
-}
-
-{
-   False-positive Race in libjemalloc.so
-   Helgrind:Race
-   obj:*/libjemalloc.so*
-   ...
-   fun:__nptl_deallocate_tsd
+   fun:je_*
    ...
 }
 

--- a/test/supp/helgrind-umf_test-jemalloc_pool.supp
+++ b/test/supp/helgrind-umf_test-jemalloc_pool.supp
@@ -1,6 +1,7 @@
 {
-   Race in libjemalloc.so  - internal issue of libjemalloc
+   False-positive Race in jemalloc
    Helgrind:Race
-   obj:*libjemalloc.so*
+   ...
+   fun:je_*
    ...
 }

--- a/test/supp/memcheck-umf_test-jemalloc_coarse_devdax.supp
+++ b/test/supp/memcheck-umf_test-jemalloc_coarse_devdax.supp
@@ -1,0 +1,7 @@
+{
+   False-positive invalid write of size 8
+   Memcheck:Addr8
+   ...
+   fun:je_*
+   ...
+}

--- a/test/supp/memcheck-umf_test-jemalloc_coarse_file.supp
+++ b/test/supp/memcheck-umf_test-jemalloc_coarse_file.supp
@@ -1,0 +1,7 @@
+{
+   False-positive invalid write of size 8
+   Memcheck:Addr8
+   ...
+   fun:je_*
+   ...
+}

--- a/test/test_installation.py
+++ b/test/test_installation.py
@@ -284,11 +284,6 @@ class UmfInstallationTester:
             help="Add this argument if the UMF was built with Disjoint Pool enabled",
         )
         self.parser.add_argument(
-            "--jemalloc-pool",
-            action="store_true",
-            help="Add this argument if the UMF was built with Jemalloc Pool enabled",
-        )
-        self.parser.add_argument(
             "--umf-version",
             action="store",
             help="Current version of the UMF, e.g. 1.0.0",
@@ -306,8 +301,6 @@ class UmfInstallationTester:
         pools = []
         if self.args.disjoint_pool:
             pools.append("disjoint_pool")
-        if self.args.jemalloc_pool:
-            pools.append("jemalloc_pool")
 
         umf_version = Version(self.args.umf_version)
 


### PR DESCRIPTION
### Description

Link statically with custom jemalloc built from sources
with the following non-default options enabled:
- `--with-jemalloc-prefix=je_` - add je_ prefix to all public APIs
- `--disable-cxx` - Disable C++ integration. This will cause new and delete operators implementations to be omitted.
- `--disable-initial-exec-tls` - Disable the initial-exec TLS model for jemalloc's internal thread-local storage (on those platforms that support explicit settings). This can allow jemalloc to be dynamically loaded after program startup (e.g. using `dlopen()`).

Fixes: #891
Fixes: #894
Fixes: #903

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
