### PR TITLE
Minor updates around versioning

### DIFF
--- a/RELEASE_STEPS.md
+++ b/RELEASE_STEPS.md
@@ -49,6 +49,10 @@ Do changes for a release:
   - If stable branch for this release is required, create it:
     - `git checkout -b v$VER.x`
     - For some early versions (like `0.1.0`) we may omit creation of the branch
+- For major/minor release, when release is done, add an extra "dev" tag on the `main` branch:
+  - `git tag -a -s -m "Development version $VERSION+1" v$VERSION+1-dev`
+    - for example, when `v0.1.0` is released, the dev tag would be `v0.2.0-dev`
+  - This way, the `main` branch will introduce itself as the next version
 
 ## Publish changes
 

--- a/RELEASE_STEPS.md
+++ b/RELEASE_STEPS.md
@@ -52,6 +52,7 @@ Do changes for a release:
 - For major/minor release, when release is done, add an extra "dev" tag on the `main` branch:
   - `git tag -a -s -m "Development version $VERSION+1" v$VERSION+1-dev`
     - for example, when `v0.1.0` is released, the dev tag would be `v0.2.0-dev`
+    - if needed, further in time, an extra dev tag can be introduced, e.g. `v0.2.0-dev1`
   - This way, the `main` branch will introduce itself as the next version
 
 ## Publish changes

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -121,12 +121,12 @@ function(set_version_variables)
         return()
     endif()
 
-    # v1.5.0-dev - we're on a development tag -> UMF ver: "1.5.0-dev"
-    string(REGEX MATCHALL "\^v([0-9]+\.[0-9]+\.[0-9]+)-dev\$" MATCHES
+    # v1.5.0-dev1 - we're on a development tag -> UMF ver: "1.5.0-dev1"
+    string(REGEX MATCHALL "\^v([0-9]+\.[0-9]+\.[0-9]+)-(dev[0-9]?)\$" MATCHES
                  ${GIT_VERSION})
     if(MATCHES)
         set(UMF_VERSION
-            "${CMAKE_MATCH_1}-dev"
+            "${CMAKE_MATCH_1}-${CMAKE_MATCH_2}"
             PARENT_SCOPE)
         set(UMF_CMAKE_VERSION
             "${CMAKE_MATCH_1}"
@@ -157,12 +157,12 @@ function(set_version_variables)
         return()
     endif()
 
-    # v1.5.0-dev-19-gb8f7a32 -> UMF ver: "1.5.0-dev.git19.gb8f7a32"
-    string(REGEX MATCHALL "v([0-9.]*)-dev-([0-9]*)-([0-9a-g]*)" MATCHES
+    # v1.5.0-dev2-19-gb8f7a32 -> UMF ver: "1.5.0-dev2.git19.gb8f7a32"
+    string(REGEX MATCHALL "v([0-9.]*)-(dev[0-9]?)-([0-9]*)-([0-9a-g]*)" MATCHES
                  ${GIT_VERSION})
     if(MATCHES)
         set(UMF_VERSION
-            "${CMAKE_MATCH_1}-dev.git${CMAKE_MATCH_2}.${CMAKE_MATCH_3}"
+            "${CMAKE_MATCH_1}-${CMAKE_MATCH_2}.git${CMAKE_MATCH_3}.${CMAKE_MATCH_4}"
             PARENT_SCOPE)
         set(UMF_CMAKE_VERSION
             "${CMAKE_MATCH_1}"

--- a/src/libumf.def
+++ b/src/libumf.def
@@ -31,9 +31,6 @@ EXPORTS
     umfFileMemoryProviderParamsSetPath
     umfFileMemoryProviderParamsSetProtection
     umfFileMemoryProviderParamsSetVisibility
-    umfFixedMemoryProviderOps
-    umfFixedMemoryProviderParamsCreate
-    umfFixedMemoryProviderParamsDestroy
     umfFree
     umfGetIPCHandle
     umfGetLastFailedMemoryProvider
@@ -121,4 +118,7 @@ EXPORTS
     umfScalablePoolParamsSetGranularity
     umfScalablePoolParamsSetKeepAllMemory
 ; Added in UMF_0.11
+    umfFixedMemoryProviderOps
+    umfFixedMemoryProviderParamsCreate
+    umfFixedMemoryProviderParamsDestroy
     umfLevelZeroMemoryProviderParamsSetFreePolicy


### PR DESCRIPTION
### Description
Each commit introduces a small update around versioning.

Comment about additional `-devX` tags (from commit msg):
```
-devX tag may be required when e.g. a first -dev tag was "replaced"
with new patch release incoming from stable branch into main.
E.g., at this moment, the main branch is introduced as v0.10.1-...
instead of v0.11.0-dev... and this is not desired.
```

Locally tested:
`UMF version: 0.99.1-dev`
`UMF version: 0.99.1-dev.git1.gc184e8e2`
`UMF version: 0.99.2-dev3.git3.gc184e8e2`

After this change is merged I'll "fix" our main branch with proper versioning with a new dev tag `v0.11.0-dev1`.

### Checklist
- [x] Code compiles without errors locally
- [x] CI workflows execute properly