### PR TITLE
Disable rsmi in hwloc build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,8 +176,8 @@ else()
                 ./configure --prefix=${hwloc_targ_BINARY_DIR}
                 --enable-static=yes --enable-shared=no --disable-libxml2
                 --disable-pci --disable-levelzero --disable-opencl
-                --disable-cuda --disable-nvml --disable-libudev CFLAGS=-fPIC
-                CXXFLAGS=-fPIC
+                --disable-cuda --disable-nvml --disable-libudev --disable-rsmi
+                CFLAGS=-fPIC CXXFLAGS=-fPIC
             WORKING_DIRECTORY ${hwloc_targ_SOURCE_DIR}
             OUTPUT ${hwloc_targ_SOURCE_DIR}/Makefile
             DEPENDS ${hwloc_targ_SOURCE_DIR}/configure)


### PR DESCRIPTION
Disable not used hwloc feature "rsmi". Silence errors during hwloc linkage to umf, like:
```
/usr/bin/ld: _deps/hwloc_targ-build/lib/libhwloc.a(topology-rsmi.o): in function `get_device_name': topology-rsmi.c:(.text+0x208): undefined reference to `rsmi_dev_name_get'
```

<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
