### PR TITLE
use the UMF version from git describe in docs, not the harcoded one

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -766,7 +766,7 @@ if(Python3_FOUND)
     add_custom_target(
         docs
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-        COMMAND ${Python3_EXECUTABLE}
+        COMMAND UMF_VERSION=${UMF_CMAKE_VERSION} ${Python3_EXECUTABLE}
                 ${UMF_CMAKE_SOURCE_DIR}/docs/generate_docs.py
         COMMENT "Generate HTML documentation using Doxygen")
 endif()

--- a/RELEASE_STEPS.md
+++ b/RELEASE_STEPS.md
@@ -39,9 +39,7 @@ Do changes for a release:
   - For major/minor release start from the `main` branch
 - Add an entry to ChangeLog, remember to change the day of the week in the release date
   - For major releases mention API and ABI compatibility with the previous release
-- Update project's version in a few places:
-  - For major and minor releases: `UMF_VERSION_CURRENT` in `include/umf/base.h` (the API version)
-  - `release` variable in `docs/config/conf.py` (for docs)
+- For major and minor releases, update `UMF_VERSION_CURRENT` in `include/umf/base.h` (the API version)
 - For major releases update ABI version in `.map` and `.def` files
   - These files are defined for all public libraries (`libumf` and `proxy_lib`, at the moment)
 - Commit these changes and tag the release:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,14 @@
 # Documentation
 
-To generate HTML documentation run the `generate_docs.py` script from any sub-dir of the
-repository (most likely `build`) or enable and use build target 'docs' (see details below).
+To generate HTML documentation, run the `generate_docs.py` script from any sub-directory of the repository (most likely `build`).
+To display the proper version of UMF in the documentation title, set the `UMF_VERSION` variable before running the script.
+
+```bash
+cd build
+$ UMF_VERSION=<your version, e.g. "0.12.1"> python ../docs/generate_docs.py
+```
+
+Documentation can also be built using the build target 'docs' (see details below).
 
 This script will create `./docs_build` sub-directory, where the intermediate and final files
 will be created. HTML docs will be in the `./docs_build/generated/html` directory.
@@ -12,13 +19,14 @@ To run documentation generation via build target use CMake commands below.
 To enable this target, python executable (in required version) has to be found in the system.
 
 ```bash
-$ cmake -B build
-$ cmake --build build --target docs
+cmake -B build
+cmake --build build --target docs
 ```
 
 ## Requirements
 
 Script to generate HTML docs requires:
- * [Doxygen](http://www.doxygen.nl/) at least v1.9.1
- * [Python](https://www.python.org/downloads/) at least v3.8
- * and python pip requirements, as defined in `third_party/requirements.txt`
+
+* [Doxygen](http://www.doxygen.nl/) at least v1.9.1
+* [Python](https://www.python.org/downloads/) at least v3.8
+* and python pip requirements, as defined in `third_party/requirements.txt`

--- a/docs/config/conf.py
+++ b/docs/config/conf.py
@@ -1,3 +1,5 @@
+import os
+
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full
@@ -18,12 +20,16 @@
 # -- Project information -----------------------------------------------------
 
 project = "Intel Unified Memory Framework"
-copyright = "2023-2024, Intel"
+copyright = "2023-2025, Intel"
 author = "Intel"
 
 # The full version, including alpha/beta/rc tags
-release = "0.11.0"
-
+release = os.getenv("UMF_VERSION", "")
+print(
+    f"UMF_VERSION used in docs: {release}"
+    if release != ""
+    else "please set UMF_VERSION environment variable before running this script"
+)
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
use the UMF version from git describe in docs, not the harcoded one

logs from the workflow on my fork:
https://github.com/bratpiorka/unified-memory-framework/actions/runs/12667121286/job/35299837634
built docs:
https://bratpiorka.github.io/unified-memory-framework/

fixes: https://github.com/oneapi-src/unified-memory-framework/issues/1024