### PR TITLE
Print more info when open() fails in the custom_file_provider example

### DIFF
--- a/examples/custom_file_provider/custom_file_provider.c
+++ b/examples/custom_file_provider/custom_file_provider.c
@@ -62,7 +62,8 @@ static umf_result_t file_init(void *params, void **provider) {
     // Open the file
     file_provider->fd = open(file_params->filename, O_RDWR | O_CREAT, 0666);
     if (file_provider->fd < 0) {
-        perror("Failed to open file");
+        perror("open()");
+        fprintf(stderr, "Failed to open the file: %s\n", file_params->filename);
         ret = UMF_RESULT_ERROR_INVALID_ARGUMENT;
         goto cleanup_malloc;
     }


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

Print more info when open() fails in the custom_file_provider example.

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
