### PR TITLE
Make coarse_alloc() return aligned address when alignment==0

### DIFF
--- a/src/coarse/coarse.h
+++ b/src/coarse/coarse.h
@@ -34,16 +34,16 @@ typedef struct coarse_callbacks_t {
 
 // coarse library allocation strategy
 typedef enum coarse_strategy_t {
+    // Check if the first free block of the 'size' size has the correct alignment.
+    // If not, use the `UMF_COARSE_MEMORY_STRATEGY_FASTEST` strategy.
+    UMF_COARSE_MEMORY_STRATEGY_FASTEST_BUT_ONE = 0,
+
     // Always allocate a free block of the (size + alignment) size
     // and cut out the properly aligned part leaving two remaining parts.
     // It is the fastest strategy but causes memory fragmentation
     // when alignment is greater than 0.
     // It is the best strategy when alignment always equals 0.
-    UMF_COARSE_MEMORY_STRATEGY_FASTEST = 0,
-
-    // Check if the first free block of the 'size' size has the correct alignment.
-    // If not, use the `UMF_COARSE_MEMORY_STRATEGY_FASTEST` strategy.
-    UMF_COARSE_MEMORY_STRATEGY_FASTEST_BUT_ONE,
+    UMF_COARSE_MEMORY_STRATEGY_FASTEST,
 
     // Look through all free blocks of the 'size' size
     // and choose the first one with the correct alignment.

--- a/src/utils/utils_common.c
+++ b/src/utils/utils_common.c
@@ -25,7 +25,6 @@ void utils_align_ptr_up_size_down(void **ptr, size_t *size, size_t alignment) {
     }
 
     ASSERT(IS_ALIGNED(p, alignment));
-    ASSERT(IS_ALIGNED(s, alignment));
 
     *ptr = (void *)p;
     *size = s;

--- a/test/coarse_lib.cpp
+++ b/test/coarse_lib.cpp
@@ -166,9 +166,10 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_basic_provider) {
 
 TEST_P(CoarseWithMemoryStrategyTest, coarseTest_basic_fixed_memory) {
     // preallocate some memory and initialize the vector with zeros
-    const size_t buff_size = 20 * MB;
+    const size_t buff_size = 20 * MB + coarse_params.page_size;
     std::vector<char> buffer(buff_size, 0);
-    void *buf = (void *)buffer.data();
+    void *buf = (void *)ALIGN_UP_SAFE((uintptr_t)buffer.data(),
+                                      coarse_params.page_size);
     ASSERT_NE(buf, nullptr);
 
     coarse_params.cb.alloc = NULL;
@@ -206,9 +207,10 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_basic_fixed_memory) {
 
 TEST_P(CoarseWithMemoryStrategyTest, coarseTest_fixed_memory_various) {
     // preallocate some memory and initialize the vector with zeros
-    const size_t buff_size = 20 * MB;
+    const size_t buff_size = 20 * MB + coarse_params.page_size;
     std::vector<char> buffer(buff_size, 0);
-    void *buf = (void *)buffer.data();
+    void *buf = (void *)ALIGN_UP_SAFE((uintptr_t)buffer.data(),
+                                      coarse_params.page_size);
     ASSERT_NE(buf, nullptr);
 
     coarse_params.cb.alloc = NULL;
@@ -627,6 +629,15 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_basic_free_cb_fails) {
 }
 
 TEST_P(CoarseWithMemoryStrategyTest, coarseTest_split_cb_fails) {
+    if (coarse_params.allocation_strategy ==
+        UMF_COARSE_MEMORY_STRATEGY_FASTEST) {
+        // This test is designed for the UMF_COARSE_MEMORY_STRATEGY_FASTEST_BUT_ONE
+        // and UMF_COARSE_MEMORY_STRATEGY_CHECK_ALL_SIZE strategies,
+        // because the UMF_COARSE_MEMORY_STRATEGY_FASTEST strategy
+        // looks always for a block of size greater by the page size.
+        return;
+    }
+
     umf_memory_provider_handle_t malloc_memory_provider;
     umf_result = umfMemoryProviderCreate(&UMF_MALLOC_MEMORY_PROVIDER_OPS, NULL,
                                          &malloc_memory_provider);
@@ -702,9 +713,10 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_split_cb_fails) {
 
 TEST_P(CoarseWithMemoryStrategyTest, coarseTest_merge_cb_fails) {
     // preallocate some memory and initialize the vector with zeros
-    const size_t buff_size = 10 * MB;
+    const size_t buff_size = 10 * MB + coarse_params.page_size;
     std::vector<char> buffer(buff_size, 0);
-    void *buf = (void *)buffer.data();
+    void *buf = (void *)ALIGN_UP_SAFE((uintptr_t)buffer.data(),
+                                      coarse_params.page_size);
     ASSERT_NE(buf, nullptr);
 
     coarse_params.cb.alloc = NULL;
@@ -901,6 +913,15 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_provider_alloc_not_set) {
 }
 
 TEST_P(CoarseWithMemoryStrategyTest, coarseTest_basic) {
+    if (coarse_params.allocation_strategy ==
+        UMF_COARSE_MEMORY_STRATEGY_FASTEST) {
+        // This test is designed for the UMF_COARSE_MEMORY_STRATEGY_FASTEST_BUT_ONE
+        // and UMF_COARSE_MEMORY_STRATEGY_CHECK_ALL_SIZE strategies,
+        // because the UMF_COARSE_MEMORY_STRATEGY_FASTEST strategy
+        // looks always for a block of size greater by the page size.
+        return;
+    }
+
     umf_memory_provider_handle_t malloc_memory_provider;
     umf_result = umfMemoryProviderCreate(&UMF_MALLOC_MEMORY_PROVIDER_OPS, NULL,
                                          &malloc_memory_provider);
@@ -1065,6 +1086,15 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_basic) {
 }
 
 TEST_P(CoarseWithMemoryStrategyTest, coarseTest_simple1) {
+    if (coarse_params.allocation_strategy ==
+        UMF_COARSE_MEMORY_STRATEGY_FASTEST) {
+        // This test is designed for the UMF_COARSE_MEMORY_STRATEGY_FASTEST_BUT_ONE
+        // and UMF_COARSE_MEMORY_STRATEGY_CHECK_ALL_SIZE strategies,
+        // because the UMF_COARSE_MEMORY_STRATEGY_FASTEST strategy
+        // looks always for a block of size greater by the page size.
+        return;
+    }
+
     umf_memory_provider_handle_t malloc_memory_provider;
     umf_result = umfMemoryProviderCreate(&UMF_MALLOC_MEMORY_PROVIDER_OPS, NULL,
                                          &malloc_memory_provider);
@@ -1106,8 +1136,9 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_simple1) {
             ASSERT_NE(t[i], nullptr);
         }
 
-        if (max_alloc_size == 0) {
-            max_alloc_size = coarse_get_stats(ch).alloc_size;
+        size_t alloc_size = coarse_get_stats(ch).alloc_size;
+        if (alloc_size > max_alloc_size) {
+            max_alloc_size = alloc_size;
         }
 
         for (int i = 0; i < nptrs; i++) {
@@ -1253,9 +1284,10 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_alignment_provider) {
 
 TEST_P(CoarseWithMemoryStrategyTest, coarseTest_alignment_fixed_memory) {
     // preallocate some memory and initialize the vector with zeros
-    const size_t alloc_size = 40 * MB;
+    const size_t alloc_size = 40 * MB + coarse_params.page_size;
     std::vector<char> buffer(alloc_size, 0);
-    void *buf = (void *)buffer.data();
+    void *buf = (void *)ALIGN_UP_SAFE((uintptr_t)buffer.data(),
+                                      coarse_params.page_size);
     ASSERT_NE(buf, nullptr);
 
     coarse_params.cb.alloc = NULL;

--- a/test/provider_devdax_memory.cpp
+++ b/test/provider_devdax_memory.cpp
@@ -233,6 +233,13 @@ TEST_P(umfProviderTest, purge_force) {
     test_alloc_free_success(provider.get(), page_size, 0, PURGE_FORCE);
 }
 
+TEST_P(umfProviderTest, purge_force_unalligned_alloc) {
+    void *ptr;
+    auto ret = umfMemoryProviderAlloc(provider.get(), page_plus_64, 0, &ptr);
+    ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+    test_alloc_free_success(provider.get(), page_size, 0, PURGE_FORCE);
+    umfMemoryProviderFree(provider.get(), ptr, page_plus_64);
+}
 // negative tests using test_alloc_failure
 
 TEST_P(umfProviderTest, alloc_page64_align_page_minus_1_WRONG_ALIGNMENT_1) {


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

Make `coarse_alloc()` always return address aligned to `coarse->page_size` when `alignment==0`.

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
