### PR TITLE
Add backward compatibility workflow and tests

### DIFF
--- a/.github/workflows/pr_push.yml
+++ b/.github/workflows/pr_push.yml
@@ -85,3 +85,11 @@ jobs:
       contents: read
       security-events: write
     uses: ./.github/workflows/reusable_trivy.yml
+  Compatibility:
+    needs: [Build]
+    uses: ./.github/workflows/reusable_compatibility.yml
+    strategy:
+      matrix:
+        tag: ["v0.10.1"]
+    with:
+      tag: ${{matrix.tag}}

--- a/.github/workflows/reusable_compatibility.yml
+++ b/.github/workflows/reusable_compatibility.yml
@@ -1,0 +1,224 @@
+# Workflow for checkig the backward compatibility of UMF.
+# Test the latest UMF shared library with binaries compiled using the older UMF 
+# shared library.
+name: Compatibility 
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Check backward compatibility with this tag
+        type: string
+        default: "v0.10.1"
+
+permissions:
+  contents: read
+
+jobs:
+  ubuntu-build:
+    name: Ubuntu
+    runs-on: 'ubuntu-22.04'
+
+    steps:
+      # NOTE: we need jemalloc for older version of UMF
+    - name: Install apt packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang cmake libnuma-dev libjemalloc-dev libtbb-dev
+
+    - name: Checkout "tag" UMF version
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        fetch-depth: 0
+        ref: refs/tags/${{inputs.tag}}
+        path: ${{github.workspace}}/tag_version
+
+    - name: Install libhwloc
+      working-directory: ${{github.workspace}}/tag_version
+      run: .github/scripts/install_hwloc.sh
+        
+    - name: Get "tag" UMF version
+      working-directory: ${{github.workspace}}/tag_version
+      run: |
+        VERSION=$(git describe --tags)
+        echo "tag version: $VERSION"
+
+    - name: Configure "tag" UMF build
+      working-directory: ${{github.workspace}}/tag_version
+      run: >
+        cmake
+        -B ${{github.workspace}}/tag_version/build
+        -DCMAKE_BUILD_TYPE=Debug
+        -DUMF_BUILD_SHARED_LIBRARY=ON
+        -DCMAKE_C_COMPILER=gcc
+        -DCMAKE_CXX_COMPILER=g++
+        -DUMF_BUILD_TESTS=ON
+        -DUMF_BUILD_LEVEL_ZERO_PROVIDER=ON
+        -DUMF_BUILD_CUDA_PROVIDER=ON
+        -DUMF_FORMAT_CODE_STYLE=OFF
+        -DUMF_DEVELOPER_MODE=ON
+        -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
+        -DUMF_BUILD_LIBUMF_POOL_DISJOINT=ON
+        -DUMF_TESTS_FAIL_ON_SKIP=ON
+
+    - name: Build "tag" UMF
+      working-directory: ${{github.workspace}}/tag_version
+      run: |
+        cmake --build ${{github.workspace}}/tag_version/build -j $(nproc)
+        
+    # For UMF < 0.11 set ptrace_scope
+    - name: Set ptrace value for IPC test
+      if: ${{ startsWith(inputs.tag, 'v0.10.') || startsWith(inputs.tag, 'v0.9.') }}
+      run: sudo bash -c "echo 0 > /proc/sys/kernel/yama/ptrace_scope"
+
+    - name: Run "tag" UMF tests
+      working-directory: ${{github.workspace}}/tag_version/build
+      run: |
+        LD_LIBRARY_PATH=${{github.workspace}}/tag_version/build/lib/ ctest --output-on-failure
+
+    - name: Checkout latest UMF version
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        fetch-depth: 0
+        path: ${{github.workspace}}/latest_version
+        
+    - name: Get latest UMF version
+      working-directory: ${{github.workspace}}/latest_version
+      run: |
+        VERSION=$(git describe --tags)
+        echo "checked version: $VERSION"
+        
+    - name: Configure latest UMF build
+      working-directory: ${{github.workspace}}/latest_version
+      run: >
+        cmake
+        -B ${{github.workspace}}/latest_version/build
+        -DCMAKE_BUILD_TYPE=Debug
+        -DUMF_BUILD_SHARED_LIBRARY=ON
+        -DCMAKE_C_COMPILER=gcc
+        -DCMAKE_CXX_COMPILER=g++
+        -DUMF_BUILD_TESTS=OFF
+        -DUMF_BUILD_LEVEL_ZERO_PROVIDER=ON
+        -DUMF_BUILD_CUDA_PROVIDER=ON
+        -DUMF_FORMAT_CODE_STYLE=OFF
+        -DUMF_DEVELOPER_MODE=ON
+        -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
+        -DUMF_BUILD_LIBUMF_POOL_DISJOINT=ON
+        -DUMF_TESTS_FAIL_ON_SKIP=ON
+
+    - name: Build latest UMF
+      working-directory: ${{github.workspace}}/latest_version
+      run: |
+        cmake --build ${{github.workspace}}/latest_version/build -j $(nproc)
+
+    # NOTE: exclude umf-provider_coarse, umf-disjointCoarseMallocPool, 
+    # umf-jemalloc_coarse_file, umf-scalable_coarse_file as they use Coarse 
+    # Provider which is not supported for UMF > 0.10.0
+    - name: Run "tag" UMF tests with latest UMF libs (warnings enabled)
+      working-directory: ${{github.workspace}}/tag_version/build
+      run: >
+        UMF_LOG="level:warning;flush:debug;output:stderr;pid:no" 
+        LD_LIBRARY_PATH=${{github.workspace}}/latest_version/build/lib/ 
+        ctest --output-on-failure -E "umf-provider_coarse|umf-disjointCoarseMallocPool|umf-jemalloc_coarse_file|umf-scalable_coarse_file"
+ 
+  windows-build:
+    name: Windows
+    env:
+      VCPKG_PATH: "${{github.workspace}}/vcpkg/packages/hwloc_x64-windows;${{github.workspace}}/vcpkg/packages/tbb_x64-windows;${{github.workspace}}/vcpkg/packages/jemalloc_x64-windows"
+    runs-on: "windows-2022"
+
+    steps:
+    - name: Checkout "tag" UMF version
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        fetch-depth: 0
+        ref: refs/tags/${{inputs.tag}}
+        path: ${{github.workspace}}/tag_version
+
+    - name: Initialize vcpkg
+      uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5
+      with:
+        vcpkgGitCommitId: 3dd44b931481d7a8e9ba412621fa810232b66289
+        vcpkgDirectory: ${{github.workspace}}/vcpkg
+        vcpkgJsonGlob: '**/vcpkg.json'
+
+    - name: Install dependencies
+      working-directory: ${{github.workspace}}/tag_version
+      run: vcpkg install
+      shell: pwsh # Specifies PowerShell as the shell for running the script.
+    
+    - name: Get "tag" UMF version
+      working-directory: ${{github.workspace}}/tag_version
+      run: |
+        $version = (git describe --tags)
+        echo "tag version: $VERSION"
+
+    - name: Configure "tag" UMF build
+      working-directory: ${{github.workspace}}/tag_version
+      run: >
+        cmake
+        -B "${{github.workspace}}/tag_version/build"
+        -DCMAKE_PREFIX_PATH="${{env.VCPKG_PATH}}"
+        -DCMAKE_C_COMPILER=cl
+        -DCMAKE_CXX_COMPILER=cl
+        -DUMF_BUILD_SHARED_LIBRARY=ON
+        -DUMF_BUILD_TESTS=ON
+        -DUMF_BUILD_LEVEL_ZERO_PROVIDER=ON
+        -DUMF_BUILD_CUDA_PROVIDER=ON
+        -DUMF_FORMAT_CODE_STYLE=OFF
+        -DUMF_DEVELOPER_MODE=ON
+        -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
+        -DUMF_BUILD_LIBUMF_POOL_DISJOINT=ON
+        -DUMF_TESTS_FAIL_ON_SKIP=ON
+
+    - name: Build "tag" UMF
+      run: cmake --build "${{github.workspace}}/tag_version/build" --config Debug -j $Env:NUMBER_OF_PROCESSORS
+
+    - name: Run "tag" UMF tests
+      working-directory: "${{github.workspace}}/tag_version/build"
+      run: ctest -C Debug --output-on-failure --test-dir test
+
+    - name: Checkout latest UMF version
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        fetch-depth: 0
+        path: ${{github.workspace}}/latest_version
+
+    # NOTE we use vcpkg setup from "tag" version
+    - name: Get latest UMF version
+      working-directory: ${{github.workspace}}/latest_version
+      run: |
+        $version = (git describe --tags)
+        echo "latest version: $VERSION"
+
+    - name: Configure latest UMF build
+      working-directory: ${{github.workspace}}/latest_version
+      run: >
+        cmake
+        -B "${{github.workspace}}/latest_version/build"
+        -DCMAKE_PREFIX_PATH="${{env.VCPKG_PATH}}"
+        -DCMAKE_C_COMPILER=cl
+        -DCMAKE_CXX_COMPILER=cl
+        -DUMF_BUILD_SHARED_LIBRARY=ON
+        -DUMF_BUILD_TESTS=OFF
+        -DUMF_BUILD_LEVEL_ZERO_PROVIDER=ON
+        -DUMF_BUILD_CUDA_PROVIDER=ON
+        -DUMF_FORMAT_CODE_STYLE=OFF
+        -DUMF_DEVELOPER_MODE=ON
+        -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
+        -DUMF_BUILD_LIBUMF_POOL_DISJOINT=ON
+        -DUMF_TESTS_FAIL_ON_SKIP=ON
+
+    - name: Build latest UMF
+      run: cmake --build "${{github.workspace}}/latest_version/build" --config Debug -j $Env:NUMBER_OF_PROCESSORS
+
+    # NOTE: exclude umf-provider_coarse, umf-disjointCoarseMallocPool, 
+    # umf-jemalloc_coarse_file, umf-scalable_coarse_file as they use Coarse 
+    # Provider which is not supported for UMF > 0.10.0
+    # NOTE2: on Windows we simply overwrite the umf.dll
+    - name: Run "tag" UMF tests with latest UMF libs (warnings enabled)
+      working-directory: ${{github.workspace}}/tag_version/build
+      run: |
+        $env:UMF_LOG="level:warning;flush:debug;output:stderr;pid:no" 
+        cp ${{github.workspace}}/latest_version/build/bin/Debug/umf.dll ${{github.workspace}}/tag_version/build/bin/Debug/umf.dll
+        ctest -C Debug --output-on-failure --test-dir test -E "umf-provider_coarse|umf-disjointCoarseMallocPool|umf-jemalloc_coarse_file|umf-scalable_coarse_file"

