### PR TITLE
add clangd files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,7 @@ out/
 # IDE Files
 /.vscode
 /.devcontainer
+
+# clangd files
+/.cache/clangd
+compile_commands.json


### PR DESCRIPTION
add clangd files to gitignore:

./.cache/clangd
compile_commands.json
