### PR TITLE
Check return value of set_context()

### DIFF
--- a/src/provider/provider_cuda.c
+++ b/src/provider/provider_cuda.c
@@ -594,7 +594,10 @@ static umf_result_t cu_memory_provider_open_ipc_handle(void *provider,
         LOG_ERR("cuIpcOpenMemHandle() failed.");
     }
 
-    set_context(restore_ctx, &restore_ctx);
+    umf_result = set_context(restore_ctx, &restore_ctx);
+    if (umf_result != UMF_RESULT_SUCCESS) {
+        LOG_ERR("Failed to restore CUDA context, ret = %d", umf_result);
+    }
 
     return cu2umf_result(cu_result);
 }


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

Check return value of set_context() in
cu_memory_provider_open_ipc_handle().

It fixes a Coverity issue no. 473892

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
