### PR TITLE
add support for CUDA allocation flags

### DIFF
--- a/include/umf/providers/provider_cuda.h
+++ b/include/umf/providers/provider_cuda.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Intel Corporation
+ * Copyright (C) 2024-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -52,6 +52,13 @@ umf_result_t umfCUDAMemoryProviderParamsSetDevice(
 umf_result_t umfCUDAMemoryProviderParamsSetMemoryType(
     umf_cuda_memory_provider_params_handle_t hParams,
     umf_usm_memory_type_t memoryType);
+
+/// @brief  Set the allocation flags in the parameters struct.
+/// @param  hParams handle to the parameters of the CUDA Memory Provider.
+/// @param  flags valid combination of CUDA allocation flags.
+/// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
+umf_result_t umfCUDAMemoryProviderParamsSetAllocFlags(
+    umf_cuda_memory_provider_params_handle_t hParams, unsigned int flags);
 
 umf_memory_provider_ops_t *umfCUDAMemoryProviderOps(void);
 

--- a/src/libumf.def
+++ b/src/libumf.def
@@ -118,6 +118,7 @@ EXPORTS
     umfScalablePoolParamsSetGranularity
     umfScalablePoolParamsSetKeepAllMemory
 ; Added in UMF_0.11
+    umfCUDAMemoryProviderParamsSetAllocFlags
     umfFixedMemoryProviderOps
     umfFixedMemoryProviderParamsCreate
     umfFixedMemoryProviderParamsDestroy

--- a/src/libumf.map
+++ b/src/libumf.map
@@ -116,6 +116,7 @@ UMF_0.10 {
 };
 
 UMF_0.11 {
+        umfCUDAMemoryProviderParamsSetAllocFlags;
         umfFixedMemoryProviderOps;
         umfFixedMemoryProviderParamsCreate;
         umfFixedMemoryProviderParamsDestroy;

--- a/test/providers/cuda_helpers.cpp
+++ b/test/providers/cuda_helpers.cpp
@@ -22,7 +22,7 @@ struct libcu_ops {
     CUresult (*cuDeviceGet)(CUdevice *device, int ordinal);
     CUresult (*cuMemAlloc)(CUdeviceptr *dptr, size_t size);
     CUresult (*cuMemFree)(CUdeviceptr dptr);
-    CUresult (*cuMemAllocHost)(void **pp, size_t size);
+    CUresult (*cuMemHostAlloc)(void **pp, size_t size, unsigned int flags);
     CUresult (*cuMemAllocManaged)(CUdeviceptr *dptr, size_t bytesize,
                                   unsigned int flags);
     CUresult (*cuMemFreeHost)(void *p);
@@ -34,6 +34,7 @@ struct libcu_ops {
     CUresult (*cuPointerGetAttributes)(unsigned int numAttributes,
                                        CUpointer_attribute *attributes,
                                        void **data, CUdeviceptr ptr);
+    CUresult (*cuMemHostGetFlags)(unsigned int *pFlags, void *p);
     CUresult (*cuStreamSynchronize)(CUstream hStream);
     CUresult (*cuCtxSynchronize)(void);
 } libcu_ops;
@@ -69,7 +70,7 @@ struct DlHandleCloser {
             libcu_ops.cuMemFree = [](auto... args) {
                 return noop_stub(args...);
             };
-            libcu_ops.cuMemAllocHost = [](auto... args) {
+            libcu_ops.cuMemHostAlloc = [](auto... args) {
                 return noop_stub(args...);
             };
             libcu_ops.cuMemAllocManaged = [](auto... args) {
@@ -88,6 +89,9 @@ struct DlHandleCloser {
                 return noop_stub(args...);
             };
             libcu_ops.cuPointerGetAttributes = [](auto... args) {
+                return noop_stub(args...);
+            };
+            libcu_ops.cuMemHostGetFlags = [](auto... args) {
                 return noop_stub(args...);
             };
             libcu_ops.cuStreamSynchronize = [](auto... args) {
@@ -164,10 +168,10 @@ int InitCUDAOps() {
         fprintf(stderr, "cuMemFree_v2 symbol not found in %s\n", lib_name);
         return -1;
     }
-    *(void **)&libcu_ops.cuMemAllocHost =
-        utils_get_symbol_addr(cuDlHandle.get(), "cuMemAllocHost_v2", lib_name);
-    if (libcu_ops.cuMemAllocHost == nullptr) {
-        fprintf(stderr, "cuMemAllocHost_v2 symbol not found in %s\n", lib_name);
+    *(void **)&libcu_ops.cuMemHostAlloc =
+        utils_get_symbol_addr(cuDlHandle.get(), "cuMemHostAlloc", lib_name);
+    if (libcu_ops.cuMemHostAlloc == nullptr) {
+        fprintf(stderr, "cuMemHostAlloc symbol not found in %s\n", lib_name);
         return -1;
     }
     *(void **)&libcu_ops.cuMemAllocManaged =
@@ -208,6 +212,12 @@ int InitCUDAOps() {
                 lib_name);
         return -1;
     }
+    *(void **)&libcu_ops.cuMemHostGetFlags =
+        utils_get_symbol_addr(cuDlHandle.get(), "cuMemHostGetFlags", lib_name);
+    if (libcu_ops.cuMemHostGetFlags == nullptr) {
+        fprintf(stderr, "cuMemHostGetFlags symbol not found in %s\n", lib_name);
+        return -1;
+    }
     *(void **)&libcu_ops.cuStreamSynchronize = utils_get_symbol_addr(
         cuDlHandle.get(), "cuStreamSynchronize", lib_name);
     if (libcu_ops.cuStreamSynchronize == nullptr) {
@@ -236,7 +246,7 @@ int InitCUDAOps() {
     libcu_ops.cuCtxSetCurrent = cuCtxSetCurrent;
     libcu_ops.cuDeviceGet = cuDeviceGet;
     libcu_ops.cuMemAlloc = cuMemAlloc;
-    libcu_ops.cuMemAllocHost = cuMemAllocHost;
+    libcu_ops.cuMemHostAlloc = cuMemHostAlloc;
     libcu_ops.cuMemAllocManaged = cuMemAllocManaged;
     libcu_ops.cuMemFree = cuMemFree;
     libcu_ops.cuMemFreeHost = cuMemFreeHost;
@@ -244,6 +254,7 @@ int InitCUDAOps() {
     libcu_ops.cuMemcpy = cuMemcpy;
     libcu_ops.cuPointerGetAttribute = cuPointerGetAttribute;
     libcu_ops.cuPointerGetAttributes = cuPointerGetAttributes;
+    libcu_ops.cuMemHostGetFlags = cuMemHostGetFlags;
     libcu_ops.cuStreamSynchronize = cuStreamSynchronize;
     libcu_ops.cuCtxSynchronize = cuCtxSynchronize;
 
@@ -371,6 +382,17 @@ umf_usm_memory_type_t get_mem_type(CUcontext context, void *ptr) {
     }
 
     return UMF_MEMORY_TYPE_UNKNOWN;
+}
+
+unsigned int get_mem_host_alloc_flags(void *ptr) {
+    unsigned int flags;
+    CUresult res = libcu_ops.cuMemHostGetFlags(&flags, ptr);
+    if (res != CUDA_SUCCESS) {
+        fprintf(stderr, "cuPointerGetAttribute() failed!\n");
+        return 0;
+    }
+
+    return flags;
 }
 
 CUcontext get_mem_context(void *ptr) {

--- a/test/providers/cuda_helpers.h
+++ b/test/providers/cuda_helpers.h
@@ -44,6 +44,8 @@ int cuda_copy(CUcontext context, CUdevice device, void *dst_ptr,
 
 umf_usm_memory_type_t get_mem_type(CUcontext context, void *ptr);
 
+unsigned int get_mem_host_alloc_flags(void *ptr);
+
 CUcontext get_mem_context(void *ptr);
 
 CUcontext get_current_context();

--- a/test/providers/provider_cuda_not_impl.cpp
+++ b/test/providers/provider_cuda_not_impl.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2025 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -24,6 +24,9 @@ TEST_F(test, cuda_provider_not_implemented) {
 
     result = umfCUDAMemoryProviderParamsSetMemoryType(hParams,
                                                       UMF_MEMORY_TYPE_DEVICE);
+    ASSERT_EQ(result, UMF_RESULT_ERROR_NOT_SUPPORTED);
+
+    result = umfCUDAMemoryProviderParamsSetAllocFlags(hParams, 0);
     ASSERT_EQ(result, UMF_RESULT_ERROR_NOT_SUPPORTED);
 
     umf_memory_provider_ops_t *ops = umfCUDAMemoryProviderOps();


### PR DESCRIPTION
Add support for CUDA allocation flags.

This PR adds one new API call for CUDA:
- `umfCUDAMemoryProviderParamsSetAllocFlags()`


### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
