### PR TITLE
use unique_ptr instead of constructor/destructor in benchmarks

### DIFF
--- a/benchmark/benchmark.hpp
+++ b/benchmark/benchmark.hpp
@@ -232,12 +232,14 @@ class alloc_benchmark : public benchmark_interface<Size, Alloc> {
             state.ResumeTiming();
         }
     }
+
     static std::vector<std::string> argsName() {
         auto n = benchmark_interface<Size, Alloc>::argsName();
         std::vector<std::string> res = {"max_allocs", "pre_allocs"};
         res.insert(res.end(), n.begin(), n.end());
         return res;
     }
+
     static std::string name() { return base::name() + "/alloc"; }
     static int64_t iterations() { return 200000; }
 
@@ -320,13 +322,16 @@ class multiple_malloc_free_benchmark : public alloc_benchmark<Size, Alloc> {
     static std::string name() {
         return base::base::name() + "/multiple_malloc_free";
     }
+
     static std::vector<std::string> argsName() {
         auto n = benchmark_interface<Size, Alloc>::argsName();
         std::vector<std::string> res = {"max_allocs"};
         res.insert(res.end(), n.begin(), n.end());
         return res;
     }
+
     static int64_t iterations() { return 2000; }
+
     std::default_random_engine generator;
     distribution dist;
 };
@@ -352,9 +357,11 @@ class provider_allocator : public allocator_interface {
         }
         return ptr;
     }
+
     void benchFree(void *ptr, size_t size) override {
         umfMemoryProviderFree(provider.provider, ptr, size);
     }
+
     static std::string name() { return Provider::name(); }
 
   private:
@@ -374,6 +381,7 @@ template <typename Pool> class pool_allocator : public allocator_interface {
     virtual void *benchAlloc(size_t size) override {
         return umfPoolMalloc(pool.pool, size);
     }
+
     virtual void benchFree(void *ptr, [[maybe_unused]] size_t size) override {
         umfPoolFree(pool.pool, ptr);
     }


### PR DESCRIPTION
On Windows static builds, destructors are invoked after the UMF destructor, causing parameter structures to be unable to be destroyed. By switching to std::unique_ptr, we ensure that parameters are properly cleaned up and the destruction order issue is resolved.