### PR TITLE
Add strings with UMF version and useful CMake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,36 +33,47 @@ include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 find_package(PkgConfig)
 
+# Define a list to store the names of all options
+set(UMF_OPTIONS_LIST "")
+list(APPEND UMF_OPTIONS_LIST CMAKE_BUILD_TYPE)
+
+# Define a macro to wrap the option() command and track the options
+macro(umf_option)
+    list(APPEND UMF_OPTIONS_LIST ${ARGV0})
+    option(${ARGV})
+endmacro()
+
 # Build Options
-option(UMF_BUILD_SHARED_LIBRARY "Build UMF as shared library" OFF)
-option(UMF_BUILD_LEVEL_ZERO_PROVIDER "Build Level Zero memory provider" ON)
-option(UMF_BUILD_CUDA_PROVIDER "Build CUDA memory provider" ON)
-option(UMF_BUILD_LIBUMF_POOL_DISJOINT
-       "Build the libumf_pool_disjoint static library" OFF)
-option(UMF_BUILD_LIBUMF_POOL_JEMALLOC
-       "Build the libumf_pool_jemalloc static library" OFF)
-option(UMF_BUILD_TESTS "Build UMF tests" ON)
-option(UMF_BUILD_GPU_TESTS "Build UMF GPU tests" OFF)
-option(UMF_BUILD_BENCHMARKS "Build UMF benchmarks" OFF)
-option(UMF_BUILD_BENCHMARKS_MT "Build UMF multithreaded benchmarks" OFF)
-option(UMF_BUILD_EXAMPLES "Build UMF examples" ON)
-option(UMF_BUILD_FUZZTESTS "Build UMF fuzz tests" OFF)
-option(UMF_BUILD_GPU_EXAMPLES "Build UMF GPU examples" OFF)
-option(UMF_DEVELOPER_MODE "Enable additional developer checks" OFF)
-option(
+umf_option(UMF_BUILD_SHARED_LIBRARY "Build UMF as shared library" OFF)
+umf_option(UMF_BUILD_LEVEL_ZERO_PROVIDER "Build Level Zero memory provider" ON)
+umf_option(UMF_BUILD_CUDA_PROVIDER "Build CUDA memory provider" ON)
+umf_option(UMF_BUILD_LIBUMF_POOL_DISJOINT
+           "Build the libumf_pool_disjoint static library" OFF)
+umf_option(UMF_BUILD_LIBUMF_POOL_JEMALLOC
+           "Build the libumf_pool_jemalloc static library" OFF)
+umf_option(UMF_BUILD_TESTS "Build UMF tests" ON)
+umf_option(UMF_BUILD_GPU_TESTS "Build UMF GPU tests" OFF)
+umf_option(UMF_BUILD_BENCHMARKS "Build UMF benchmarks" OFF)
+umf_option(UMF_BUILD_BENCHMARKS_MT "Build UMF multithreaded benchmarks" OFF)
+umf_option(UMF_BUILD_EXAMPLES "Build UMF examples" ON)
+umf_option(UMF_BUILD_FUZZTESTS "Build UMF fuzz tests" OFF)
+umf_option(UMF_BUILD_GPU_EXAMPLES "Build UMF GPU examples" OFF)
+umf_option(UMF_DEVELOPER_MODE "Enable additional developer checks" OFF)
+umf_option(
     UMF_DISABLE_HWLOC
     "Disable hwloc and UMF features requiring it (OS provider, memtargets, topology discovery)"
     OFF)
-option(
+umf_option(
     UMF_LINK_HWLOC_STATICALLY
     "Link UMF with HWLOC library statically (supported for Linux, MacOS and Release build on Windows)"
     OFF)
-option(UMF_FORMAT_CODE_STYLE
-       "Add clang, cmake, and black -format-check and -format-apply targets"
-       OFF)
+umf_option(
+    UMF_FORMAT_CODE_STYLE
+    "Add clang, cmake, and black -format-check and -format-apply targets" OFF)
 set(UMF_HWLOC_NAME
     "hwloc"
     CACHE STRING "Custom name for hwloc library w/o extension")
+list(APPEND UMF_OPTIONS_LIST UMF_HWLOC_NAME)
 set(UMF_INSTALL_RPATH
     ""
     CACHE
@@ -71,13 +82,13 @@ set(UMF_INSTALL_RPATH
 )
 
 # Only a part of skips is treated as a failure now. TODO: extend to all tests
-option(UMF_TESTS_FAIL_ON_SKIP "Treat skips in tests as fail" OFF)
-option(UMF_USE_ASAN "Enable AddressSanitizer checks" OFF)
-option(UMF_USE_UBSAN "Enable UndefinedBehaviorSanitizer checks" OFF)
-option(UMF_USE_TSAN "Enable ThreadSanitizer checks" OFF)
-option(UMF_USE_MSAN "Enable MemorySanitizer checks" OFF)
-option(UMF_USE_VALGRIND "Enable Valgrind instrumentation" OFF)
-option(UMF_USE_COVERAGE "Build with coverage enabled (Linux only)" OFF)
+umf_option(UMF_TESTS_FAIL_ON_SKIP "Treat skips in tests as fail" OFF)
+umf_option(UMF_USE_ASAN "Enable AddressSanitizer checks" OFF)
+umf_option(UMF_USE_UBSAN "Enable UndefinedBehaviorSanitizer checks" OFF)
+umf_option(UMF_USE_TSAN "Enable ThreadSanitizer checks" OFF)
+umf_option(UMF_USE_MSAN "Enable MemorySanitizer checks" OFF)
+umf_option(UMF_USE_VALGRIND "Enable Valgrind instrumentation" OFF)
+umf_option(UMF_USE_COVERAGE "Build with coverage enabled (Linux only)" OFF)
 
 # set UMF_PROXY_LIB_BASED_ON_POOL to one of: SCALABLE or JEMALLOC
 set(KNOWN_PROXY_LIB_POOLS SCALABLE JEMALLOC)
@@ -87,6 +98,7 @@ set(UMF_PROXY_LIB_BASED_ON_POOL
           "A UMF pool the proxy library is based on (SCALABLE or JEMALLOC)")
 set_property(CACHE UMF_PROXY_LIB_BASED_ON_POOL
              PROPERTY STRINGS ${KNOWN_PROXY_LIB_POOLS})
+list(APPEND UMF_OPTIONS_LIST UMF_PROXY_LIB_BASED_ON_POOL)
 
 if(UMF_BUILD_TESTS
    AND DEFINED ENV{CI}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,15 +2,19 @@
 
 
 <!-- TODO: Add [Naming convention](#naming-convention) section -->
-- [Opening new issues](#opening-new-issues)
-- [Submitting Pull Requests](#submitting-pull-requests)
+- [Contributing to UMF (Unified Memory Framework)](#contributing-to-umf-unified-memory-framework)
+  - [Opening new issues](#opening-new-issues)
+  - [Submitting Pull Requests](#submitting-pull-requests)
     - [Building and testing](#building-and-testing)
     - [Code style](#code-style)
-    - [When my PR is merged?](#when-my-PR-is-merged)
+    - [When my PR is merged?](#when-my-pr-is-merged)
     - [Extending public API](#extending-public-api)
     - [License](#license)
     - [Adding new dependency](#adding-new-dependency)
-- [Code coverage](#code-coverage)
+  - [Code coverage](#code-coverage)
+  - [Debugging](#debugging)
+    - [Checking the UMF version and CMake variables (Linux only)](#checking-the-umf-version-and-cmake-variables-linux-only)
+      - [Requirements](#requirements)
 
 Below you'll find instructions on how to contribute to UMF, either with code changes
 or issues. All contributions are most welcome!
@@ -222,3 +226,19 @@ $ apt install lcov
 $ lcov --capture --directory . --output-file coverage.info
 $ genhtml -o html_report coverage.info
 ```
+
+## Debugging
+
+### Checking the UMF version and CMake variables (Linux only)
+
+Strings with the UMF version and useful CMake variables can be grepped in the following way:
+
+```bash
+$ strings libumf.so | grep "@(#)"
+@(#) Intel(R) UMF version: 0.11.0-dev.git66.g89e3831d
+@(#) Intel(R) UMF CMake variables: "CMAKE_BUILD_TYPE:Debug,...
+```
+
+#### Requirements
+
+- binutils package (Linux)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,10 +11,24 @@ set(UMF_CUDA_INCLUDE_DIR
     ""
     CACHE PATH "Directory containing the CUDA headers")
 
+# Compose the UMF_ALL_CMAKE_VARIABLES variable containing CMake options that
+# will be saved in the constant string.
+list(SORT UMF_OPTIONS_LIST ORDER DESCENDING)
+foreach(_var ${UMF_OPTIONS_LIST})
+    # Preprocessor definitions containing '#' cannot be passed on to the
+    # compiler command line because many compilers do not support it.
+    if(NOT "${${_var}}" MATCHES "#")
+        set(UMF_ALL_CMAKE_VARIABLES
+            "${_var}:${${_var}},${UMF_ALL_CMAKE_VARIABLES}")
+    endif()
+endforeach()
+
 # Compile definitions for UMF library.
 #
 # TODO: Cleanup the compile definitions across all the CMake files
-set(UMF_COMMON_COMPILE_DEFINITIONS UMF_VERSION=${UMF_VERSION})
+set(UMF_COMMON_COMPILE_DEFINITIONS
+    UMF_VERSION=${UMF_VERSION}
+    UMF_ALL_CMAKE_VARIABLES="${UMF_ALL_CMAKE_VARIABLES}")
 
 add_subdirectory(utils)
 

--- a/src/utils/utils_log.c
+++ b/src/utils/utils_log.c
@@ -32,6 +32,29 @@
 #include "utils_common.h"
 #include "utils_log.h"
 
+#define UMF_MAGIC_STR "\x00@(#) "
+#define UMF_PREF_STR "Intel(R) "
+#define UMF_PREFIX UMF_MAGIC_STR UMF_PREF_STR
+
+// convert a define to a C string
+#define STR_(X) #X
+#define STR(X) STR_(X)
+
+#ifdef UMF_VERSION
+#define STR_UMF_VERSION "UMF version: " STR(UMF_VERSION)
+#define LOG_STR_UMF_VERSION STR_UMF_VERSION ", "
+char const __umf_str_2_version[] = UMF_PREFIX STR_UMF_VERSION;
+#else /* !UMF_VERSION */
+#error "UMF_VERSION not defined!"
+#endif /* !UMF_VERSION */
+
+#ifdef UMF_ALL_CMAKE_VARIABLES
+char const __umf_str_1__all_cmake_vars[] =
+    UMF_PREFIX "UMF CMake variables: " STR(UMF_ALL_CMAKE_VARIABLES);
+#else /* !UMF_ALL_CMAKE_VARIABLES */
+#error "UMF_ALL_CMAKE_VARIABLES not defined!"
+#endif /* !UMF_ALL_CMAKE_VARIABLES */
+
 #define LOG_MAX 8192
 #define LOG_HEADER 256
 #define MAX_FILE_PATH 256
@@ -305,17 +328,8 @@ void utils_log_init(void) {
         loggerConfig.flushLevel = LOG_FATAL;
     }
 
-#ifdef UMF_VERSION
-// convert a define to a C string
-#define STR_(X) #X
-#define STR(X) STR_(X)
-#define STR_UMF_VERSION "UMF version: " STR(UMF_VERSION) ", "
-#else /* !UMF_VERSION */
-#error "UMF_VERSION not defined!"
-#endif /* !UMF_VERSION */
-
     LOG_INFO(
-        "Logger enabled (" STR_UMF_VERSION
+        "Logger enabled (" LOG_STR_UMF_VERSION
         "level: %s, flush: %s, pid: %s, timestamp: %s)",
         level_to_str(loggerConfig.level), level_to_str(loggerConfig.flushLevel),
         bool_to_str(loggerConfig.pid), bool_to_str(loggerConfig.timestamp));

--- a/test/utils/utils_log.cpp
+++ b/test/utils/utils_log.cpp
@@ -110,6 +110,9 @@ const char *env_variable = "";
 #ifndef UMF_VERSION
 #define UMF_VERSION "test version"
 #endif
+#ifndef UMF_ALL_CMAKE_VARIABLES
+#define UMF_ALL_CMAKE_VARIABLES "test UMF_ALL_CMAKE_VARIABLES"
+#endif
 #include "utils/utils_log.c"
 #undef utils_env_var
 #undef fopen


### PR DESCRIPTION
### Description

Add strings with UMF version and useful CMake variables that can be grepped in the following way:

```sh
$ strings libumf.so | grep "@(#)"
@(#) Intel(R) UMF version: 0.10.0-git4.g55d6db70
@(#) Intel(R) UMF CMake variables: "CMAKE_BUILD_TYPE:Debug,UMF_BUILD_BENCHMARKS:OFF,UMF_BUILD_BENCHMARKS_MT:OFF,UMF_BUILD_CUDA_PROVIDER:ON,UMF_BUILD_EXAMPLES:ON,UMF_BUILD_FUZZTESTS:OFF,UMF_BUILD_GPU_EXAMPLES:OFF,UMF_BUILD_GPU_TESTS:OFF,UMF_BUILD_LEVEL_ZERO_PROVIDER:ON,UMF_BUILD_LIBUMF_POOL_DISJOINT:OFF,UMF_BUILD_LIBUMF_POOL_JEMALLOC:ON,UMF_BUILD_SHARED_LIBRARY:ON,UMF_BUILD_TESTS:ON,UMF_DEVELOPER_MODE:ON,UMF_DISABLE_HWLOC:OFF,UMF_FORMAT_CODE_STYLE:ON,UMF_HWLOC_NAME:hwloc,UMF_LINK_HWLOC_STATICALLY:OFF,UMF_PROXY_LIB_BASED_ON_POOL:SCALABLE,UMF_TESTS_FAIL_ON_SKIP:OFF,UMF_USE_ASAN:OFF,UMF_USE_COVERAGE:OFF,UMF_USE_MSAN:OFF,UMF_USE_TSAN:OFF,UMF_USE_UBSAN:OFF,UMF_USE_VALGRIND:OFF,"
```

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
