### PR TITLE
Update description of UMF_LINK_HWLOC_STATICALLY flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ option(
     OFF)
 option(
     UMF_LINK_HWLOC_STATICALLY
-    "Link UMF with HWLOC library statically (supported for Linux, MacOS and Release build on Windows)"
+    "Link UMF with HWLOC library statically (proxy library will be disabled on Windows+Debug build)"
     OFF)
 option(UMF_FORMAT_CODE_STYLE
        "Add clang, cmake, and black -format-check and -format-apply targets"

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ List of options provided by CMake:
 | UMF_USE_MSAN | Enable MemorySanitizer checks | ON/OFF | OFF |
 | UMF_USE_VALGRIND | Enable Valgrind instrumentation | ON/OFF | OFF |
 | UMF_USE_COVERAGE | Build with coverage enabled (Linux only) | ON/OFF | OFF |
-| UMF_LINK_HWLOC_STATICALLY | Link UMF with HWLOC library statically (Windows+Release only) | ON/OFF | OFF |
+| UMF_LINK_HWLOC_STATICALLY | Link UMF with HWLOC library statically (proxy library will be disabled on Windows+Debug build) | ON/OFF | OFF |
 | UMF_DISABLE_HWLOC | Disable features that requires hwloc (OS provider, memory targets, topology discovery) | ON/OFF | OFF |
 
 ## Architecture: memory pools and providers


### PR DESCRIPTION


<!-- Provide a short summary of your changes in the Title above -->

### Description
It is supported on Linux, MacOS, and Windows with the exception that the proxy library is disabled when this flag is used on Windows with Debug config.
