### PR TITLE
Run pr_push on schedule at night to get full code coverage from QEMU

### DIFF
--- a/.github/workflows/pr_push.yml
+++ b/.github/workflows/pr_push.yml
@@ -7,6 +7,8 @@ on:
     branches-ignore:
       - 'dependabot/**'
   pull_request:
+  schedule:
+    - cron:  '0 1 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -53,7 +55,7 @@ jobs:
     needs: [FastBuild]
     uses: ./.github/workflows/reusable_qemu.yml
     with:
-      short_run: true
+      short_run: ${{ github.event_name == 'schedule' && 'false' || 'true' }}
   Benchmarks:
     needs: [Build]
     uses: ./.github/workflows/reusable_benchmarks.yml


### PR DESCRIPTION

### Description

Run pr_push on schedule at night to get full code coverage from QEMU.

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
