### PR TITLE
Fix using LIBHWLOC_INCLUDE_DIRS in tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -59,7 +59,7 @@ function(build_umf_test)
         set(INC_DIRS ${INC_DIRS} ${LEVEL_ZERO_INCLUDE_DIRS})
     endif()
 
-    if(UMF_LINK_HWLOC_STATICALLY)
+    if(NOT UMF_DISABLE_HWLOC)
         set(INC_DIRS ${INC_DIRS} ${LIBHWLOC_INCLUDE_DIRS})
     endif()
 


### PR DESCRIPTION

<!-- Provide a short summary of your changes in the Title above -->

### Description

`LIBHWLOC_INCLUDE_DIRS` should be used always
when hwloc is not disabled.

Ref: #1066

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
