### PR TITLE
Fix building the custom jemalloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,13 +164,13 @@ else()
     add_custom_command(
         COMMAND make
         WORKING_DIRECTORY ${jemalloc_targ_SOURCE_DIR}
-        OUTPUT ${jemalloc_targ_SOURCE_DIR}/lib/libjemalloc.la
+        OUTPUT ${jemalloc_targ_SOURCE_DIR}/lib/libjemalloc.a
         DEPENDS ${jemalloc_targ_SOURCE_DIR}/Makefile)
     add_custom_command(
         COMMAND make install
         WORKING_DIRECTORY ${jemalloc_targ_SOURCE_DIR}
         OUTPUT ${jemalloc_targ_BINARY_DIR}/lib/libjemalloc.a
-        DEPENDS ${jemalloc_targ_SOURCE_DIR}/lib/libjemalloc.la)
+        DEPENDS ${jemalloc_targ_SOURCE_DIR}/lib/libjemalloc.a)
 
     add_custom_target(jemalloc_prod
                       DEPENDS ${jemalloc_targ_BINARY_DIR}/lib/libjemalloc.a)


### PR DESCRIPTION
### Description

The `make install` step is executed always
and all UMF tests are re-linked also always now
because of an incorrect dependence.
This patch fixes that.

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
