### PR TITLE
do not use global ctor/dtor for test params

### DIFF
--- a/test/ipcAPI.cpp
+++ b/test/ipcAPI.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // This file contains tests for UMF pool API
@@ -115,5 +115,6 @@ HostMemoryAccessor hostMemoryAccessor;
 
 INSTANTIATE_TEST_SUITE_P(umfIpcTestSuite, umfIpcTest,
                          ::testing::Values(ipcTestParams{
-                             umfProxyPoolOps(), nullptr, &IPC_MOCK_PROVIDER_OPS,
-                             nullptr, &hostMemoryAccessor}));
+                             umfProxyPoolOps(), nullptr, nullptr,
+                             &IPC_MOCK_PROVIDER_OPS, nullptr, nullptr,
+                             &hostMemoryAccessor}));

--- a/test/memoryPoolAPI.cpp
+++ b/test/memoryPoolAPI.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // This file contains tests for UMF pool API
@@ -295,15 +295,17 @@ TEST_F(tagTest, SetAndGetInvalidPool) {
 
 INSTANTIATE_TEST_SUITE_P(
     mallocPoolTest, umfPoolTest,
-    ::testing::Values(poolCreateExtParams{&MALLOC_POOL_OPS, nullptr,
-                                          &UMF_NULL_PROVIDER_OPS, nullptr},
-                      poolCreateExtParams{umfProxyPoolOps(), nullptr,
-                                          &BA_GLOBAL_PROVIDER_OPS, nullptr}));
+    ::testing::Values(poolCreateExtParams{&MALLOC_POOL_OPS, nullptr, nullptr,
+                                          &UMF_NULL_PROVIDER_OPS, nullptr,
+                                          nullptr},
+                      poolCreateExtParams{umfProxyPoolOps(), nullptr, nullptr,
+                                          &BA_GLOBAL_PROVIDER_OPS, nullptr,
+                                          nullptr}));
 
 INSTANTIATE_TEST_SUITE_P(mallocMultiPoolTest, umfMultiPoolTest,
                          ::testing::Values(poolCreateExtParams{
-                             umfProxyPoolOps(), nullptr,
-                             &BA_GLOBAL_PROVIDER_OPS, nullptr}));
+                             umfProxyPoolOps(), nullptr, nullptr,
+                             &BA_GLOBAL_PROVIDER_OPS, nullptr, nullptr}));
 
 INSTANTIATE_TEST_SUITE_P(umfPoolWithCreateFlagsTest, umfPoolWithCreateFlagsTest,
                          ::testing::Values(0,

--- a/test/pools/disjoint_pool.cpp
+++ b/test/pools/disjoint_pool.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -11,16 +11,12 @@
 #include "provider_null.h"
 #include "provider_trace.h"
 
-using disjoint_params_unique_handle_t =
-    std::unique_ptr<umf_disjoint_pool_params_t,
-                    decltype(&umfDisjointPoolParamsDestroy)>;
-
 static constexpr size_t DEFAULT_DISJOINT_SLAB_MIN_SIZE = 4096;
 static constexpr size_t DEFAULT_DISJOINT_MAX_POOLABLE_SIZE = 4096;
 static constexpr size_t DEFAULT_DISJOINT_CAPACITY = 4;
 static constexpr size_t DEFAULT_DISJOINT_MIN_BUCKET_SIZE = 64;
 
-disjoint_params_unique_handle_t poolConfig() {
+void *defaultPoolConfig() {
     umf_disjoint_pool_params_handle_t config = nullptr;
     umf_result_t res = umfDisjointPoolParamsCreate(&config);
     if (res != UMF_RESULT_SUCCESS) {
@@ -50,8 +46,12 @@ disjoint_params_unique_handle_t poolConfig() {
         throw std::runtime_error("Failed to set min bucket size");
     }
 
-    return disjoint_params_unique_handle_t(config,
-                                           &umfDisjointPoolParamsDestroy);
+    return config;
+}
+
+umf_result_t poolConfigDestroy(void *config) {
+    return umfDisjointPoolParamsDestroy(
+        static_cast<umf_disjoint_pool_params_handle_t>(config));
 }
 
 using umf_test::test;
@@ -83,16 +83,20 @@ TEST_F(test, freeErrorPropagation) {
     provider_handle = providerUnique.get();
 
     // force all allocations to go to memory provider
-    disjoint_params_unique_handle_t params = poolConfig();
-    umf_result_t retp =
-        umfDisjointPoolParamsSetMaxPoolableSize(params.get(), 0);
+    umf_disjoint_pool_params_handle_t params;
+    umf_result_t retp = umfDisjointPoolParamsCreate(&params);
+    EXPECT_EQ(retp, UMF_RESULT_SUCCESS);
+    retp = umfDisjointPoolParamsSetMaxPoolableSize(params, 0);
     EXPECT_EQ(retp, UMF_RESULT_SUCCESS);
 
     umf_memory_pool_handle_t pool = NULL;
-    retp = umfPoolCreate(umfDisjointPoolOps(), provider_handle, params.get(), 0,
-                         &pool);
+    retp =
+        umfPoolCreate(umfDisjointPoolOps(), provider_handle, params, 0, &pool);
     EXPECT_EQ(retp, UMF_RESULT_SUCCESS);
     auto poolHandle = umf_test::wrapPoolUnique(pool);
+
+    retp = umfDisjointPoolParamsDestroy(params);
+    EXPECT_EQ(retp, UMF_RESULT_SUCCESS);
 
     static constexpr size_t size = 1024;
     void *ptr = umfPoolMalloc(pool, size);
@@ -114,12 +118,12 @@ TEST_F(test, sharedLimits) {
 
     struct memory_provider : public umf_test::provider_base_t {
         umf_result_t alloc(size_t size, size_t, void **ptr) noexcept {
-            *ptr = malloc(size);
+            *ptr = umf_ba_global_alloc(size);
             numAllocs++;
             return UMF_RESULT_SUCCESS;
         }
         umf_result_t free(void *ptr, [[maybe_unused]] size_t size) noexcept {
-            ::free(ptr);
+            umf_ba_global_free(ptr);
             numFrees++;
             return UMF_RESULT_SUCCESS;
         }
@@ -130,9 +134,9 @@ TEST_F(test, sharedLimits) {
     static constexpr size_t SlabMinSize = 1024;
     static constexpr size_t MaxSize = 4 * SlabMinSize;
 
-    disjoint_params_unique_handle_t config = poolConfig();
-    umf_result_t ret =
-        umfDisjointPoolParamsSetSlabMinSize(config.get(), SlabMinSize);
+    umf_disjoint_pool_params_handle_t params =
+        (umf_disjoint_pool_params_handle_t)defaultPoolConfig();
+    umf_result_t ret = umfDisjointPoolParamsSetSlabMinSize(params, SlabMinSize);
     EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
 
     auto limits =
@@ -141,7 +145,7 @@ TEST_F(test, sharedLimits) {
             umfDisjointPoolSharedLimitsCreate(MaxSize),
             &umfDisjointPoolSharedLimitsDestroy);
 
-    ret = umfDisjointPoolParamsSetSharedLimits(config.get(), limits.get());
+    ret = umfDisjointPoolParamsSetSharedLimits(params, limits.get());
     EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
 
     auto provider =
@@ -149,15 +153,18 @@ TEST_F(test, sharedLimits) {
 
     umf_memory_pool_handle_t pool1 = NULL;
     umf_memory_pool_handle_t pool2 = NULL;
-    ret = umfPoolCreate(umfDisjointPoolOps(), provider.get(),
-                        (void *)config.get(), 0, &pool1);
+    ret =
+        umfPoolCreate(umfDisjointPoolOps(), provider.get(), params, 0, &pool1);
     EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
     auto poolHandle1 = umf_test::wrapPoolUnique(pool1);
 
-    ret = umfPoolCreate(umfDisjointPoolOps(), provider.get(),
-                        (void *)config.get(), 0, &pool2);
+    ret =
+        umfPoolCreate(umfDisjointPoolOps(), provider.get(), params, 0, &pool2);
     EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
     auto poolHandle2 = umf_test::wrapPoolUnique(pool2);
+
+    ret = umfDisjointPoolParamsDestroy(params);
+    EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
 
     EXPECT_EQ(0, numAllocs);
     EXPECT_EQ(0, numFrees);
@@ -243,23 +250,24 @@ TEST_F(test, disjointPoolInvalidBucketSize) {
     umfDisjointPoolParamsDestroy(params);
 }
 
-disjoint_params_unique_handle_t defaultPoolConfig = poolConfig();
 INSTANTIATE_TEST_SUITE_P(disjointPoolTests, umfPoolTest,
                          ::testing::Values(poolCreateExtParams{
-                             umfDisjointPoolOps(),
-                             (void *)defaultPoolConfig.get(),
-                             &BA_GLOBAL_PROVIDER_OPS, nullptr}));
+                             umfDisjointPoolOps(), defaultPoolConfig,
+                             poolConfigDestroy, &BA_GLOBAL_PROVIDER_OPS,
+                             nullptr, nullptr}));
+
+void *memProviderParams() { return (void *)&DEFAULT_DISJOINT_CAPACITY; }
 
 INSTANTIATE_TEST_SUITE_P(
     disjointPoolTests, umfMemTest,
     ::testing::Values(std::make_tuple(
-        poolCreateExtParams{
-            umfDisjointPoolOps(), (void *)defaultPoolConfig.get(),
-            &MOCK_OUT_OF_MEM_PROVIDER_OPS, (void *)&DEFAULT_DISJOINT_CAPACITY},
+        poolCreateExtParams{umfDisjointPoolOps(), defaultPoolConfig,
+                            poolConfigDestroy, &MOCK_OUT_OF_MEM_PROVIDER_OPS,
+                            memProviderParams, nullptr},
         static_cast<int>(DEFAULT_DISJOINT_CAPACITY) / 2)));
 
 INSTANTIATE_TEST_SUITE_P(disjointMultiPoolTests, umfMultiPoolTest,
                          ::testing::Values(poolCreateExtParams{
-                             umfDisjointPoolOps(),
-                             (void *)defaultPoolConfig.get(),
-                             &BA_GLOBAL_PROVIDER_OPS, nullptr}));
+                             umfDisjointPoolOps(), defaultPoolConfig,
+                             poolConfigDestroy, &BA_GLOBAL_PROVIDER_OPS,
+                             nullptr, nullptr}));

--- a/test/pools/jemalloc_coarse_devdax.cpp
+++ b/test/pools/jemalloc_coarse_devdax.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2025 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -7,17 +7,19 @@
 
 #include "pool_coarse.hpp"
 
-using devdax_params_unique_handle_t =
-    std::unique_ptr<umf_devdax_memory_provider_params_t,
-                    decltype(&umfDevDaxMemoryProviderParamsDestroy)>;
-
-devdax_params_unique_handle_t create_devdax_params() {
+bool devDaxEnvSet() {
     char *path = getenv("UMF_TESTS_DEVDAX_PATH");
     char *size = getenv("UMF_TESTS_DEVDAX_SIZE");
     if (path == nullptr || path[0] == 0 || size == nullptr || size[0] == 0) {
-        return devdax_params_unique_handle_t(
-            nullptr, &umfDevDaxMemoryProviderParamsDestroy);
+        return false;
     }
+
+    return true;
+}
+
+void *createDevDaxParams() {
+    char *path = getenv("UMF_TESTS_DEVDAX_PATH");
+    char *size = getenv("UMF_TESTS_DEVDAX_SIZE");
 
     umf_devdax_memory_provider_params_handle_t params = NULL;
     umf_result_t res =
@@ -27,17 +29,16 @@ devdax_params_unique_handle_t create_devdax_params() {
             "Failed to create DevDax Memory Provider params");
     }
 
-    return devdax_params_unique_handle_t(params,
-                                         &umfDevDaxMemoryProviderParamsDestroy);
+    return params;
 }
 
-auto devdaxParams = create_devdax_params();
-
 static std::vector<poolCreateExtParams> poolParamsList =
-    devdaxParams.get() ? std::vector<poolCreateExtParams>{poolCreateExtParams{
-                             umfJemallocPoolOps(), nullptr,
-                             umfDevDaxMemoryProviderOps(), devdaxParams.get()}}
-                       : std::vector<poolCreateExtParams>{};
+    devDaxEnvSet()
+        ? std::vector<poolCreateExtParams>{poolCreateExtParams{
+              umfJemallocPoolOps(), nullptr, nullptr,
+              umfDevDaxMemoryProviderOps(), createDevDaxParams,
+              (pfnProviderParamsDestroy)umfDevDaxMemoryProviderParamsDestroy}}
+        : std::vector<poolCreateExtParams>{};
 
 INSTANTIATE_TEST_SUITE_P(jemallocCoarseDevDaxTest, umfPoolTest,
                          ::testing::ValuesIn(poolParamsList));

--- a/test/pools/jemalloc_coarse_file.cpp
+++ b/test/pools/jemalloc_coarse_file.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2025 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -7,25 +7,25 @@
 
 #include "pool_coarse.hpp"
 
-using file_params_unique_handle_t =
-    std::unique_ptr<umf_file_memory_provider_params_t,
-                    decltype(&umfFileMemoryProviderParamsDestroy)>;
-
-file_params_unique_handle_t get_file_params_default(char *path) {
+void *getFileParamsDefault() {
     umf_file_memory_provider_params_handle_t file_params = NULL;
-    umf_result_t res = umfFileMemoryProviderParamsCreate(&file_params, path);
+    umf_result_t res =
+        umfFileMemoryProviderParamsCreate(&file_params, FILE_PATH);
     if (res != UMF_RESULT_SUCCESS) {
         throw std::runtime_error(
             "Failed to create File Memory Provider params");
     }
 
-    return file_params_unique_handle_t(file_params,
-                                       &umfFileMemoryProviderParamsDestroy);
+    return file_params;
 }
 
-file_params_unique_handle_t fileParams = get_file_params_default(FILE_PATH);
+umf_result_t destroyFileParams(void *params) {
+    return umfFileMemoryProviderParamsDestroy(
+        (umf_file_memory_provider_params_handle_t)params);
+}
 
 INSTANTIATE_TEST_SUITE_P(jemallocCoarseFileTest, umfPoolTest,
                          ::testing::Values(poolCreateExtParams{
-                             umfJemallocPoolOps(), nullptr,
-                             umfFileMemoryProviderOps(), fileParams.get()}));
+                             umfJemallocPoolOps(), nullptr, nullptr,
+                             umfFileMemoryProviderOps(), getFileParamsDefault,
+                             destroyFileParams}));

--- a/test/pools/jemalloc_pool.cpp
+++ b/test/pools/jemalloc_pool.cpp
@@ -15,21 +15,26 @@ using os_params_unique_handle_t =
     std::unique_ptr<umf_os_memory_provider_params_t,
                     decltype(&umfOsMemoryProviderParamsDestroy)>;
 
-os_params_unique_handle_t createOsMemoryProviderParams() {
+void *createOsMemoryProviderParams() {
     umf_os_memory_provider_params_handle_t params = nullptr;
     umf_result_t res = umfOsMemoryProviderParamsCreate(&params);
     if (res != UMF_RESULT_SUCCESS) {
         throw std::runtime_error("Failed to create os memory provider params");
     }
 
-    return os_params_unique_handle_t(params, &umfOsMemoryProviderParamsDestroy);
+    return params;
 }
-auto defaultParams = createOsMemoryProviderParams();
 
-INSTANTIATE_TEST_SUITE_P(jemallocPoolTest, umfPoolTest,
-                         ::testing::Values(poolCreateExtParams{
-                             umfJemallocPoolOps(), nullptr,
-                             umfOsMemoryProviderOps(), defaultParams.get()}));
+umf_result_t destroyOsMemoryProviderParams(void *params) {
+    return umfOsMemoryProviderParamsDestroy(
+        (umf_os_memory_provider_params_handle_t)params);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    jemallocPoolTest, umfPoolTest,
+    ::testing::Values(poolCreateExtParams{
+        umfJemallocPoolOps(), nullptr, nullptr, umfOsMemoryProviderOps(),
+        createOsMemoryProviderParams, destroyOsMemoryProviderParams}));
 
 // this test makes sure that jemalloc does not use
 // memory provider to allocate metadata (and hence
@@ -41,17 +46,41 @@ TEST_F(test, metadataNotAllocatedUsingProvider) {
 
     // set coarse grain allocations to PROT_NONE so that we can be sure
     // jemalloc does not touch any of the allocated memory
-    umf_os_memory_provider_params_handle_t params = nullptr;
-    umf_result_t res = umfOsMemoryProviderParamsCreate(&params);
-    ASSERT_EQ(res, UMF_RESULT_SUCCESS);
-    res = umfOsMemoryProviderParamsSetProtection(params, UMF_PROTECTION_NONE);
-    ASSERT_EQ(res, UMF_RESULT_SUCCESS);
 
-    auto pool = poolCreateExtUnique(
-        {umfJemallocPoolOps(), nullptr, umfOsMemoryProviderOps(), params});
+    auto providerParamsCreate = []() {
+        umf_os_memory_provider_params_handle_t params = nullptr;
+        umf_result_t res = umfOsMemoryProviderParamsCreate(&params);
+        if (res != UMF_RESULT_SUCCESS) {
+            throw std::runtime_error(
+                "Failed to create OS Memory Provider params");
+        }
+        res =
+            umfOsMemoryProviderParamsSetProtection(params, UMF_PROTECTION_NONE);
+        if (res != UMF_RESULT_SUCCESS) {
+            throw std::runtime_error(
+                "Failed to set OS Memory Provider params protection");
+        }
+        return (void *)params;
+    };
 
-    res = umfOsMemoryProviderParamsDestroy(params);
-    ASSERT_EQ(res, UMF_RESULT_SUCCESS);
+    auto providerParamsDestroy = [](void *params) {
+        umf_result_t res = umfOsMemoryProviderParamsDestroy(
+            (umf_os_memory_provider_params_handle_t)params);
+        if (res != UMF_RESULT_SUCCESS) {
+            throw std::runtime_error(
+                "Failed to destroy OS Memory Provider params");
+        }
+        return res;
+    };
+
+    auto pool = poolCreateExtUnique({
+        umfJemallocPoolOps(),
+        nullptr,
+        nullptr,
+        umfOsMemoryProviderOps(),
+        (pfnProviderParamsCreate)providerParamsCreate,
+        (pfnProviderParamsDestroy)providerParamsDestroy,
+    });
 
     std::vector<std::shared_ptr<void>> allocs;
     for (size_t i = 0; i < numAllocs; i++) {

--- a/test/pools/pool_base_alloc.cpp
+++ b/test/pools/pool_base_alloc.cpp
@@ -47,5 +47,5 @@ umf_memory_pool_ops_t BA_POOL_OPS = umf::poolMakeCOps<base_alloc_pool, void>();
 
 INSTANTIATE_TEST_SUITE_P(baPool, umfPoolTest,
                          ::testing::Values(poolCreateExtParams{
-                             &BA_POOL_OPS, nullptr,
-                             &umf_test::BASE_PROVIDER_OPS, nullptr}));
+                             &BA_POOL_OPS, nullptr, nullptr,
+                             &umf_test::BASE_PROVIDER_OPS, nullptr, nullptr}));

--- a/test/pools/scalable_coarse_file.cpp
+++ b/test/pools/scalable_coarse_file.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2025 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -7,25 +7,25 @@
 
 #include "pool_coarse.hpp"
 
-using file_params_unique_handle_t =
-    std::unique_ptr<umf_file_memory_provider_params_t,
-                    decltype(&umfFileMemoryProviderParamsDestroy)>;
-
-file_params_unique_handle_t get_file_params_default(char *path) {
+void *getFileParamsDefault() {
     umf_file_memory_provider_params_handle_t file_params = NULL;
-    umf_result_t res = umfFileMemoryProviderParamsCreate(&file_params, path);
+    umf_result_t res =
+        umfFileMemoryProviderParamsCreate(&file_params, FILE_PATH);
     if (res != UMF_RESULT_SUCCESS) {
         throw std::runtime_error(
             "Failed to create File Memory Provider params");
     }
 
-    return file_params_unique_handle_t(file_params,
-                                       &umfFileMemoryProviderParamsDestroy);
+    return file_params;
 }
 
-file_params_unique_handle_t fileParams = get_file_params_default(FILE_PATH);
+umf_result_t destroyFileParams(void *params) {
+    return umfFileMemoryProviderParamsDestroy(
+        (umf_file_memory_provider_params_handle_t)params);
+}
 
 INSTANTIATE_TEST_SUITE_P(scalableCoarseFileTest, umfPoolTest,
                          ::testing::Values(poolCreateExtParams{
-                             umfScalablePoolOps(), nullptr,
-                             umfFileMemoryProviderOps(), fileParams.get()}));
+                             umfScalablePoolOps(), nullptr, nullptr,
+                             umfFileMemoryProviderOps(), getFileParamsDefault,
+                             destroyFileParams}));

