### PR TITLE
Fix disjoint_pool unit tests

### DIFF
--- a/test/pools/disjoint_pool.cpp
+++ b/test/pools/disjoint_pool.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -61,14 +61,14 @@ TEST_F(test, freeErrorPropagation) {
     static umf_result_t expectedResult = UMF_RESULT_SUCCESS;
     struct memory_provider : public umf_test::provider_base_t {
         umf_result_t alloc(size_t size, size_t, void **ptr) noexcept {
-            *ptr = malloc(size);
+            *ptr = umf_ba_global_alloc(size);
             return UMF_RESULT_SUCCESS;
         }
 
         umf_result_t free(void *ptr, [[maybe_unused]] size_t size) noexcept {
             // do the actual free only when we expect the success
             if (expectedResult == UMF_RESULT_SUCCESS) {
-                ::free(ptr);
+                umf_ba_global_free(ptr);
             }
             return expectedResult;
         }
@@ -114,12 +114,12 @@ TEST_F(test, sharedLimits) {
 
     struct memory_provider : public umf_test::provider_base_t {
         umf_result_t alloc(size_t size, size_t, void **ptr) noexcept {
-            *ptr = malloc(size);
+            *ptr = umf_ba_global_alloc(size);
             numAllocs++;
             return UMF_RESULT_SUCCESS;
         }
         umf_result_t free(void *ptr, [[maybe_unused]] size_t size) noexcept {
-            ::free(ptr);
+            umf_ba_global_free(ptr);
             numFrees++;
             return UMF_RESULT_SUCCESS;
         }


### PR DESCRIPTION

### Description

The UMF tests should not use the default system allocator to allocate memory, because they may not work correctly under the UMF proxy library when they and the proxy library are dynamically linked with the same libumf.so file.

In such case the same tracker is used in both: the test and the proxy library, so there may be conflicts of memory allocations. An allocation made originally by the the default system allocator in the test is first added to the tracker by the proxy library (which replaced the system allocator) and then the test itself tries to add the same pointer to the same tracker in the tracking provider of the pool that had made this allocation.

Fixes: #240

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
