### PR TITLE
Increase refcount to ze_loader/CUDA libraries when Level Zero/CUDA providers are used

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -86,6 +86,16 @@ function(add_umf_benchmark)
         set_property(TEST ${BENCH_NAME} PROPERTY ENVIRONMENT_MODIFICATION
                                                  "${DLL_PATH_LIST}")
     endif()
+    if(LINUX)
+        # prepend LD_LIBRARY_PATH with ${CMAKE_BINARY_DIR}/lib it is required
+        # because ${CMAKE_BINARY_DIR}/lib contains libze_loader.so and tests
+        # should use it instead of system one.
+        set_property(
+            TEST ${BENCH_NAME}
+            PROPERTY ENVIRONMENT_MODIFICATION
+                     "LD_LIBRARY_PATH=path_list_prepend:${CMAKE_BINARY_DIR}/lib"
+        )
+    endif()
 
     if(UMF_BUILD_LIBUMF_POOL_DISJOINT)
         target_compile_definitions(${BENCH_NAME}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -72,6 +72,16 @@ if(UMF_BUILD_GPU_EXAMPLES
         set_property(TEST ${EXAMPLE_NAME} PROPERTY ENVIRONMENT_MODIFICATION
                                                    "${DLL_PATH_LIST}")
     endif()
+    if(LINUX)
+        # prepend LD_LIBRARY_PATH with ${CMAKE_BINARY_DIR}/lib it is required
+        # because ${CMAKE_BINARY_DIR}/lib contains libze_loader.so and tests
+        # should use it instead of system one.
+        set_property(
+            TEST ${EXAMPLE_NAME}
+            PROPERTY ENVIRONMENT_MODIFICATION
+                     "LD_LIBRARY_PATH=path_list_prepend:${CMAKE_BINARY_DIR}/lib"
+        )
+    endif()
 else()
     message(STATUS "GPU Level Zero shared memory example requires "
                    "UMF_BUILD_GPU_EXAMPLES, UMF_BUILD_LEVEL_ZERO_PROVIDER and "
@@ -150,6 +160,16 @@ if(UMF_BUILD_GPU_EXAMPLES
         # append PATH to DLLs
         set_property(TEST ${EXAMPLE_NAME} PROPERTY ENVIRONMENT_MODIFICATION
                                                    "${DLL_PATH_LIST}")
+    endif()
+    if(LINUX)
+        # prepend LD_LIBRARY_PATH with ${CMAKE_BINARY_DIR}/lib it is required
+        # because ${CMAKE_BINARY_DIR}/lib contains libze_loader.so and tests
+        # should use it instead of system one.
+        set_property(
+            TEST ${EXAMPLE_NAME}
+            PROPERTY ENVIRONMENT_MODIFICATION
+                     "LD_LIBRARY_PATH=path_list_prepend:${CMAKE_BINARY_DIR}/lib"
+        )
     endif()
 else()
     message(

--- a/examples/ipc_level_zero/CMakeLists.txt
+++ b/examples/ipc_level_zero/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2024-2025 Intel Corporation
 # Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -69,6 +69,6 @@ if(LINUX)
         TEST ${EXAMPLE_NAME}
         PROPERTY
             ENVIRONMENT_MODIFICATION
-            "LD_LIBRARY_PATH=path_list_append:${LIBUMF_LIBRARY_DIRS};LD_LIBRARY_PATH=path_list_append:${LIBHWLOC_LIBRARY_DIRS}"
+            "LD_LIBRARY_PATH=path_list_prepend:${LIBUMF_LIBRARY_DIRS};LD_LIBRARY_PATH=path_list_append:${LIBHWLOC_LIBRARY_DIRS}"
     )
 endif()

--- a/examples/level_zero_shared_memory/CMakeLists.txt
+++ b/examples/level_zero_shared_memory/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2024-2025 Intel Corporation
 # Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -70,6 +70,6 @@ if(LINUX)
         TEST ${EXAMPLE_NAME}
         PROPERTY
             ENVIRONMENT_MODIFICATION
-            "LD_LIBRARY_PATH=path_list_append:${LIBUMF_LIBRARY_DIRS};LD_LIBRARY_PATH=path_list_append:${LIBHWLOC_LIBRARY_DIRS}"
+            "LD_LIBRARY_PATH=path_list_prepend:${LIBUMF_LIBRARY_DIRS};LD_LIBRARY_PATH=path_list_append:${LIBHWLOC_LIBRARY_DIRS}"
     )
 endif()

--- a/include/umf/base.h
+++ b/include/umf/base.h
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -45,6 +45,8 @@ typedef enum umf_result_t {
     UMF_RESULT_ERROR_NOT_SUPPORTED = 5, ///< Operation not supported
     UMF_RESULT_ERROR_USER_SPECIFIC =
         6, ///< Failure in user provider code (i.e in user provided callback)
+    UMF_RESULT_ERROR_DEPENDENCY_UNAVAILABLE =
+        7, ///< External required dependency is unavailable or missing
     UMF_RESULT_ERROR_UNKNOWN = 0x7ffffffe ///< Unknown or internal error
 } umf_result_t;
 

--- a/src/libumf.c
+++ b/src/libumf.c
@@ -12,6 +12,7 @@
 #include "base_alloc_global.h"
 #include "ipc_cache.h"
 #include "memspace_internal.h"
+#include "provider_cuda_internal.h"
 #include "provider_level_zero_internal.h"
 #include "provider_tracking.h"
 #include "utils_common.h"
@@ -81,6 +82,7 @@ void umfTearDown(void) {
 
     fini_umfTearDown:
         fini_ze_global_state();
+        fini_cu_global_state();
         LOG_DEBUG("UMF library finalized");
     }
 }

--- a/src/libumf.c
+++ b/src/libumf.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2024 Intel Corporation
+ * Copyright (C) 2024-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -12,6 +12,7 @@
 #include "base_alloc_global.h"
 #include "ipc_cache.h"
 #include "memspace_internal.h"
+#include "provider_level_zero_internal.h"
 #include "provider_tracking.h"
 #include "utils_common.h"
 #include "utils_log.h"
@@ -79,6 +80,7 @@ void umfTearDown(void) {
         LOG_DEBUG("UMF base allocator destroyed");
 
     fini_umfTearDown:
+        fini_ze_global_state();
         LOG_DEBUG("UMF library finalized");
     }
 }

--- a/src/provider/provider_cuda_internal.h
+++ b/src/provider/provider_cuda_internal.h
@@ -1,0 +1,10 @@
+/*
+ *
+ * Copyright (C) 2025 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ */
+
+void fini_cu_global_state(void);

--- a/src/provider/provider_level_zero_internal.h
+++ b/src/provider/provider_level_zero_internal.h
@@ -1,0 +1,10 @@
+/*
+ *
+ * Copyright (C) 2025 Intel Corporation
+ *
+ * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ */
+
+void fini_ze_global_state(void);

--- a/src/utils/utils_level_zero.cpp
+++ b/src/utils/utils_level_zero.cpp
@@ -144,10 +144,15 @@ int InitLevelZeroOps() {
     const char *lib_name = "libze_loader.so";
 #endif
     // Load Level Zero symbols
-    // NOTE that we use UMF_UTIL_OPEN_LIBRARY_GLOBAL which add all loaded symbols to the
+#if OPEN_ZE_LIBRARY_GLOBAL
+    // NOTE UMF_UTIL_OPEN_LIBRARY_GLOBAL adds all loaded symbols to the
     // global symbol table.
+    int open_flags = UMF_UTIL_OPEN_LIBRARY_GLOBAL;
+#else
+    int open_flags = 0;
+#endif
     zeDlHandle = std::unique_ptr<void, DlHandleCloser>(
-        utils_open_library(lib_name, UMF_UTIL_OPEN_LIBRARY_GLOBAL));
+        utils_open_library(lib_name, open_flags));
     *(void **)&libze_ops.zeInit =
         utils_get_symbol_addr(zeDlHandle.get(), "zeInit", lib_name);
     if (libze_ops.zeInit == nullptr) {

--- a/src/utils/utils_load_library.c
+++ b/src/utils/utils_load_library.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2024 Intel Corporation
+ * Copyright (C) 2024-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -32,7 +32,11 @@
 #ifdef _WIN32
 
 void *utils_open_library(const char *filename, int userFlags) {
-    (void)userFlags; //unused for win
+    if (userFlags & UMF_UTIL_OPEN_LIBRARY_NO_LOAD) {
+        HMODULE hModule;
+        BOOL ret = GetModuleHandleEx(0, TEXT(filename), &hModule);
+        return ret ? hModule : NULL;
+    }
     return LoadLibrary(TEXT(filename));
 }
 
@@ -65,6 +69,9 @@ void *utils_open_library(const char *filename, int userFlags) {
     int dlopenFlags = RTLD_LAZY;
     if (userFlags & UMF_UTIL_OPEN_LIBRARY_GLOBAL) {
         dlopenFlags |= RTLD_GLOBAL;
+    }
+    if (userFlags & UMF_UTIL_OPEN_LIBRARY_NO_LOAD) {
+        dlopenFlags |= RTLD_NOLOAD;
     }
 
     void *handle = dlopen(filename, dlopenFlags);

--- a/src/utils/utils_load_library.h
+++ b/src/utils/utils_load_library.h
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2024 Intel Corporation
+ * Copyright (C) 2024-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -17,7 +17,10 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+// The symbols defined by this library will be made available for symbol resolution of subsequently loaded libraries.
 #define UMF_UTIL_OPEN_LIBRARY_GLOBAL 1
+// Don't load the library. utils_open_library succeeds if the library is already loaded.
+#define UMF_UTIL_OPEN_LIBRARY_NO_LOAD 1 << 1
 
 void *utils_open_library(const char *filename, int userFlags);
 int utils_close_library(void *handle);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -154,6 +154,16 @@ function(add_umf_test)
         set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT_MODIFICATION
                                                 "${DLL_PATH_LIST}")
     endif()
+    if(LINUX)
+        # prepend LD_LIBRARY_PATH with ${CMAKE_BINARY_DIR}/lib it is required
+        # because ${CMAKE_BINARY_DIR}/lib contains libze_loader.so and tests
+        # should use it instead of system one.
+        set_property(
+            TEST ${TEST_NAME}
+            PROPERTY ENVIRONMENT_MODIFICATION
+                     "LD_LIBRARY_PATH=path_list_prepend:${CMAKE_BINARY_DIR}/lib"
+        )
+    endif()
 endfunction()
 
 add_subdirectory(common)
@@ -535,6 +545,16 @@ function(add_umf_ipc_test)
     if(NOT UMF_TESTS_FAIL_ON_SKIP)
         set_tests_properties(${TEST_NAME} PROPERTIES SKIP_RETURN_CODE 125)
     endif()
+    if(LINUX)
+        # prepend LD_LIBRARY_PATH with ${CMAKE_BINARY_DIR}/lib it is required
+        # because ${CMAKE_BINARY_DIR}/lib contains libze_loader.so and tests
+        # should use it instead of system one.
+        set_property(
+            TEST ${TEST_NAME}
+            PROPERTY ENVIRONMENT_MODIFICATION
+                     "LD_LIBRARY_PATH=path_list_prepend:${CMAKE_BINARY_DIR}/lib"
+        )
+    endif()
 endfunction()
 
 if(LINUX)
@@ -740,5 +760,15 @@ if(LINUX
                 "${CMAKE_INSTALL_PREFIX}" "${STANDALONE_CMAKE_OPTIONS}"
                 ${EXAMPLES}
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+        if(LINUX)
+            # prepend LD_LIBRARY_PATH with ${CMAKE_BINARY_DIR}/lib it is
+            # required because ${CMAKE_BINARY_DIR}/lib contains libze_loader.so
+            # and tests should use it instead of system one.
+            set_property(
+                TEST umf-standalone_examples
+                PROPERTY
+                    ENVIRONMENT_MODIFICATION
+                    "LD_LIBRARY_PATH=path_list_prepend:${CMAKE_BINARY_DIR}/lib")
+        endif()
     endif()
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -415,12 +415,20 @@ if(UMF_BUILD_GPU_TESTS AND UMF_BUILD_LEVEL_ZERO_PROVIDER)
         LIBS ${UMF_UTILS_FOR_TEST} ze_loader)
 
     add_umf_test(
-        NAME provider_level_zero_dlopen
+        NAME provider_level_zero_dlopen_global
         SRCS providers/provider_level_zero.cpp
              ${UMF_UTILS_DIR}/utils_level_zero.cpp ${BA_SOURCES_FOR_TEST}
         LIBS ${UMF_UTILS_FOR_TEST})
-    target_compile_definitions(umf_test-provider_level_zero_dlopen
-                               PUBLIC USE_DLOPEN=1)
+    target_compile_definitions(umf_test-provider_level_zero_dlopen_global
+                               PUBLIC USE_DLOPEN=1 OPEN_ZE_LIBRARY_GLOBAL=1)
+
+    add_umf_test(
+        NAME provider_level_zero_dlopen_local
+        SRCS providers/provider_level_zero.cpp
+             ${UMF_UTILS_DIR}/utils_level_zero.cpp ${BA_SOURCES_FOR_TEST}
+        LIBS ${UMF_UTILS_FOR_TEST})
+    target_compile_definitions(umf_test-provider_level_zero_dlopen_local
+                               PUBLIC USE_DLOPEN=1 OPEN_ZE_LIBRARY_GLOBAL=0)
 endif()
 
 if(NOT UMF_BUILD_LEVEL_ZERO_PROVIDER)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -450,12 +450,20 @@ if(UMF_BUILD_GPU_TESTS AND UMF_BUILD_CUDA_PROVIDER)
             LIBS ${UMF_UTILS_FOR_TEST} cuda)
 
         add_umf_test(
-            NAME provider_cuda_dlopen
+            NAME provider_cuda_dlopen_global
             SRCS providers/provider_cuda.cpp providers/cuda_helpers.cpp
                  ${BA_SOURCES_FOR_TEST}
             LIBS ${UMF_UTILS_FOR_TEST})
-        target_compile_definitions(umf_test-provider_cuda_dlopen
-                                   PUBLIC USE_DLOPEN=1)
+        target_compile_definitions(umf_test-provider_cuda_dlopen_global
+                                   PUBLIC USE_DLOPEN=1 OPEN_CU_LIBRARY_GLOBAL=1)
+
+        add_umf_test(
+            NAME provider_cuda_dlopen_local
+            SRCS providers/provider_cuda.cpp providers/cuda_helpers.cpp
+                 ${BA_SOURCES_FOR_TEST}
+            LIBS ${UMF_UTILS_FOR_TEST})
+        target_compile_definitions(umf_test-provider_cuda_dlopen_local
+                                   PUBLIC USE_DLOPEN=1 OPEN_CU_LIBRARY_GLOBAL=0)
     else()
         message(
             STATUS

--- a/test/providers/cuda_helpers.cpp
+++ b/test/providers/cuda_helpers.cpp
@@ -113,10 +113,15 @@ int InitCUDAOps() {
     const char *lib_name = "libcuda.so";
 #endif
     // CUDA symbols
-    // NOTE that we use UMF_UTIL_OPEN_LIBRARY_GLOBAL which add all loaded
-    // symbols to the global symbol table.
+#if OPEN_CU_LIBRARY_GLOBAL
+    // NOTE UMF_UTIL_OPEN_LIBRARY_GLOBAL adds all loaded symbols to the
+    // global symbol table.
+    int open_flags = UMF_UTIL_OPEN_LIBRARY_GLOBAL;
+#else
+    int open_flags = 0;
+#endif
     cuDlHandle = std::unique_ptr<void, DlHandleCloser>(
-        utils_open_library(lib_name, UMF_UTIL_OPEN_LIBRARY_GLOBAL));
+        utils_open_library(lib_name, open_flags));
 
     // NOTE: some symbols defined in the lib have _vX postfixes - this is
     // important to load the proper version of functions


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description
Prior to this PR, the Level Zero provider did not `dlopen(“libze_loader.so”)` at all. We suppose that UMF’s client, who uses Level Zero provider, loaded `libze_loader.so` into the process. But what if there are two clients in the process:

1. The first client loads `libze_loader.so` into the process and uses the Level Zero provider. In that case, UMF inits Level Zero symbols via `dlsym`. Then the first client destroys the Level Zero Memory provider and unloads the `libze_loader.so`.
2. Then the second client loads `libze_loader.so` into the process and uses the Level Zero provider. But our current implementation does not catch such situation and Level Zero symbols are considered initialized, but the `dlsym` should be done again.

This PR fixes that. The UMF acquires handle to the `libze_loader.so` via `dlopen`. There is a `RTLD_NOLOAD` flag that tells `dlopen` not to load the library and succeed only if the library is already loaded. It allows to increase the refcount to the `libze_loader.so` and not unload it when the first client calls `dlclose`.

This PR should fix the #926.

Fixes: https://github.com/intel/llvm/issues/16944 (confirmed by @ldorau)

### Checklist

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
- [x] New tests added, especially if they will fail without my changes
- [x] All newly added source files have a license
- [x] All newly added source files are referenced in CMake files

