### PR TITLE
Do not check coverage in the Release multi-numa build

### DIFF
--- a/.github/workflows/reusable_gpu.yml
+++ b/.github/workflows/reusable_gpu.yml
@@ -129,5 +129,5 @@ jobs:
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: ${{ matrix.build_type == 'Debug' && matrix.os == 'Ubuntu' }}
         with:
-          name: ${{env.COVERAGE_NAME}}-${{matrix.os}}-${{matrix.build_type}}-shared-${{matrix.shared_library}}
+          name: ${{env.COVERAGE_NAME}}-shared-${{matrix.shared_library}}
           path: ${{env.COVERAGE_DIR}}

--- a/.github/workflows/reusable_multi_numa.yml
+++ b/.github/workflows/reusable_multi_numa.yml
@@ -69,7 +69,7 @@ jobs:
             --gtest_filter="-*checkModeLocal/*:*checkModePreferredEmptyNodeset/*:testNuma.checkModeInterleave"
 
       - name: Check coverage
-        if: matrix.os == 'ubuntu-22.04'
+        if: ${{ matrix.build_type == 'Debug' && matrix.os == 'ubuntu-22.04' }}
         working-directory: ${{env.BUILD_DIR}}
         run: |
           export COVERAGE_FILE_NAME=${{env.COVERAGE_NAME}}-${{matrix.os}}-shared-${{matrix.shared_library}}
@@ -79,7 +79,7 @@ jobs:
           mv ./$COVERAGE_FILE_NAME ${{env.COVERAGE_DIR}}
 
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
-        if: matrix.os == 'ubuntu-22.04'
+        if: ${{ matrix.build_type == 'Debug' && matrix.os == 'ubuntu-22.04' }}
         with:
-          name: ${{env.COVERAGE_NAME}}-${{matrix.os}}-${{matrix.build_type}}-shared-${{matrix.shared_library}}
+          name: ${{env.COVERAGE_NAME}}-${{matrix.os}}-shared-${{matrix.shared_library}}
           path: ${{env.COVERAGE_DIR}}


### PR DESCRIPTION
### Description

1) Do not check coverage in the Release multi-numa build
2) Unify the name of the coverage data file in the `upload-artifact`
   step and the coverage artifact file in the `Check coverage` step.
   A name of the coverage artifact file in the `Check coverage` step
   must be unique.

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
