### PR TITLE
Fix: remove incorrect assert in utils_align_ptr_up_size_down()

### DIFF
--- a/src/utils/utils_common.c
+++ b/src/utils/utils_common.c
@@ -25,7 +25,6 @@ void utils_align_ptr_up_size_down(void **ptr, size_t *size, size_t alignment) {
     }
 
     ASSERT(IS_ALIGNED(p, alignment));
-    ASSERT(IS_ALIGNED(s, alignment));
 
     *ptr = (void *)p;
     *size = s;

--- a/test/utils/utils_linux.cpp
+++ b/test/utils/utils_linux.cpp
@@ -2,6 +2,7 @@
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <cstdint>
 #include <sys/mman.h>
 
 #include "base.hpp"
@@ -168,4 +169,20 @@ TEST_F(test, utils_open) {
     EXPECT_EQ(utils_devdax_open(NULL), -1);
     EXPECT_EQ(utils_file_open(NULL), -1);
     EXPECT_EQ(utils_file_open_or_create(NULL), -1);
+}
+
+TEST_F(test, utils_align_ptr_up_size_down) {
+    uintptr_t ptr = 0x4000;
+    size_t size = 0x8000;
+    size_t alignment = 0x4000;
+    utils_align_ptr_up_size_down((void **)&ptr, &size, alignment);
+    EXPECT_EQ(ptr, 0x4000);
+    EXPECT_EQ(size, 0x8000);
+
+    ptr = 0x4001;
+    size = 0x8000;
+    alignment = 0x4000;
+    utils_align_ptr_up_size_down((void **)&ptr, &size, alignment);
+    EXPECT_EQ(ptr, 0x8000);
+    EXPECT_EQ(size, 0x4001);
 }


### PR DESCRIPTION
### Description

Remove incorrect assert in `utils_align_ptr_up_size_down()`.
A pointer is aligned, but a size is only adjusted to the new pointer.
The size does not have to be aligned.

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
