### PR TITLE
Fix icx build

### DIFF
--- a/.github/workflows/reusable_basic.yml
+++ b/.github/workflows/reusable_basic.yml
@@ -179,7 +179,8 @@ jobs:
     - name: Run tests
       working-directory: ${{env.BUILD_DIR}}
       run: |
-        LD_LIBRARY_PATH=${{env.BUILD_DIR}}/lib/ ctest --output-on-failure # run all tests for better coverage
+        ${{ matrix.compiler.cxx == 'icpx' && '. /opt/intel/oneapi/setvars.sh' || true }}
+        LD_LIBRARY_PATH="${{env.BUILD_DIR}}/lib/:${LD_LIBRARY_PATH}" ctest --output-on-failure
 
     - name: Check coverage
       if:  ${{ matrix.build_type == 'Debug' && matrix.compiler.c == 'gcc' }}

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -378,9 +378,6 @@ function(add_umf_library)
         elseif(LINUX)
             target_link_options(${ARG_NAME} PRIVATE
                                 "-Wl,--version-script=${ARG_LINUX_MAP_FILE}")
-            if(CMAKE_C_COMPILER_ID STREQUAL "IntelLLVM")
-                target_link_options(${ARG_NAME} PRIVATE -no-intel-lib)
-            endif()
         endif()
     endif()
 


### PR DESCRIPTION
partially reverts changes from #1030 

`-no-intel-lib` breaks the compiler's build, as these extra intel libs should be normally usable and reachable.

Fix our CI build with sourcing setvars and updating LD_LIBRARY_PATH.

// Verified on my fork, ICX build only: https://github.com/lukaszstolarczuk/unified-memory-framework/actions/runs/13200540850