--- a/test/pools/scalable_pool.cpp
+++ b/test/pools/scalable_pool.cpp
@@ -9,25 +9,26 @@
 #include "poolFixtures.hpp"
 #include "provider.hpp"
 
-using os_params_unique_handle_t =
-    std::unique_ptr<umf_os_memory_provider_params_t,
-                    decltype(&umfOsMemoryProviderParamsDestroy)>;
-
-os_params_unique_handle_t createOsMemoryProviderParams() {
+void *createOsMemoryProviderParams() {
     umf_os_memory_provider_params_handle_t params = nullptr;
     umf_result_t res = umfOsMemoryProviderParamsCreate(&params);
     if (res != UMF_RESULT_SUCCESS) {
         throw std::runtime_error("Failed to create os memory provider params");
     }
 
-    return os_params_unique_handle_t(params, &umfOsMemoryProviderParamsDestroy);
+    return params;
 }
-auto defaultParams = createOsMemoryProviderParams();
 
-INSTANTIATE_TEST_SUITE_P(scalablePoolTest, umfPoolTest,
-                         ::testing::Values(poolCreateExtParams{
-                             umfScalablePoolOps(), nullptr,
-                             umfOsMemoryProviderOps(), defaultParams.get()}));
+umf_result_t destroyOsMemoryProviderParams(void *params) {
+    return umfOsMemoryProviderParamsDestroy(
+        (umf_os_memory_provider_params_handle_t)params);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    scalablePoolTest, umfPoolTest,
+    ::testing::Values(poolCreateExtParams{
+        umfScalablePoolOps(), nullptr, nullptr, umfOsMemoryProviderOps(),
+        createOsMemoryProviderParams, destroyOsMemoryProviderParams}));
 
 using scalablePoolParams = std::tuple<size_t, bool>;
 struct umfScalablePoolParamsTest


### PR DESCRIPTION
Do not use global constructor/destructors for test params.

### Description
Currently, all provider and pool tests use parameters created during the instantiation phase, with automatic destructors called upon program exit. The problem occurs when the creation of some parameters requires our global base allocator (in the case for the Disjoint Pool in the C version - not merged yet). In this scenario, the global base allocator's free() function could be called after the deletion of the entire global base allocator, because we cannot guarantee the correct order of destructors. Additionally, in the failing scenario, the base allocator's debug checks will report memory leaks.

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [ ] CI workflows execute properly

