### PR TITLE
Fix L0 provider

### DIFF
--- a/src/provider/provider_level_zero.c
+++ b/src/provider/provider_level_zero.c
@@ -336,6 +336,10 @@ static umf_result_t ze_memory_provider_initialize(void *params,
     ze_provider->device = ze_params->level_zero_device_handle;
     ze_provider->memory_type = (ze_memory_type_t)ze_params->memory_type;
 
+    memset(&ze_provider->device_properties, 0,
+           sizeof(ze_provider->device_properties));
+    ze_provider->device_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
+
     if (ze_provider->device) {
         umf_result_t ret = ze2umf_result(g_ze_ops.zeDeviceGetProperties(
             ze_provider->device, &ze_provider->device_properties));
@@ -345,9 +349,6 @@ static umf_result_t ze_memory_provider_initialize(void *params,
             umf_ba_global_free(ze_provider);
             return ret;
         }
-    } else {
-        memset(&ze_provider->device_properties, 0,
-               sizeof(ze_provider->device_properties));
     }
 
     if (ze_params->resident_device_count) {


### PR DESCRIPTION
Set device_properties.stype during init.

Found by L0 validation layer.

<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
