### PR TITLE
Fix bench cache restore

### DIFF
--- a/.github/workflows/reusable_benchmarks.yml
+++ b/.github/workflows/reusable_benchmarks.yml
@@ -159,5 +159,5 @@ jobs:
       if: ${{ always() && inputs.upload_report }}
       uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
-        path: ${{env.BUILD_DIR}}/benchmark_results.html
+        path: umf-repo/build/benchmark_results.html
         key: benchmark-results-${{ github.run_id }}

--- a/.github/workflows/reusable_docs_build.yml
+++ b/.github/workflows/reusable_docs_build.yml
@@ -45,20 +45,19 @@ jobs:
           -DUMF_DISABLE_HWLOC=ON
         cmake --build build --target docs
 
-    - name: Download benchmark HTML before uploading with documentation on GitHub pages
-    # If the benchmark results are meant to be uploaded on GH pages
+    # If we upload HTML docs, we want to include benchmark results as well
+    - name: Download benchmark HTML before uploading docs
       if: ${{ inputs.upload == true }}
       id: download-bench-html
       uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
-        path: ${{github.workspace}}/build/benchmark_results.html
+        path: umf-repo/build/benchmark_results.html
         key: benchmark-results-
 
     - name: Move benchmark HTML
       if: ${{ inputs.upload == true && steps.download-bench-html.outputs.cache-hit != '' }}
-      # exact or partial cache hit
       run: |
-        mv ${{ github.workspace }}/build/benchmark_results.html ${{ github.workspace }}/build/docs_build/generated/html
+        mv umf-repo/build/benchmark_results.html ${{github.workspace}}/build/docs_build/generated/html
 
     - name: Upload artifact
       if: ${{ inputs.upload == true }}


### PR DESCRIPTION
Fix cache for bench results - dir should most likely match, when cached and restored.

Side note, caches are accessible only on the same branch - PR cannot access caches from, e.g., main branch.

// I tested this only partially: https://github.com/oneapi-src/unified-memory-framework/actions/runs/13075967093/job/36488171640