### PR TITLE
Minor fixes to clean up resources in tests

### DIFF
--- a/test/pools/disjoint_pool.cpp
+++ b/test/pools/disjoint_pool.cpp
@@ -29,20 +29,24 @@ disjoint_params_unique_handle_t poolConfig() {
     res = umfDisjointPoolParamsSetSlabMinSize(config,
                                               DEFAULT_DISJOINT_SLAB_MIN_SIZE);
     if (res != UMF_RESULT_SUCCESS) {
+        umfDisjointPoolParamsDestroy(config);
         throw std::runtime_error("Failed to set slab min size");
     }
     res = umfDisjointPoolParamsSetMaxPoolableSize(
         config, DEFAULT_DISJOINT_MAX_POOLABLE_SIZE);
     if (res != UMF_RESULT_SUCCESS) {
+        umfDisjointPoolParamsDestroy(config);
         throw std::runtime_error("Failed to set max poolable size");
     }
     res = umfDisjointPoolParamsSetCapacity(config, DEFAULT_DISJOINT_CAPACITY);
     if (res != UMF_RESULT_SUCCESS) {
+        umfDisjointPoolParamsDestroy(config);
         throw std::runtime_error("Failed to set capacity");
     }
     res = umfDisjointPoolParamsSetMinBucketSize(
         config, DEFAULT_DISJOINT_MIN_BUCKET_SIZE);
     if (res != UMF_RESULT_SUCCESS) {
+        umfDisjointPoolParamsDestroy(config);
         throw std::runtime_error("Failed to set min bucket size");
     }
 

--- a/test/provider_os_memory.cpp
+++ b/test/provider_os_memory.cpp
@@ -441,18 +441,22 @@ disjoint_params_unique_handle_t disjointPoolParams() {
     }
     res = umfDisjointPoolParamsSetSlabMinSize(params, 4096);
     if (res != UMF_RESULT_SUCCESS) {
+        umfDisjointPoolParamsDestroy(params);
         throw std::runtime_error("Failed to set slab min size");
     }
     res = umfDisjointPoolParamsSetMaxPoolableSize(params, 4096);
     if (res != UMF_RESULT_SUCCESS) {
+        umfDisjointPoolParamsDestroy(params);
         throw std::runtime_error("Failed to set max poolable size");
     }
     res = umfDisjointPoolParamsSetCapacity(params, 4);
     if (res != UMF_RESULT_SUCCESS) {
+        umfDisjointPoolParamsDestroy(params);
         throw std::runtime_error("Failed to set capacity");
     }
     res = umfDisjointPoolParamsSetMinBucketSize(params, 64);
     if (res != UMF_RESULT_SUCCESS) {
+        umfDisjointPoolParamsDestroy(params);
         throw std::runtime_error("Failed to set min bucket size");
     }
 


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description
Minor fixes to properly clean up resources when disjoint pool params functions return an error. 

### Checklist

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [ ] CI workflows execute properly

