### PR TITLE
Add the `get_umf_debug_info.sh` script to print saved strings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,6 +239,25 @@ $ strings libumf.so | grep "@(#)"
 @(#) Intel(R) UMF CMake variables: "CMAKE_BUILD_TYPE:Debug,...
 ```
 
+or using the dedicated `scripts/get_umf_debug_info.sh` script with any user binary:
+
+```bash
+$ scripts/get_umf_debug_info.sh ./build/test/umf_test-base
+./build/test/umf_test-base is not linked with the UMF library.
+
+$ scripts/get_umf_debug_info.sh ./build/test/umf_test-ipc
+./build/test/umf_test-ipc is statically linked with the UMF library.
+Strings:
+@(#) Intel(R) UMF version: 0.10.0-git4.gbf701ee8
+@(#) Intel(R) UMF CMake variables: "CMAKE_BUILD_TYPE:Debug,UMF_BUILD_BENCHMARKS:OFF, ..."
+
+$ scripts/get_umf_debug_info.sh ./build/test/umf_test-c_api_disjoint_pool
+./build/test/umf_test-c_api_disjoint_pool is dynamically linked with the UMF library.
+Strings:
+@(#) Intel(R) UMF version: 0.10.0-git4.gbf701ee8
+@(#) Intel(R) UMF CMake variables: "CMAKE_BUILD_TYPE:Debug,UMF_BUILD_BENCHMARKS:OFF, ..."
+```
+
 #### Requirements
 
 - binutils package (Linux)

--- a/scripts/get_umf_debug_info.sh
+++ b/scripts/get_umf_debug_info.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Copyright (C) 2024 Intel Corporation
+# Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+BINARY=$1
+
+if [ "$BINARY" = "" ]; then
+	echo "Usage: $(basename $0) <binary_name>"
+	exit 1
+fi
+
+if ! which strings >/dev/null; then
+	echo "strings command not found. Please install the binutils package."
+	exit 1
+fi
+
+# check if the binary is statically linked with libumf
+# or if it is the UMF library itself
+if [ $(strings $BINARY | grep -c -e "@(#) Intel(R) UMF") -gt 0 ]; then
+	BIN_NO_LINK=$(readlink -f "$BINARY")
+	FILE_INFO=$(file $BIN_NO_LINK)
+	if [[ "$FILE_INFO" == *"libumf.so"*"ELF 64-bit LSB shared object"*"dynamically linked"* ]]; then
+		echo "$BINARY is the UMF library ($BIN_NO_LINK)."
+	else
+		echo "$BINARY is statically linked with the UMF library."
+	fi
+
+	echo "Strings in $BIN_NO_LINK:"
+	strings $BIN_NO_LINK | grep "@(#) Intel(R) UMF"
+	exit 0
+fi
+
+# check if the binary is dynamically linked with libumf
+if [ $(ldd $BINARY | grep -c -e "libumf.so") -gt 0 ]; then
+	UMF_LIB=$(ldd $BINARY | grep libumf.so | awk '{ print $3 }')
+	UMF_LIB=$(readlink -f "$UMF_LIB")
+	echo "$BINARY is dynamically linked with the UMF library ($UMF_LIB)."
+	echo "Strings in $UMF_LIB:"
+	strings $UMF_LIB | grep "@(#) Intel(R) UMF"
+	exit 0
+fi
+
+echo "$BINARY does not contain magic strings of the UMF library."


### PR DESCRIPTION
### Description

Add the `get_umf_debug_info.sh` script to print saved strings.
It can be used with any user binary:
```sh
$ scripts/get_umf_debug_info.sh ./build/test/umf_test-base
./test/umf_test-base does not contain magic strings of the UMF library.

$ scripts/get_umf_debug_info.sh ./build/test/umf_test-ipc
./test/umf_test-ipc is statically linked with the UMF library.
Strings in /mnt/wsl/files/repos/unified-memory-framework/build/test/umf_test-ipc:
@(#) Intel(R) UMF version: 0.10.0-git4.g806ce00c
@(#) Intel(R) UMF CMake variables: "CMAKE_BUILD_TYPE:Debug,UMF_BUILD_BENCHMARKS:OFF,UMF_BUILD_BENCHMARKS_MT:OFF,UMF_BUILD_CUDA_PROVIDER:ON,UMF_BUILD_EXAMPLES:ON,UMF_BUILD_FUZZTESTS:OFF,UMF_BUILD_GPU_EXAMPLES:OFF,UMF_BUILD_GPU_TESTS:OFF,UMF_BUILD_LEVEL_ZERO_PROVIDER:ON,UMF_BUILD_LIBUMF_POOL_DISJOINT:OFF,UMF_BUILD_LIBUMF_POOL_JEMALLOC:ON,UMF_BUILD_SHARED_LIBRARY:ON,UMF_BUILD_TESTS:ON,UMF_DEVELOPER_MODE:ON,UMF_DISABLE_HWLOC:OFF,UMF_FORMAT_CODE_STYLE:ON,UMF_HWLOC_NAME:hwloc,UMF_LINK_HWLOC_STATICALLY:OFF,UMF_PROXY_LIB_BASED_ON_POOL:SCALABLE,UMF_TESTS_FAIL_ON_SKIP:OFF,UMF_USE_ASAN:OFF,UMF_USE_COVERAGE:OFF,UMF_USE_MSAN:OFF,UMF_USE_TSAN:OFF,UMF_USE_UBSAN:OFF,UMF_USE_VALGRIND:OFF,"

$ scripts/get_umf_debug_info.sh ./build/test/umf_test-c_api_disjoint_pool
./test/umf_test-c_api_disjoint_pool is dynamically linked with the UMF library (/mnt/wsl/files/repos/unified-memory-framework/build/lib/libumf.so.0.10.0).
Strings in /mnt/wsl/files/repos/unified-memory-framework/build/lib/libumf.so.0.10.0:
@(#) Intel(R) UMF version: 0.10.0-git4.g806ce00c
@(#) Intel(R) UMF CMake variables: "CMAKE_BUILD_TYPE:Debug,UMF_BUILD_BENCHMARKS:OFF,UMF_BUILD_BENCHMARKS_MT:OFF,UMF_BUILD_CUDA_PROVIDER:ON,UMF_BUILD_EXAMPLES:ON,UMF_BUILD_FUZZTESTS:OFF,UMF_BUILD_GPU_EXAMPLES:OFF,UMF_BUILD_GPU_TESTS:OFF,UMF_BUILD_LEVEL_ZERO_PROVIDER:ON,UMF_BUILD_LIBUMF_POOL_DISJOINT:OFF,UMF_BUILD_LIBUMF_POOL_JEMALLOC:ON,UMF_BUILD_SHARED_LIBRARY:ON,UMF_BUILD_TESTS:ON,UMF_DEVELOPER_MODE:ON,UMF_DISABLE_HWLOC:OFF,UMF_FORMAT_CODE_STYLE:ON,UMF_HWLOC_NAME:hwloc,UMF_LINK_HWLOC_STATICALLY:OFF,UMF_PROXY_LIB_BASED_ON_POOL:SCALABLE,UMF_TESTS_FAIL_ON_SKIP:OFF,UMF_USE_ASAN:OFF,UMF_USE_COVERAGE:OFF,UMF_USE_MSAN:OFF,UMF_USE_TSAN:OFF,UMF_USE_UBSAN:OFF,UMF_USE_VALGRIND:OFF,"

$ scripts/get_umf_debug_info.sh ./build/lib/libumf.so
./build/lib/libumf.so is the UMF library (/mnt/wsl/files/repos/unified-memory-framework/build/lib/libumf.so.0.10.0).
Strings in /mnt/wsl/files/repos/unified-memory-framework/build/lib/libumf.so.0.10.0:
@(#) Intel(R) UMF version: 0.10.0-git4.g806ce00c
@(#) Intel(R) UMF CMake variables: "CMAKE_BUILD_TYPE:Debug,UMF_BUILD_BENCHMARKS:OFF,UMF_BUILD_BENCHMARKS_MT:OFF,UMF_BUILD_CUDA_PROVIDER:ON,UMF_BUILD_EXAMPLES:ON,UMF_BUILD_FUZZTESTS:OFF,UMF_BUILD_GPU_EXAMPLES:OFF,UMF_BUILD_GPU_TESTS:OFF,UMF_BUILD_LEVEL_ZERO_PROVIDER:ON,UMF_BUILD_LIBUMF_POOL_DISJOINT:OFF,UMF_BUILD_LIBUMF_POOL_JEMALLOC:ON,UMF_BUILD_SHARED_LIBRARY:ON,UMF_BUILD_TESTS:ON,UMF_DEVELOPER_MODE:ON,UMF_DISABLE_HWLOC:OFF,UMF_FORMAT_CODE_STYLE:ON,UMF_HWLOC_NAME:hwloc,UMF_LINK_HWLOC_STATICALLY:OFF,UMF_PROXY_LIB_BASED_ON_POOL:SCALABLE,UMF_TESTS_FAIL_ON_SKIP:OFF,UMF_USE_ASAN:OFF,UMF_USE_COVERAGE:OFF,UMF_USE_MSAN:OFF,UMF_USE_TSAN:OFF,UMF_USE_UBSAN:OFF,UMF_USE_VALGRIND:OFF,"
```

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