--- a/RELEASE_STEPS.md
+++ b/RELEASE_STEPS.md
@@ -40,6 +40,9 @@ Do changes for a release:
 - Add an entry to ChangeLog, remember to change the day of the week in the release date
   - For major and minor (prior 1.0.0) releases mention API and ABI compatibility with the previous release
 - For major and minor releases, update `UMF_VERSION_CURRENT` in `include/umf/base.h` (the API version)
+  - In case of any changes to the memory provider or pool operations structures, 
+    ensure that you also update the corresponding `UMF_PROVIDER_OPS_VERSION_CURRENT` 
+    or `UMF_POOL_OPS_VERSION_CURRENT`. Additionally, make sure to implement backward compatibility with older versions
 - For major and minor (prior 1.0.0) releases update ABI version in `.map` and `.def` files
   - These files are defined for all public libraries (`libumf` and `proxy_lib`, at the moment)
 - Commit these changes and tag the release:

--- a/examples/custom_file_provider/custom_file_provider.c
+++ b/examples/custom_file_provider/custom_file_provider.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2024 Intel Corporation
+ * Copyright (C) 2024-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -234,7 +234,7 @@ static umf_result_t file_get_min_page_size(void *provider, void *ptr,
 
 // File provider operations
 static umf_memory_provider_ops_t file_ops = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_PROVIDER_OPS_VERSION_CURRENT,
     .initialize = file_init,
     .finalize = file_deinit,
     .alloc = file_alloc,

--- a/include/umf/memory_pool.h
+++ b/include/umf/memory_pool.h
@@ -11,6 +11,7 @@
 #define UMF_MEMORY_POOL_H 1
 
 #include <umf/base.h>
+#include <umf/memory_pool_ops.h>
 #include <umf/memory_provider.h>
 
 #ifdef __cplusplus
@@ -21,12 +22,6 @@ extern "C" {
 ///        structure containing pointers to implementations of provider-specific
 ///        functions
 typedef struct umf_memory_pool_t *umf_memory_pool_handle_t;
-
-/// @brief This structure comprises function pointers used by corresponding umfPool*
-///        calls. Each memory pool implementation should initialize all function
-///        pointers.
-///
-typedef struct umf_memory_pool_ops_t umf_memory_pool_ops_t;
 
 /// @brief Supported pool creation flags
 typedef enum umf_pool_create_flag_t {

--- a/include/umf/memory_pool_ops.h
+++ b/include/umf/memory_pool_ops.h
@@ -17,14 +17,19 @@
 extern "C" {
 #endif
 
+/// @brief Version of the Memory Pool ops structure.
+/// NOTE: This is equal to the latest UMF version, in which the ops structure
+/// has been modified.
+#define UMF_POOL_OPS_VERSION_CURRENT UMF_MAKE_VERSION(0, 11)
+
 ///
 /// @brief This structure comprises function pointers used by corresponding umfPool*
 /// calls. Each memory pool implementation should initialize all function
 /// pointers.
 ///
-typedef struct umf_memory_pool_ops_t {
+typedef struct umf_memory_pool_ops_0_11_t {
     /// Version of the ops structure.
-    /// Should be initialized using UMF_VERSION_CURRENT.
+    /// Should be initialized using UMF_POOL_OPS_VERSION_CURRENT.
     uint32_t version;
 
     ///
@@ -120,7 +125,8 @@ typedef struct umf_memory_pool_ops_t {
     ///         The value is undefined if the previous allocation was successful.
     ///
     umf_result_t (*get_last_allocation_error)(void *pool);
-} umf_memory_pool_ops_t;
+} umf_memory_pool_ops_0_11_t;
+typedef umf_memory_pool_ops_0_11_t umf_memory_pool_ops_t;
 
 #ifdef __cplusplus
 }

--- a/include/umf/memory_provider_ops.h
+++ b/include/umf/memory_provider_ops.h
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -16,12 +16,17 @@
 extern "C" {
 #endif
 
+/// @brief Version of the Memory Provider ops structure.
+/// NOTE: This is equal to the latest UMF version, in which the ops structure
+/// has been modified.
+#define UMF_PROVIDER_OPS_VERSION_CURRENT UMF_MAKE_VERSION(0, 11)
+
 ///
 /// @brief This structure comprises optional function pointers used
 /// by corresponding umfMemoryProvider* calls. A memory provider implementation
 /// can keep them NULL.
 ///
-typedef struct umf_memory_provider_ext_ops_t {
+typedef struct umf_memory_provider_ext_ops_0_11_t {
     ///
     /// @brief Discard physical pages within the virtual memory mapping associated at the given addr
     ///        and \p size. This call is asynchronous and may delay purging the pages indefinitely.
@@ -78,13 +83,14 @@ typedef struct umf_memory_provider_ext_ops_t {
     umf_result_t (*allocation_split)(void *hProvider, void *ptr,
                                      size_t totalSize, size_t firstSize);
 
-} umf_memory_provider_ext_ops_t;
+} umf_memory_provider_ext_ops_0_11_t;
+typedef umf_memory_provider_ext_ops_0_11_t umf_memory_provider_ext_ops_t;
 
 ///
 /// @brief This structure comprises optional IPC API. The API allows sharing of
 /// memory objects across different processes. A memory provider implementation can keep them NULL.
 ///
-typedef struct umf_memory_provider_ipc_ops_t {
+typedef struct umf_memory_provider_ipc_ops_0_11_t {
     ///
     /// @brief Retrieve the size of opaque data structure required to store IPC data.
     /// @param provider pointer to the memory provider.
@@ -134,16 +140,17 @@ typedef struct umf_memory_provider_ipc_ops_t {
     ///         UMF_RESULT_ERROR_INVALID_ARGUMENT if invalid \p ptr is passed.
     ///         UMF_RESULT_ERROR_NOT_SUPPORTED if IPC functionality is not supported by this provider.
     umf_result_t (*close_ipc_handle)(void *provider, void *ptr, size_t size);
-} umf_memory_provider_ipc_ops_t;
+} umf_memory_provider_ipc_ops_0_11_t;
+typedef umf_memory_provider_ipc_ops_0_11_t umf_memory_provider_ipc_ops_t;
 
 ///
 /// @brief This structure comprises function pointers used by corresponding
 /// umfMemoryProvider* calls. Each memory provider implementation should
 /// initialize all function pointers.
 ///
-typedef struct umf_memory_provider_ops_t {
+typedef struct umf_memory_provider_ops_0_11_t {
     /// Version of the ops structure.
-    /// Should be initialized using UMF_VERSION_CURRENT.
+    /// Should be initialized using UMF_PROVIDER_OPS_VERSION_CURRENT.
     uint32_t version;
 
     ///
@@ -245,7 +252,8 @@ typedef struct umf_memory_provider_ops_t {
     /// @brief Optional IPC ops. The API allows sharing of memory objects across different processes.
     ///
     umf_memory_provider_ipc_ops_t ipc;
-} umf_memory_provider_ops_t;
+} umf_memory_provider_ops_0_11_t;
+typedef umf_memory_provider_ops_0_11_t umf_memory_provider_ops_t;
 
 #ifdef __cplusplus
 }

--- a/include/umf/providers/provider_devdax_memory.h
+++ b/include/umf/providers/provider_devdax_memory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Intel Corporation
+ * Copyright (C) 2024-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -65,6 +65,10 @@ typedef enum umf_devdax_memory_provider_native_error {
     UMF_DEVDAX_RESULT_ERROR_PURGE_FORCE_FAILED, ///< Force purging failed
 } umf_devdax_memory_provider_native_error_t;
 
+/// @cond
+// use 0.11 version of the ops by default
+#define umfDevDaxMemoryProviderOps umfDevDaxMemoryProviderOps_0_11
+/// @endcond
 umf_memory_provider_ops_t *umfDevDaxMemoryProviderOps(void);
 
 #ifdef __cplusplus

--- a/include/umf/providers/provider_file_memory.h
+++ b/include/umf/providers/provider_file_memory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Intel Corporation
+ * Copyright (C) 2024-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -66,6 +66,10 @@ typedef enum umf_file_memory_provider_native_error {
     UMF_FILE_RESULT_ERROR_PURGE_FORCE_FAILED, ///< Force purging failed
 } umf_file_memory_provider_native_error_t;
 
+/// @cond
+// use 0.11 version of the ops by default
+#define umfFileMemoryProviderOps umfFileMemoryProviderOps_0_11
+/// @endcond
 umf_memory_provider_ops_t *umfFileMemoryProviderOps(void);
 
 #ifdef __cplusplus

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,9 +76,13 @@ set(UMF_SOURCES
     memspaces/memspace_highest_bandwidth.c
     memspaces/memspace_lowest_latency.c
     memspaces/memspace_numa.c
+    provider/provider_coarse_deprecated.c
     provider/provider_cuda.c
+    provider/provider_deprecated.c
     provider/provider_devdax_memory.c
+    provider/provider_devdax_memory_deprecated.c
     provider/provider_file_memory.c
+    provider/provider_file_memory_deprecated.c
     provider/provider_fixed_memory.c
     provider/provider_level_zero.c
     provider/provider_os_memory.c

--- a/src/cpp_helpers.hpp
+++ b/src/cpp_helpers.hpp
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -67,7 +67,7 @@ umf_result_t initialize(T *obj, ArgsTuple &&args) {
 
 template <typename T> umf_memory_pool_ops_t poolOpsBase() {
     umf_memory_pool_ops_t ops{};
-    ops.version = UMF_VERSION_CURRENT;
+    ops.version = UMF_POOL_OPS_VERSION_CURRENT;
     ops.finalize = [](void *obj) { delete reinterpret_cast<T *>(obj); };
     UMF_ASSIGN_OP(ops, T, malloc, ((void *)nullptr));
     UMF_ASSIGN_OP(ops, T, calloc, ((void *)nullptr));
@@ -81,7 +81,7 @@ template <typename T> umf_memory_pool_ops_t poolOpsBase() {
 
 template <typename T> constexpr umf_memory_provider_ops_t providerOpsBase() {
     umf_memory_provider_ops_t ops{};
-    ops.version = UMF_VERSION_CURRENT;
+    ops.version = UMF_PROVIDER_OPS_VERSION_CURRENT;
     ops.finalize = [](void *obj) { delete reinterpret_cast<T *>(obj); };
     UMF_ASSIGN_OP(ops, T, alloc, UMF_RESULT_ERROR_UNKNOWN);
     UMF_ASSIGN_OP(ops, T, free, UMF_RESULT_ERROR_UNKNOWN);

--- a/src/libumf.def
+++ b/src/libumf.def
@@ -14,18 +14,20 @@ EXPORTS
     umfTearDown
     umfGetCurrentVersion
     umfCloseIPCHandle
+    umfCoarseMemoryProviderGetStats ; deprecated
+    umfCoarseMemoryProviderOps  ; deprecated
     umfCUDAMemoryProviderOps
     umfCUDAMemoryProviderParamsCreate
     umfCUDAMemoryProviderParamsDestroy
     umfCUDAMemoryProviderParamsSetContext
     umfCUDAMemoryProviderParamsSetDevice
     umfCUDAMemoryProviderParamsSetMemoryType
-    umfDevDaxMemoryProviderOps
+    umfDevDaxMemoryProviderOps=umfDevDaxMemoryProviderOps_0_10 ; deprecated
     umfDevDaxMemoryProviderParamsCreate
     umfDevDaxMemoryProviderParamsDestroy
     umfDevDaxMemoryProviderParamsSetDeviceDax
     umfDevDaxMemoryProviderParamsSetProtection
-    umfFileMemoryProviderOps
+    umfFileMemoryProviderOps=umfFileMemoryProviderOps_0_10 ; deprecated
     umfFileMemoryProviderParamsCreate
     umfFileMemoryProviderParamsDestroy
     umfFileMemoryProviderParamsSetPath
@@ -118,6 +120,8 @@ EXPORTS
     umfScalablePoolParamsSetGranularity
     umfScalablePoolParamsSetKeepAllMemory
 ; Added in UMF_0.11
+    umfDevDaxMemoryProviderOps_0_11 ; redefined 0.10
+    umfFileMemoryProviderOps_0_11   ; redefined 0.10
     umfFixedMemoryProviderOps
     umfFixedMemoryProviderParamsCreate
     umfFixedMemoryProviderParamsDestroy

--- a/src/libumf.map
+++ b/src/libumf.map
@@ -8,18 +8,20 @@ UMF_0.10 {
         umfTearDown;
         umfGetCurrentVersion;
         umfCloseIPCHandle;
+        umfCoarseMemoryProviderGetStats; # deprecated
+        umfCoarseMemoryProviderOps; # deprecated
         umfCUDAMemoryProviderOps;
         umfCUDAMemoryProviderParamsCreate;
         umfCUDAMemoryProviderParamsDestroy;
         umfCUDAMemoryProviderParamsSetContext;
         umfCUDAMemoryProviderParamsSetDevice;
         umfCUDAMemoryProviderParamsSetMemoryType;
-        umfDevDaxMemoryProviderOps;
+        umfDevDaxMemoryProviderOps; # deprecated
         umfDevDaxMemoryProviderParamsCreate;
         umfDevDaxMemoryProviderParamsDestroy;
         umfDevDaxMemoryProviderParamsSetDeviceDax;
         umfDevDaxMemoryProviderParamsSetProtection;
-        umfFileMemoryProviderOps;
+        umfFileMemoryProviderOps; # deprecated
         umfFileMemoryProviderParamsCreate;
         umfFileMemoryProviderParamsDestroy;
         umfFileMemoryProviderParamsSetPath;
@@ -116,6 +118,8 @@ UMF_0.10 {
 };
 
 UMF_0.11 {
+        umfDevDaxMemoryProviderOps_0_11; # redefined 0.10
+        umfFileMemoryProviderOps_0_11; # redefined 0.10
         umfFixedMemoryProviderOps;
         umfFixedMemoryProviderParamsCreate;
         umfFixedMemoryProviderParamsDestroy;

--- a/src/memory_pool.c
+++ b/src/memory_pool.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -38,7 +38,11 @@ static umf_result_t umfPoolCreateInternal(const umf_memory_pool_ops_t *ops,
         return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
 
-    assert(ops->version == UMF_VERSION_CURRENT);
+    if (ops->version != UMF_POOL_OPS_VERSION_CURRENT) {
+        LOG_WARN("memory pool ops version \"%d\" is different than the current "
+                 "version \"%d\"",
+                 ops->version, UMF_POOL_OPS_VERSION_CURRENT);
+    }
 
     if (!(flags & UMF_POOL_CREATE_FLAG_DISABLE_TRACKING)) {
         // Wrap provider with memory tracking provider.

--- a/src/memory_provider.c
+++ b/src/memory_provider.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -11,6 +11,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <umf/memory_provider.h>
 
@@ -18,6 +19,7 @@
 #include "base_alloc_global.h"
 #include "libumf.h"
 #include "memory_provider_internal.h"
+#include "provider_deprecated.h"
 #include "utils_assert.h"
 
 typedef struct umf_memory_provider_t {
@@ -163,7 +165,7 @@ umf_result_t umfMemoryProviderCreate(const umf_memory_provider_ops_t *ops,
                                      void *params,
                                      umf_memory_provider_handle_t *hProvider) {
     libumfInit();
-    if (!ops || !hProvider || !validateOps(ops)) {
+    if (!ops || !hProvider) {
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
 
@@ -197,12 +199,7 @@ umf_result_t umfMemoryProviderCreate(const umf_memory_provider_ops_t *ops,
         return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
 
-    assert(ops->version == UMF_VERSION_CURRENT);
-
-    provider->ops = *ops;
-
-    assignOpsExtDefaults(&(provider->ops));
-    assignOpsIpcDefaults(&(provider->ops));
+    provider->ops = ops_current_ver;
 
     void *provider_priv;
     umf_result_t ret = ops->initialize(params, &provider_priv);

--- a/src/memtarget.c
+++ b/src/memtarget.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -15,6 +15,7 @@
 #include "memtarget_internal.h"
 #include "memtarget_ops.h"
 #include "utils_concurrency.h"
+#include "utils_log.h"
 
 umf_result_t umfMemtargetCreate(const umf_memtarget_ops_t *ops, void *params,
                                 umf_memtarget_handle_t *memoryTarget) {
@@ -29,7 +30,11 @@ umf_result_t umfMemtargetCreate(const umf_memtarget_ops_t *ops, void *params,
         return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
 
-    assert(ops->version == UMF_VERSION_CURRENT);
+    if (ops->version != UMF_MEMTARGET_OPS_VERSION_CURRENT) {
+        LOG_WARN("memtarget ops version \"%d\" is different than the current "
+                 "version \"%d\"",
+                 ops->version, UMF_MEMTARGET_OPS_VERSION_CURRENT);
+    }
 
     target->ops = ops;
 

--- a/src/memtarget_internal.h
+++ b/src/memtarget_internal.h
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -16,7 +16,6 @@
 extern "C" {
 #endif
 
-struct umf_memtarget_ops_t;
 typedef struct umf_memtarget_ops_t umf_memtarget_ops_t;
 
 typedef struct umf_memtarget_t {

--- a/src/memtarget_ops.h
+++ b/src/memtarget_ops.h
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -17,6 +17,11 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// Version of the Memtarget ops structure.
+// NOTE: This is equal to the latest UMF version, in which the ops structure
+// has been modified.
+#define UMF_MEMTARGET_OPS_VERSION_CURRENT UMF_MAKE_VERSION(0, 11)
 
 typedef struct umf_memtarget_ops_t {
     /// Version of the ops structure.

--- a/src/memtargets/memtarget_numa.c
+++ b/src/memtargets/memtarget_numa.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -390,7 +390,7 @@ static umf_result_t numa_compare(void *memTarget, void *otherMemTarget,
 }
 
 struct umf_memtarget_ops_t UMF_MEMTARGET_NUMA_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_MEMTARGET_OPS_VERSION_CURRENT,
     .initialize = numa_initialize,
     .finalize = numa_finalize,
     .pool_create_from_memspace = numa_pool_create_from_memspace,

--- a/src/pool/pool_jemalloc.c
+++ b/src/pool/pool_jemalloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2022-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -454,7 +454,7 @@ static umf_result_t op_get_last_allocation_error(void *pool) {
 }
 
 static umf_memory_pool_ops_t UMF_JEMALLOC_POOL_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_POOL_OPS_VERSION_CURRENT,
     .initialize = op_initialize,
     .finalize = op_finalize,
     .malloc = op_malloc,

--- a/src/pool/pool_proxy.c
+++ b/src/pool/pool_proxy.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2024 Intel Corporation
+ * Copyright (C) 2024-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -123,7 +123,7 @@ static umf_result_t proxy_get_last_allocation_error(void *pool) {
 }
 
 static umf_memory_pool_ops_t UMF_PROXY_POOL_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_POOL_OPS_VERSION_CURRENT,
     .initialize = proxy_pool_initialize,
     .finalize = proxy_pool_finalize,
     .malloc = proxy_malloc,

--- a/src/pool/pool_scalable.c
+++ b/src/pool/pool_scalable.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -382,7 +382,7 @@ static umf_result_t tbb_get_last_allocation_error(void *pool) {
 }
 
 static umf_memory_pool_ops_t UMF_SCALABLE_POOL_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_POOL_OPS_VERSION_CURRENT,
     .initialize = tbb_pool_initialize,
     .finalize = tbb_pool_finalize,
     .malloc = tbb_malloc,

--- a/src/provider/provider_coarse_deprecated.c
+++ b/src/provider/provider_coarse_deprecated.c
@@ -1,0 +1,34 @@
+
+/*
+ * Copyright (C) 2025 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+*/
+
+#include <umf.h>
+#include <umf/memory_provider.h>
+#include <umf/memory_provider_ops.h>
+
+#include "utils_log.h"
+
+umf_memory_provider_ops_t *umfCoarseMemoryProviderOps(void) {
+    LOG_ERR("Coarse Provider is deprecated!");
+    return NULL;
+}
+
+typedef struct coarse_memory_provider_stats_t {
+    size_t alloc_size;
+    size_t used_size;
+    size_t num_upstream_blocks;
+    size_t num_all_blocks;
+    size_t num_free_blocks;
+} coarse_memory_provider_stats_t;
+
+coarse_memory_provider_stats_t
+umfCoarseMemoryProviderGetStats(umf_memory_provider_handle_t provider) {
+    (void)provider;
+    LOG_ERR("Coarse Provider is deprecated!");
+    coarse_memory_provider_stats_t ret = {0};
+    return ret;
+}

--- a/src/provider/provider_cuda.c
+++ b/src/provider/provider_cuda.c
@@ -618,8 +618,8 @@ cu_memory_provider_close_ipc_handle(void *provider, void *ptr, size_t size) {
     return UMF_RESULT_SUCCESS;
 }
 
-static struct umf_memory_provider_ops_t UMF_CUDA_MEMORY_PROVIDER_OPS = {
-    .version = UMF_VERSION_CURRENT,
+static umf_memory_provider_ops_t UMF_CUDA_MEMORY_PROVIDER_OPS = {
+    .version = UMF_PROVIDER_OPS_VERSION_CURRENT,
     .initialize = cu_memory_provider_initialize,
     .finalize = cu_memory_provider_finalize,
     .alloc = cu_memory_provider_alloc,

--- a/src/provider/provider_deprecated.c
+++ b/src/provider/provider_deprecated.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+*/
+
+#include <assert.h>
+#include <string.h>
+
+#include <umf.h>
+#include <umf/memory_provider.h>
+#include <umf/memory_provider_ops.h>
+
+#include "provider_deprecated.h"
+
+umf_result_t umfDefaultFree_0_10(void *provider, void *ptr, size_t size) {
+    (void)provider;
+    (void)ptr;
+    (void)size;
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+}
+
+umf_result_t
+umfTranslateMemoryProviderOps_0_10(umf_memory_provider_ops_0_10_t *ops_0_10,
+                                   umf_memory_provider_ops_t *ops) {
+    ops->version = UMF_PROVIDER_OPS_VERSION_CURRENT;
+    ops->alloc = ops_0_10->alloc;
+
+    // in UMF 0.10 the free() was a part of ext and could be NULL
+    if (ops_0_10->ext.free != NULL) {
+        ops->free = ops_0_10->ext.free;
+    } else {
+        ops->free = umfDefaultFree_0_10;
+    }
+
+    ops->get_last_native_error = ops_0_10->get_last_native_error;
+    ops->get_recommended_page_size = ops_0_10->get_recommended_page_size;
+    ops->get_min_page_size = ops_0_10->get_min_page_size;
+    ops->get_name = ops_0_10->get_name;
+    ops->initialize = ops_0_10->initialize;
+    ops->finalize = ops_0_10->finalize;
+
+    ops->ext.purge_lazy = ops_0_10->ext.purge_lazy;
+    ops->ext.purge_force = ops_0_10->ext.purge_force;
+    ops->ext.allocation_merge = ops_0_10->ext.allocation_merge;
+    ops->ext.allocation_split = ops_0_10->ext.allocation_split;
+
+    // IPC hasn't changed
+    assert(sizeof(umf_memory_provider_ipc_ops_t) ==
+           sizeof(umf_memory_provider_ipc_ops_0_10_t));
+    memcpy(&ops->ipc, &ops_0_10->ipc, sizeof(ops_0_10->ipc));
+
+    return UMF_RESULT_SUCCESS;
+}

--- a/src/provider/provider_deprecated.h
+++ b/src/provider/provider_deprecated.h
@@ -1,0 +1,69 @@
+/*
+ *
+ * Copyright (C) 2025 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ */
+
+#ifndef UMF_PROVIDER_DEPRECATED_H
+#define UMF_PROVIDER_DEPRECATED_H 1
+
+#include <umf/base.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// define Memory Provider ops structure 0.10
+// NOTE: in UMF 0.10 the free() was optional and was a part of the "ext"
+// structure
+typedef struct umf_memory_provider_ext_ops_0_10_t {
+    umf_result_t (*free)(void *provider, void *ptr, size_t size);
+    umf_result_t (*purge_lazy)(void *provider, void *ptr, size_t size);
+    umf_result_t (*purge_force)(void *provider, void *ptr, size_t size);
+    umf_result_t (*allocation_merge)(void *hProvider, void *lowPtr,
+                                     void *highPtr, size_t totalSize);
+    umf_result_t (*allocation_split)(void *hProvider, void *ptr,
+                                     size_t totalSize, size_t firstSize);
+} umf_memory_provider_ext_ops_0_10_t;
+
+typedef struct umf_memory_provider_ipc_ops_0_10_t {
+    umf_result_t (*get_ipc_handle_size)(void *provider, size_t *size);
+    umf_result_t (*get_ipc_handle)(void *provider, const void *ptr, size_t size,
+                                   void *providerIpcData);
+    umf_result_t (*put_ipc_handle)(void *provider, void *providerIpcData);
+    umf_result_t (*open_ipc_handle)(void *provider, void *providerIpcData,
+                                    void **ptr);
+    umf_result_t (*close_ipc_handle)(void *provider, void *ptr, size_t size);
+} umf_memory_provider_ipc_ops_0_10_t;
+
+typedef struct umf_memory_provider_ops_0_10_t {
+    uint32_t version;
+    umf_result_t (*initialize)(void *params, void **provider);
+    void (*finalize)(void *provider);
+    umf_result_t (*alloc)(void *provider, size_t size, size_t alignment,
+                          void **ptr);
+    void (*get_last_native_error)(void *provider, const char **ppMessage,
+                                  int32_t *pError);
+    umf_result_t (*get_recommended_page_size)(void *provider, size_t size,
+                                              size_t *pageSize);
+    umf_result_t (*get_min_page_size)(void *provider, void *ptr,
+                                      size_t *pageSize);
+    const char *(*get_name)(void *provider);
+    umf_memory_provider_ext_ops_0_10_t ext;
+    umf_memory_provider_ipc_ops_0_10_t ipc;
+} umf_memory_provider_ops_0_10_t;
+
+umf_result_t umfDefaultFree_0_10(void *provider, void *ptr, size_t size);
+
+umf_result_t
+umfTranslateMemoryProviderOps_0_10(umf_memory_provider_ops_0_10_t *ops_0_10,
+                                   umf_memory_provider_ops_t *ops);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* #ifndef UMF_PROVIDER_DEPRECATED_H */

--- a/src/provider/provider_devdax_memory.c
+++ b/src/provider/provider_devdax_memory.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Intel Corporation
+ * Copyright (C) 2024-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -529,8 +529,8 @@ static umf_result_t devdax_free(void *provider, void *ptr, size_t size) {
     return coarse_free(devdax_provider->coarse, ptr, size);
 }
 
-static umf_memory_provider_ops_t UMF_DEVDAX_MEMORY_PROVIDER_OPS = {
-    .version = UMF_VERSION_CURRENT,
+umf_memory_provider_ops_0_11_t UMF_DEVDAX_MEMORY_PROVIDER_OPS_0_11 = {
+    .version = UMF_PROVIDER_OPS_VERSION_CURRENT,
     .initialize = devdax_initialize,
     .finalize = devdax_finalize,
     .alloc = devdax_alloc,
@@ -547,10 +547,11 @@ static umf_memory_provider_ops_t UMF_DEVDAX_MEMORY_PROVIDER_OPS = {
     .ipc.get_ipc_handle = devdax_get_ipc_handle,
     .ipc.put_ipc_handle = devdax_put_ipc_handle,
     .ipc.open_ipc_handle = devdax_open_ipc_handle,
-    .ipc.close_ipc_handle = devdax_close_ipc_handle};
+    .ipc.close_ipc_handle = devdax_close_ipc_handle,
+};
 
-umf_memory_provider_ops_t *umfDevDaxMemoryProviderOps(void) {
-    return &UMF_DEVDAX_MEMORY_PROVIDER_OPS;
+umf_memory_provider_ops_0_11_t *umfDevDaxMemoryProviderOps_0_11(void) {
+    return &UMF_DEVDAX_MEMORY_PROVIDER_OPS_0_11;
 }
 
 umf_result_t umfDevDaxMemoryProviderParamsCreate(

--- a/src/provider/provider_devdax_memory_deprecated.c
+++ b/src/provider/provider_devdax_memory_deprecated.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+*/
+
+#include <umf/memory_provider.h>
+#include <umf/memory_provider_ops.h>
+
+#include "provider_deprecated.h"
+#include "utils_log.h"
+
+// DevDax Provider is not supported on Windows
+#if defined(_WIN32) || defined(UMF_NO_HWLOC)
+
+umf_memory_provider_ops_t *umfDevDaxMemoryProviderOps_0_10(void) {
+    // not supported
+    LOG_ERR("DevDax memory provider is disabled!");
+    return NULL;
+}
+
+#else // !defined(_WIN32) && !defined(UMF_NO_HWLOC)
+
+// The ops structure for the DevDax Memory Provider has been changed between
+// UMF 0.10 and 0.11 (in 0.10 there was no "free()" method)
+
+extern umf_memory_provider_ops_0_11_t UMF_DEVDAX_MEMORY_PROVIDER_OPS_0_11;
+static umf_memory_provider_ops_0_10_t UMF_DEVDAX_MEMORY_PROVIDER_OPS_0_10;
+
+#if !defined(__APPLE__)
+// Set 0_10 version as the default one for dlsym()
+asm(".symver "
+    "umfDevDaxMemoryProviderOps_0_10,umfDevDaxMemoryProviderOps@@UMF_0.10");
+#endif
+
+umf_memory_provider_ops_0_10_t *umfDevDaxMemoryProviderOps_0_10(void) {
+    umf_memory_provider_ops_0_11_t ops = UMF_DEVDAX_MEMORY_PROVIDER_OPS_0_11;
+    umf_memory_provider_ops_0_10_t ops_0_10 = {
+        .version = UMF_MAKE_VERSION(0, 10),
+        .initialize = ops.initialize,
+        .finalize = ops.finalize,
+        .alloc = ops.alloc,
+        .get_last_native_error = ops.get_last_native_error,
+        .get_recommended_page_size = ops.get_recommended_page_size,
+        .get_min_page_size = ops.get_min_page_size,
+        .get_name = ops.get_name,
+        .ext.purge_lazy = ops.ext.purge_lazy,
+        .ext.purge_force = ops.ext.purge_force,
+        .ext.allocation_merge = ops.ext.allocation_merge,
+        .ext.allocation_split = ops.ext.allocation_split,
+        .ipc.get_ipc_handle_size = ops.ipc.get_ipc_handle_size,
+        .ipc.get_ipc_handle = ops.ipc.get_ipc_handle,
+        .ipc.put_ipc_handle = ops.ipc.put_ipc_handle,
+        .ipc.open_ipc_handle = ops.ipc.open_ipc_handle,
+        .ipc.close_ipc_handle = ops.ipc.close_ipc_handle,
+    };
+
+    UMF_DEVDAX_MEMORY_PROVIDER_OPS_0_10 = ops_0_10;
+    return &UMF_DEVDAX_MEMORY_PROVIDER_OPS_0_10;
+}
+
+#endif // !defined(_WIN32) && !defined(UMF_NO_HWLOC)

--- a/src/provider/provider_file_memory.c
+++ b/src/provider/provider_file_memory.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Intel Corporation
+ * Copyright (C) 2024-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -847,8 +847,8 @@ static umf_result_t file_free(void *provider, void *ptr, size_t size) {
     return coarse_free(file_provider->coarse, ptr, size);
 }
 
-static umf_memory_provider_ops_t UMF_FILE_MEMORY_PROVIDER_OPS = {
-    .version = UMF_VERSION_CURRENT,
+umf_memory_provider_ops_0_11_t UMF_FILE_MEMORY_PROVIDER_OPS_0_11 = {
+    .version = UMF_PROVIDER_OPS_VERSION_CURRENT,
     .initialize = file_initialize,
     .finalize = file_finalize,
     .alloc = file_alloc,
@@ -865,10 +865,11 @@ static umf_memory_provider_ops_t UMF_FILE_MEMORY_PROVIDER_OPS = {
     .ipc.get_ipc_handle = file_get_ipc_handle,
     .ipc.put_ipc_handle = file_put_ipc_handle,
     .ipc.open_ipc_handle = file_open_ipc_handle,
-    .ipc.close_ipc_handle = file_close_ipc_handle};
+    .ipc.close_ipc_handle = file_close_ipc_handle,
+};
 
-umf_memory_provider_ops_t *umfFileMemoryProviderOps(void) {
-    return &UMF_FILE_MEMORY_PROVIDER_OPS;
+umf_memory_provider_ops_0_11_t *umfFileMemoryProviderOps_0_11(void) {
+    return &UMF_FILE_MEMORY_PROVIDER_OPS_0_11;
 }
 
 umf_result_t umfFileMemoryProviderParamsCreate(

--- a/src/provider/provider_file_memory_deprecated.c
+++ b/src/provider/provider_file_memory_deprecated.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+*/
+
+#include <umf.h>
+#include <umf/memory_provider.h>
+#include <umf/memory_provider_ops.h>
+
+#include "provider_deprecated.h"
+#include "utils_log.h"
+
+#if defined(_WIN32) || defined(UMF_NO_HWLOC)
+
+umf_memory_provider_ops_t *umfFileMemoryProviderOps_0_10(void) {
+    // not supported
+    LOG_ERR("File memory provider is disabled!");
+    return NULL;
+}
+
+#else // !defined(_WIN32) && !defined(UMF_NO_HWLOC)
+
+// The ops structure for the File Memory Povider has been changed between
+// UMF 0.10 and 0.11 (in 0.10 there was no "free()" method)
+
+extern umf_memory_provider_ops_0_11_t UMF_FILE_MEMORY_PROVIDER_OPS_0_11;
+static umf_memory_provider_ops_0_10_t UMF_FILE_MEMORY_PROVIDER_OPS_0_10;
+
+#if !defined(__APPLE__)
+// Set 0_10 version as the default one for dlsym()
+asm(".symver "
+    "umfFileMemoryProviderOps_0_10,umfFileMemoryProviderOps@@UMF_0.10");
+#endif
+
+umf_memory_provider_ops_0_10_t *umfFileMemoryProviderOps_0_10(void) {
+    umf_memory_provider_ops_0_11_t ops = UMF_FILE_MEMORY_PROVIDER_OPS_0_11;
+    umf_memory_provider_ops_0_10_t ops_0_10 = {
+        .version = UMF_MAKE_VERSION(0, 10),
+        .initialize = ops.initialize,
+        .finalize = ops.finalize,
+        .alloc = ops.alloc,
+        .get_last_native_error = ops.get_last_native_error,
+        .get_recommended_page_size = ops.get_recommended_page_size,
+        .get_min_page_size = ops.get_min_page_size,
+        .get_name = ops.get_name,
+        .ext.purge_lazy = ops.ext.purge_lazy,
+        .ext.purge_force = ops.ext.purge_force,
+        .ext.allocation_merge = ops.ext.allocation_merge,
+        .ext.allocation_split = ops.ext.allocation_split,
+        .ipc.get_ipc_handle_size = ops.ipc.get_ipc_handle_size,
+        .ipc.get_ipc_handle = ops.ipc.get_ipc_handle,
+        .ipc.put_ipc_handle = ops.ipc.put_ipc_handle,
+        .ipc.open_ipc_handle = ops.ipc.open_ipc_handle,
+        .ipc.close_ipc_handle = ops.ipc.close_ipc_handle,
+    };
+
+    UMF_FILE_MEMORY_PROVIDER_OPS_0_10 = ops_0_10;
+    return &UMF_FILE_MEMORY_PROVIDER_OPS_0_10;
+}
+
+#endif // !defined(_WIN32) && !defined(UMF_NO_HWLOC)

--- a/src/provider/provider_fixed_memory.c
+++ b/src/provider/provider_fixed_memory.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Intel Corporation
+ * Copyright (C) 2024-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -254,7 +254,7 @@ static umf_result_t fixed_free(void *provider, void *ptr, size_t size) {
 }
 
 static umf_memory_provider_ops_t UMF_FIXED_MEMORY_PROVIDER_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_PROVIDER_OPS_VERSION_CURRENT,
     .initialize = fixed_initialize,
     .finalize = fixed_finalize,
     .alloc = fixed_alloc,

--- a/src/provider/provider_level_zero.c
+++ b/src/provider/provider_level_zero.c
@@ -821,8 +821,8 @@ ze_memory_provider_close_ipc_handle(void *provider, void *ptr, size_t size) {
     return UMF_RESULT_SUCCESS;
 }
 
-static struct umf_memory_provider_ops_t UMF_LEVEL_ZERO_MEMORY_PROVIDER_OPS = {
-    .version = UMF_VERSION_CURRENT,
+static umf_memory_provider_ops_t UMF_LEVEL_ZERO_MEMORY_PROVIDER_OPS = {
+    .version = UMF_PROVIDER_OPS_VERSION_CURRENT,
     .initialize = ze_memory_provider_initialize,
     .finalize = ze_memory_provider_finalize,
     .alloc = ze_memory_provider_alloc,

--- a/src/provider/provider_os_memory.c
+++ b/src/provider/provider_os_memory.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2022-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -1402,7 +1402,7 @@ static umf_result_t os_close_ipc_handle(void *provider, void *ptr,
 }
 
 static umf_memory_provider_ops_t UMF_OS_MEMORY_PROVIDER_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_PROVIDER_OPS_VERSION_CURRENT,
     .initialize = os_initialize,
     .finalize = os_finalize,
     .alloc = os_alloc,

--- a/src/provider/provider_tracking.c
+++ b/src/provider/provider_tracking.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -750,7 +750,7 @@ static umf_result_t trackingCloseIpcHandle(void *provider, void *ptr,
 }
 
 umf_memory_provider_ops_t UMF_TRACKING_MEMORY_PROVIDER_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_PROVIDER_OPS_VERSION_CURRENT,
     .initialize = trackingInitialize,
     .finalize = trackingFinalize,
     .alloc = trackingAlloc,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -625,6 +625,20 @@ if(LINUX
                  "LD_LIBRARY_PATH=path_list_append:${CMAKE_BINARY_DIR}/lib")
 endif()
 
+if(LINUX
+   AND UMF_BUILD_SHARED_LIBRARY
+   AND NOT UMF_DISABLE_HWLOC)
+    add_umf_test(
+        NAME multiple_symbols
+        SRCS test_multiple_symbols.c
+        LIBS dl)
+    # append LD_LIBRARY_PATH to the libumf
+    set_property(
+        TEST umf-multiple_symbols
+        PROPERTY ENVIRONMENT_MODIFICATION
+                 "LD_LIBRARY_PATH=path_list_append:${CMAKE_BINARY_DIR}/lib")
+endif()
+
 # Tests of examples as standalone projects. TODO: enable this for Windows (maybe
 # replace test_examples.sh with CMake script?)
 if(LINUX

--- a/test/common/pool_null.c
+++ b/test/common/pool_null.c
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -64,7 +64,7 @@ static umf_result_t nullGetLastStatus(void *pool) {
 }
 
 umf_memory_pool_ops_t UMF_NULL_POOL_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_POOL_OPS_VERSION_CURRENT,
     .initialize = nullInitialize,
     .finalize = nullFinalize,
     .malloc = nullMalloc,

--- a/test/common/pool_trace.c
+++ b/test/common/pool_trace.c
@@ -90,7 +90,7 @@ static umf_result_t traceGetLastStatus(void *pool) {
 }
 
 umf_memory_pool_ops_t UMF_TRACE_POOL_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_POOL_OPS_VERSION_CURRENT,
     .initialize = traceInitialize,
     .finalize = traceFinalize,
     .malloc = traceMalloc,

--- a/test/common/provider_null.c
+++ b/test/common/provider_null.c
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -130,7 +130,7 @@ static umf_result_t nullCloseIpcHandle(void *provider, void *ptr, size_t size) {
 }
 
 umf_memory_provider_ops_t UMF_NULL_PROVIDER_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_PROVIDER_OPS_VERSION_CURRENT,
     .initialize = nullInitialize,
     .finalize = nullFinalize,
     .alloc = nullAlloc,

--- a/test/common/provider_trace.c
+++ b/test/common/provider_trace.c
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -191,7 +191,7 @@ static umf_result_t traceCloseIpcHandle(void *provider, void *ptr,
 }
 
 umf_memory_provider_ops_t UMF_TRACE_PROVIDER_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_PROVIDER_OPS_VERSION_CURRENT,
     .initialize = traceInitialize,
     .finalize = traceFinalize,
     .alloc = traceAlloc,

--- a/test/test_multiple_symbols.c
+++ b/test/test_multiple_symbols.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2024-2025 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+*/
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include <umf/memory_provider_ops.h>
+
+typedef void *(*umfGetPtr_t)(void);
+
+// UMF so handle
+static void *h_umf;
+
+static void load_symbol(void *handle, const char *name, void **dest) {
+    void *symbol = dlsym(handle, name);
+    if (symbol == NULL) {
+        fprintf(stderr, "umf_load: symbol %s NOT found\n", name);
+        *dest = NULL;
+        return;
+    }
+
+    fprintf(stderr, "umf_load: symbol found: %s\n", name);
+
+    *dest = symbol;
+}
+
+static int umf_load() {
+    umfGetPtr_t umfFileMemoryProviderOps;
+    umfGetPtr_t umfFileMemoryProviderOps_0_11;
+    umfGetPtr_t umfDevDaxMemoryProviderOps;
+    umfGetPtr_t umfDevDaxMemoryProviderOps_0_11;
+
+    char *umf_lib_name = "libumf.so";
+    h_umf = dlopen(umf_lib_name, RTLD_LAZY);
+    if (h_umf == NULL) {
+        fprintf(stderr, "umf_load: UMF library not found (%s)\n", umf_lib_name);
+        return -1;
+    }
+
+    load_symbol(h_umf, "umfFileMemoryProviderOps",
+                (void **)&umfFileMemoryProviderOps);
+    if (umfFileMemoryProviderOps == NULL) {
+        goto err_dlclose;
+    } else {
+        umf_memory_provider_ops_t *ops = umfFileMemoryProviderOps();
+        if (ops == NULL) {
+            fprintf(stderr, "umfFileMemoryProviderOps: NULL ops\n");
+            goto err_dlclose;
+        }
+
+        // default version of umfFileMemoryProviderOps should return ops_0_10
+        if (ops->version != UMF_MAKE_VERSION(0, 10)) {
+            fprintf(stderr, "umfFileMemoryProviderOps: bad ops version\n");
+            goto err_dlclose;
+        }
+    }
+
+    load_symbol(h_umf, "umfFileMemoryProviderOps_0_11",
+                (void **)&umfFileMemoryProviderOps_0_11);
+    if (umfFileMemoryProviderOps_0_11 == NULL) {
+        goto err_dlclose;
+    } else {
+        umf_memory_provider_ops_0_11_t *ops = umfFileMemoryProviderOps_0_11();
+        if (ops == NULL) {
+            fprintf(stderr, "umfFileMemoryProviderOps_0_11: NULL ops\n");
+            goto err_dlclose;
+        }
+
+        if (ops->version != UMF_MAKE_VERSION(0, 11)) {
+            fprintf(stderr, "umfFileMemoryProviderOps_0_11: bad ops version\n");
+            goto err_dlclose;
+        }
+    }
+
+    load_symbol(h_umf, "umfDevDaxMemoryProviderOps",
+                (void **)&umfDevDaxMemoryProviderOps);
+    if (umfDevDaxMemoryProviderOps == NULL) {
+        goto err_dlclose;
+    } else {
+        umf_memory_provider_ops_t *ops = umfDevDaxMemoryProviderOps();
+        if (ops == NULL) {
+            fprintf(stderr, "umfDevDaxMemoryProviderOps: NULL ops\n");
+            goto err_dlclose;
+        }
+
+        // default version of umfDevDaxMemoryProviderOps should return ops_0_10
+        if (ops->version != UMF_MAKE_VERSION(0, 10)) {
+            fprintf(stderr, "umfDevDaxMemoryProviderOps: bad ops version\n");
+            goto err_dlclose;
+        }
+    }
+
+    load_symbol(h_umf, "umfDevDaxMemoryProviderOps_0_11",
+                (void **)&umfDevDaxMemoryProviderOps_0_11);
+    if (umfDevDaxMemoryProviderOps_0_11 == NULL) {
+        goto err_dlclose;
+    } else {
+        umf_memory_provider_ops_0_11_t *ops = umfDevDaxMemoryProviderOps_0_11();
+        if (ops == NULL) {
+            fprintf(stderr, "umfDevDaxMemoryProviderOps_0_11: NULL ops\n");
+            goto err_dlclose;
+        }
+
+        if (ops->version != UMF_MAKE_VERSION(0, 11)) {
+            fprintf(stderr,
+                    "umfDevDaxMemoryProviderOps_0_11: bad ops version\n");
+            goto err_dlclose;
+        }
+    }
+
+    return 0;
+
+err_dlclose:
+    dlclose(h_umf);
+
+    return -1;
+}
+
+static void umf_unload() {
+    fprintf(stderr, "umf_unload: closing umf library ...\n");
+    dlclose(h_umf);
+    fprintf(stderr, "umf_unload: umf library closed\n");
+}
+
+int main(void) {
+
+    if (umf_load()) {
+        return -1;
+    }
+
+    umf_unload();
+    return 0;
+}


### PR DESCRIPTION
Add backward compatibility workflow and tests.

Suppose we have umfFunc_0_11 and umfFunc_0_10. With this PR:
* "umfFunc" == "umfFunc_0_11" in compile time (using #define)
* UMF exports 2 symbols: "umfFunc@@UMF_0.10" and "umfFunc_0_11@@UMF_0.11"
* dlsym("umfFunc") == "umfFunc_0_10"
* dlsym("umfFunc_0_11") == "umfFunc_0_11"

Major changes:
* use UMF_PROVIDER_OPS_VERSION_CURRENT and UMF_POOL_OPS_VERSION_CURRENT for versioning memory provider and pools struct instead of UMF_VERSION_CURRENT that would be used only for versioning the lib
* add new implementation for umfDevDaxMemoryProviderOps and umfFileMemoryProviderOps ver 0.11
* handle old (0.10) provider ops in umfMemoryProviderCreate
* do not assert when the user pass an old provider/pool version of ops to umfMemoryProvider/PoolCreate and print a warning instead
* add tests for multiple symbols (file and DevDax providers ops) - assume that calling dlsym without a specified version returns the oldest implementation


fixes https://github.com/oneapi-src/unified-memory-framework/issues/908 