### PR TITLE
Add LIBHWLOC_INCLUDE_DIRS to build_umf_test()

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -59,6 +59,10 @@ function(build_umf_test)
         set(INC_DIRS ${INC_DIRS} ${LEVEL_ZERO_INCLUDE_DIRS})
     endif()
 
+    if(UMF_LINK_HWLOC_STATICALLY)
+        set(INC_DIRS ${INC_DIRS} ${LIBHWLOC_INCLUDE_DIRS})
+    endif()
+
     if(UMF_POOL_JEMALLOC_ENABLED)
         set(CPL_DEFS ${CPL_DEFS} UMF_POOL_JEMALLOC_ENABLED=1)
     endif()


### PR DESCRIPTION
### Description

Add `LIBHWLOC_INCLUDE_DIRS` to `build_umf_test()`
when `UMF_LINK_HWLOC_STATICALLY` is ON.

Ref: #1065

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
