### PR TITLE
v0.10.1 patch release - review

### DIFF
--- a/.github/workflows/reusable_basic.yml
+++ b/.github/workflows/reusable_basic.yml
@@ -8,7 +8,7 @@ permissions:
 
 env:
   # for installation testing - it should match with version set in CMake
-  UMF_VERSION: 0.10.0
+  UMF_VERSION: 0.10.1
   BUILD_DIR : "${{github.workspace}}/build"
   INSTL_DIR : "${{github.workspace}}/../install-dir"
   COVERAGE_DIR : "${{github.workspace}}/coverage"

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+Thu Jan 09 2025 Łukasz Stolarczuk <lukasz.stolarczuk@intel.com>
+
+	* Version 0.10.1
+
+	This patch release contains:
+	- Set symbol versions 0.10 in def/map files (#1013)
+	- Fix: remove incorrect assert in utils_align_ptr_up_size_down() (#977)
+	- Add strings with UMF version and useful CMake options (#992)
+	- Extended error messages, when providers are disabled (#1012)
+
 Mon Dec 09 2024 Łukasz Stolarczuk <lukasz.stolarczuk@intel.com>
 
 	* Version 0.10.0

--- a/scripts/docs_config/conf.py
+++ b/scripts/docs_config/conf.py
@@ -22,7 +22,7 @@ copyright = "2023-2024, Intel"
 author = "Intel"
 
 # The full version, including alpha/beta/rc tags
-release = "0.10.0"
+release = "0.10.1"
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
This PR is just a draft for reviewing contents of patch release v0.10.1.

It will not build, as the upstream repo doesn't have the tag. Tested on my fork with the release pushed: https://github.com/lukaszstolarczuk/unified-memory-framework/actions/runs/12690230833

\
// Testing this release in UR: https://github.com/oneapi-src/unified-runtime/pull/2537