### PR TITLE
Increase pool size of the "leak" base allocator in proxy lib

### DIFF
--- a/src/proxy_lib/proxy_lib.c
+++ b/src/proxy_lib/proxy_lib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Intel Corporation
+ * Copyright (C) 2024-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -301,7 +301,9 @@ static inline void *ba_generic_realloc(umf_ba_linear_pool_t *pool, void *ptr,
 /*** The "LEAK" linear base allocator functions ******************************/
 /*****************************************************************************/
 
-static void ba_leak_create(void) { Base_alloc_leak = umf_ba_linear_create(0); }
+static void ba_leak_create(void) {
+    Base_alloc_leak = umf_ba_linear_create(4 * 1024 * 1024);
+}
 
 // it does not implement destroy(), because we cannot destroy non-freed memory
 


### PR DESCRIPTION
This improves search time if ptr belongs to leak pool, during free

<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
