### PR TITLE
Make ICX enabled again

### DIFF
--- a/.github/workflows/reusable_basic.yml
+++ b/.github/workflows/reusable_basic.yml
@@ -74,15 +74,15 @@ jobs:
             disable_hwloc: 'OFF'
             link_hwloc_statically: 'OFF'
           # test icx compiler
-          # - os: 'ubuntu-22.04'
-            # build_type: Release
-            # compiler: {c: icx, cxx: icpx}
-            # shared_library: 'ON'
-            # level_zero_provider: 'ON'
-            # cuda_provider: 'ON'
-            # install_tbb: 'ON'
-            # disable_hwloc: 'OFF'
-            # link_hwloc_statically: 'OFF'
+          - os: 'ubuntu-22.04'
+            build_type: Release
+            compiler: {c: icx, cxx: icpx}
+            shared_library: 'ON'
+            level_zero_provider: 'ON'
+            cuda_provider: 'ON'
+            install_tbb: 'ON'
+            disable_hwloc: 'OFF'
+            link_hwloc_statically: 'OFF'
           # test without installing TBB
           - os: 'ubuntu-22.04'
             build_type: Release

--- a/.github/workflows/reusable_basic.yml
+++ b/.github/workflows/reusable_basic.yml
@@ -182,8 +182,7 @@ jobs:
     - name: Run tests
       working-directory: ${{env.BUILD_DIR}}
       run: |
-        ${{ matrix.compiler.cxx == 'icpx' && '. /opt/intel/oneapi/setvars.sh' || true }}
-        ctest --output-on-failure # run all tests for better coverage
+        LD_LIBRARY_PATH=${{env.BUILD_DIR}}/lib/ ctest --output-on-failure # run all tests for better coverage
 
     - name: Check coverage
       if:  ${{ matrix.build_type == 'Debug' && matrix.compiler.c == 'gcc' }}

--- a/.github/workflows/reusable_sanitizers.yml
+++ b/.github/workflows/reusable_sanitizers.yml
@@ -77,7 +77,6 @@ jobs:
         ASAN_OPTIONS: allocator_may_return_null=1
         TSAN_OPTIONS: allocator_may_return_null=1
       run: |
-        ${{ matrix.compiler.cxx == 'icpx' && '. /opt/intel/oneapi/setvars.sh' || true }}
         ctest --output-on-failure
 
   windows-build:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,12 @@ include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 find_package(PkgConfig)
 
+if(CMAKE_C_COMPILER_ID STREQUAL "IntelLLVM")
+    # Compiler dependencies needs to be in library path or to be linked
+    # statically
+    add_link_options(-static-intel)
+endif()
+
 # Build Options
 option(UMF_BUILD_SHARED_LIBRARY "Build UMF as shared library" OFF)
 option(UMF_BUILD_LEVEL_ZERO_PROVIDER "Build Level Zero memory provider" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,12 +33,6 @@ include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 find_package(PkgConfig)
 
-if(CMAKE_C_COMPILER_ID STREQUAL "IntelLLVM")
-    # Compiler dependencies needs to be in library path or to be linked
-    # statically
-    add_link_options(-static-intel)
-endif()
-
 # Build Options
 option(UMF_BUILD_SHARED_LIBRARY "Build UMF as shared library" OFF)
 option(UMF_BUILD_LEVEL_ZERO_PROVIDER "Build Level Zero memory provider" ON)

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 Intel Corporation
+# Copyright (C) 2023-2025 Intel Corporation
 # Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -378,6 +378,9 @@ function(add_umf_library)
         elseif(LINUX)
             target_link_options(${ARG_NAME} PRIVATE
                                 "-Wl,--version-script=${ARG_LINUX_MAP_FILE}")
+            if(CMAKE_C_COMPILER_ID STREQUAL "IntelLLVM")
+                target_link_options(${ARG_NAME} PRIVATE -no-intel-lib)
+            endif()
         endif()
     endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,9 +1,15 @@
-# Copyright (C) 2022-2024 Intel Corporation
+# Copyright (C) 2022-2025 Intel Corporation
 # Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
+
+if(CMAKE_C_COMPILER_ID STREQUAL "IntelLLVM")
+    # Compiler dependencies needs to be in library path or to be linked
+    # statically
+    add_link_options(-static-intel)
+endif()
 
 include(FetchContent)
 FetchContent_Declare(


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description
There is a problem with linkage under icx/icpx due to linking against compiler libs.
When executing tests without sourced paths to compiler (prevents from loading compiler version of UMF) there are errors of missing symbols/libs.

### Considerations
There was 2 options:
- link statically against compiler dependencies using `-static-intel`
- omit linking Intel compiler extensions with `-no-intel-lib` ([more info](https://www.intel.com/content/www/us/en/docs/cpp-compiler/developer-guide-reference/2021-8/no-intel-lib-qno-intel-lib.html)) or using another option `-Wl,-as-needed'`

First works like a charm, but the UMF contains icx/icpx needed dependencies compiled in, I don't know it's a problem or not. 
Last option require to force `gtest` to compile the same way - without Intel compiler dependencies (e.g. `svml`, `imf` etc). According to `gtest` documentation we can share `CMAKE_(C/CXX)_FLAGS`. Another approach is to split steps and apply patch.

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

Fixes #843

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
