### PR TITLE
Add backward compatibility workflow and tests (ver 2)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,3 +36,4 @@ Before checking all the boxes please mark the PR as draft.
 - [ ] All newly added source files have a license
 - [ ] All newly added source files are referenced in CMake files
 - [ ] Logger (with debug/info/... messages) is used
+- [ ] All API changes are reflected in docs and def/map files, and are tested

--- a/.github/workflows/pr_push.yml
+++ b/.github/workflows/pr_push.yml
@@ -85,3 +85,11 @@ jobs:
       contents: read
       security-events: write
     uses: ./.github/workflows/reusable_trivy.yml
+  Compatibility:
+    needs: [Build]
+    uses: ./.github/workflows/reusable_compatibility.yml
+    strategy:
+      matrix:
+        tag: ["v0.11.0-dev1"]
+    with:
+      tag: ${{matrix.tag}}

--- a/.github/workflows/reusable_compatibility.yml
+++ b/.github/workflows/reusable_compatibility.yml
@@ -1,0 +1,211 @@
+# Workflow for checkig the backward compatibility of UMF.
+# Test the latest UMF shared library with binaries compiled using the older UMF 
+# shared library.
+name: Compatibility 
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Check backward compatibility with this tag
+        type: string
+        default: "v0.11.0-dev1"
+
+permissions:
+  contents: read
+
+jobs:
+  ubuntu-build:
+    name: Ubuntu
+    runs-on: 'ubuntu-22.04'
+
+    steps:
+    - name: Install apt packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang cmake libnuma-dev libtbb-dev
+
+    - name: Checkout "tag" UMF version
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        fetch-depth: 0
+        ref: refs/tags/${{inputs.tag}}
+        path: ${{github.workspace}}/tag_version
+
+    - name: Install libhwloc
+      working-directory: ${{github.workspace}}/tag_version
+      run: .github/scripts/install_hwloc.sh
+        
+    - name: Get "tag" UMF version
+      working-directory: ${{github.workspace}}/tag_version
+      run: |
+        VERSION=$(git describe --tags)
+        echo "tag version: $VERSION"
+
+    - name: Configure "tag" UMF build
+      working-directory: ${{github.workspace}}/tag_version
+      run: >
+        cmake
+        -B ${{github.workspace}}/tag_version/build
+        -DCMAKE_BUILD_TYPE=Debug
+        -DUMF_BUILD_SHARED_LIBRARY=ON
+        -DCMAKE_C_COMPILER=gcc
+        -DCMAKE_CXX_COMPILER=g++
+        -DUMF_BUILD_TESTS=ON
+        -DUMF_BUILD_LEVEL_ZERO_PROVIDER=ON
+        -DUMF_BUILD_CUDA_PROVIDER=ON
+        -DUMF_FORMAT_CODE_STYLE=OFF
+        -DUMF_DEVELOPER_MODE=ON
+        -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
+        -DUMF_BUILD_LIBUMF_POOL_DISJOINT=ON
+        -DUMF_TESTS_FAIL_ON_SKIP=ON
+
+    - name: Build "tag" UMF
+      working-directory: ${{github.workspace}}/tag_version
+      run: |
+        cmake --build ${{github.workspace}}/tag_version/build -j $(nproc)
+        
+    - name: Run "tag" UMF tests
+      working-directory: ${{github.workspace}}/tag_version/build
+      run: |
+        LD_LIBRARY_PATH=${{github.workspace}}/tag_version/build/lib/ ctest --output-on-failure
+
+    - name: Checkout latest UMF version
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        fetch-depth: 0
+        path: ${{github.workspace}}/latest_version
+        
+    - name: Get latest UMF version
+      working-directory: ${{github.workspace}}/latest_version
+      run: |
+        VERSION=$(git describe --tags)
+        echo "checked version: $VERSION"
+        
+    - name: Configure latest UMF build
+      working-directory: ${{github.workspace}}/latest_version
+      run: >
+        cmake
+        -B ${{github.workspace}}/latest_version/build
+        -DCMAKE_BUILD_TYPE=Debug
+        -DUMF_BUILD_SHARED_LIBRARY=ON
+        -DCMAKE_C_COMPILER=gcc
+        -DCMAKE_CXX_COMPILER=g++
+        -DUMF_BUILD_TESTS=OFF
+        -DUMF_BUILD_LEVEL_ZERO_PROVIDER=ON
+        -DUMF_BUILD_CUDA_PROVIDER=ON
+        -DUMF_FORMAT_CODE_STYLE=OFF
+        -DUMF_DEVELOPER_MODE=ON
+        -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
+        -DUMF_BUILD_LIBUMF_POOL_DISJOINT=ON
+        -DUMF_TESTS_FAIL_ON_SKIP=ON
+
+    - name: Build latest UMF
+      working-directory: ${{github.workspace}}/latest_version
+      run: |
+        cmake --build ${{github.workspace}}/latest_version/build -j $(nproc)
+
+    - name: Run "tag" UMF tests with latest UMF libs (warnings enabled)
+      working-directory: ${{github.workspace}}/tag_version/build
+      run: >
+        UMF_LOG="level:warning;flush:debug;output:stderr;pid:no" 
+        LD_LIBRARY_PATH=${{github.workspace}}/latest_version/build/lib/ 
+        ctest --output-on-failure
+ 
+  windows-build:
+    name: Windows
+    env:
+      VCPKG_PATH: "${{github.workspace}}/vcpkg/packages/hwloc_x64-windows;${{github.workspace}}/vcpkg/packages/tbb_x64-windows;${{github.workspace}}/vcpkg/packages/jemalloc_x64-windows"
+    runs-on: "windows-2022"
+
+    steps:
+    - name: Checkout "tag" UMF version
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        fetch-depth: 0
+        ref: refs/tags/${{inputs.tag}}
+        path: ${{github.workspace}}/tag_version
+
+    - name: Initialize vcpkg
+      uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5
+      with:
+        vcpkgGitCommitId: 3dd44b931481d7a8e9ba412621fa810232b66289
+        vcpkgDirectory: ${{github.workspace}}/vcpkg
+        vcpkgJsonGlob: '**/vcpkg.json'
+
+    - name: Install dependencies
+      working-directory: ${{github.workspace}}/tag_version
+      run: vcpkg install
+      shell: pwsh # Specifies PowerShell as the shell for running the script.
+    
+    - name: Get "tag" UMF version
+      working-directory: ${{github.workspace}}/tag_version
+      run: |
+        $version = (git describe --tags)
+        echo "tag version: $VERSION"
+
+    - name: Configure "tag" UMF build
+      working-directory: ${{github.workspace}}/tag_version
+      run: >
+        cmake
+        -B "${{github.workspace}}/tag_version/build"
+        -DCMAKE_PREFIX_PATH="${{env.VCPKG_PATH}}"
+        -DCMAKE_C_COMPILER=cl
+        -DCMAKE_CXX_COMPILER=cl
+        -DUMF_BUILD_SHARED_LIBRARY=ON
+        -DUMF_BUILD_TESTS=ON
+        -DUMF_BUILD_LEVEL_ZERO_PROVIDER=ON
+        -DUMF_BUILD_CUDA_PROVIDER=ON
+        -DUMF_FORMAT_CODE_STYLE=OFF
+        -DUMF_DEVELOPER_MODE=ON
+        -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
+        -DUMF_BUILD_LIBUMF_POOL_DISJOINT=ON
+        -DUMF_TESTS_FAIL_ON_SKIP=ON
+
+    - name: Build "tag" UMF
+      run: cmake --build "${{github.workspace}}/tag_version/build" --config Debug -j $Env:NUMBER_OF_PROCESSORS
+
+    - name: Run "tag" UMF tests
+      working-directory: "${{github.workspace}}/tag_version/build"
+      run: ctest -C Debug --output-on-failure --test-dir test
+
+    - name: Checkout latest UMF version
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        fetch-depth: 0
+        path: ${{github.workspace}}/latest_version
+
+    # NOTE we use vcpkg setup from "tag" version
+    - name: Get latest UMF version
+      working-directory: ${{github.workspace}}/latest_version
+      run: |
+        $version = (git describe --tags)
+        echo "latest version: $VERSION"
+
+    - name: Configure latest UMF build
+      working-directory: ${{github.workspace}}/latest_version
+      run: >
+        cmake
+        -B "${{github.workspace}}/latest_version/build"
+        -DCMAKE_PREFIX_PATH="${{env.VCPKG_PATH}}"
+        -DCMAKE_C_COMPILER=cl
+        -DCMAKE_CXX_COMPILER=cl
+        -DUMF_BUILD_SHARED_LIBRARY=ON
+        -DUMF_BUILD_TESTS=OFF
+        -DUMF_BUILD_LEVEL_ZERO_PROVIDER=ON
+        -DUMF_BUILD_CUDA_PROVIDER=ON
+        -DUMF_FORMAT_CODE_STYLE=OFF
+        -DUMF_DEVELOPER_MODE=ON
+        -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
+        -DUMF_BUILD_LIBUMF_POOL_DISJOINT=ON
+        -DUMF_TESTS_FAIL_ON_SKIP=ON
+
+    - name: Build latest UMF
+      run: cmake --build "${{github.workspace}}/latest_version/build" --config Debug -j $Env:NUMBER_OF_PROCESSORS
+
+    - name: Run "tag" UMF tests with latest UMF libs (warnings enabled)
+      working-directory: ${{github.workspace}}/tag_version/build
+      run: |
+        $env:UMF_LOG="level:warning;flush:debug;output:stderr;pid:no" 
+        cp ${{github.workspace}}/latest_version/build/bin/Debug/umf.dll ${{github.workspace}}/tag_version/build/bin/Debug/umf.dll
+        ctest -C Debug --output-on-failure --test-dir test

--- a/RELEASE_STEPS.md
+++ b/RELEASE_STEPS.md
@@ -40,6 +40,7 @@ Do changes for a release:
 - Add an entry to ChangeLog, remember to change the day of the week in the release date
   - For major and minor (prior 1.0.0) releases mention API and ABI compatibility with the previous release
 - For major and minor releases, update `UMF_VERSION_CURRENT` in `include/umf/base.h` (the API version)
+  - For changes in ops structures, update corresponding UMF_*_OPS_VERSION_CURRENT
 - For major and minor (prior 1.0.0) releases update ABI version in `.map` and `.def` files
   - These files are defined for all public libraries (`libumf` and `proxy_lib`, at the moment)
 - Commit these changes and tag the release:

--- a/examples/custom_file_provider/custom_file_provider.c
+++ b/examples/custom_file_provider/custom_file_provider.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2024 Intel Corporation
+ * Copyright (C) 2024-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -234,7 +234,7 @@ static umf_result_t file_get_min_page_size(void *provider, void *ptr,
 
 // File provider operations
 static umf_memory_provider_ops_t file_ops = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_PROVIDER_OPS_VERSION_CURRENT,
     .initialize = file_init,
     .finalize = file_deinit,
     .alloc = file_alloc,

--- a/include/umf/memory_pool.h
+++ b/include/umf/memory_pool.h
@@ -11,6 +11,7 @@
 #define UMF_MEMORY_POOL_H 1
 
 #include <umf/base.h>
+#include <umf/memory_pool_ops.h>
 #include <umf/memory_provider.h>
 
 #ifdef __cplusplus
@@ -21,12 +22,6 @@ extern "C" {
 ///        structure containing pointers to implementations of provider-specific
 ///        functions
 typedef struct umf_memory_pool_t *umf_memory_pool_handle_t;
-
-/// @brief This structure comprises function pointers used by corresponding umfPool*
-///        calls. Each memory pool implementation should initialize all function
-///        pointers.
-///
-typedef struct umf_memory_pool_ops_t umf_memory_pool_ops_t;
 
 /// @brief Supported pool creation flags
 typedef enum umf_pool_create_flag_t {

--- a/include/umf/memory_pool_ops.h
+++ b/include/umf/memory_pool_ops.h
@@ -17,6 +17,11 @@
 extern "C" {
 #endif
 
+/// @brief Version of the Memory Pool ops structure.
+/// NOTE: This is equal to the latest UMF version, in which the ops structure
+/// has been modified.
+#define UMF_POOL_OPS_VERSION_CURRENT UMF_MAKE_VERSION(0, 11)
+
 ///
 /// @brief This structure comprises function pointers used by corresponding umfPool*
 /// calls. Each memory pool implementation should initialize all function
@@ -24,7 +29,7 @@ extern "C" {
 ///
 typedef struct umf_memory_pool_ops_t {
     /// Version of the ops structure.
-    /// Should be initialized using UMF_VERSION_CURRENT.
+    /// Should be initialized using UMF_POOL_OPS_VERSION_CURRENT.
     uint32_t version;
 
     ///

--- a/include/umf/memory_provider_ops.h
+++ b/include/umf/memory_provider_ops.h
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -15,6 +15,11 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/// @brief Version of the Memory Provider ops structure.
+/// NOTE: This is equal to the latest UMF version, in which the ops structure
+/// has been modified.
+#define UMF_PROVIDER_OPS_VERSION_CURRENT UMF_MAKE_VERSION(0, 11)
 
 ///
 /// @brief This structure comprises optional function pointers used
@@ -143,7 +148,7 @@ typedef struct umf_memory_provider_ipc_ops_t {
 ///
 typedef struct umf_memory_provider_ops_t {
     /// Version of the ops structure.
-    /// Should be initialized using UMF_VERSION_CURRENT.
+    /// Should be initialized using UMF_PROVIDER_OPS_VERSION_CURRENT.
     uint32_t version;
 
     ///

--- a/src/cpp_helpers.hpp
+++ b/src/cpp_helpers.hpp
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -67,7 +67,7 @@ umf_result_t initialize(T *obj, ArgsTuple &&args) {
 
 template <typename T> umf_memory_pool_ops_t poolOpsBase() {
     umf_memory_pool_ops_t ops{};
-    ops.version = UMF_VERSION_CURRENT;
+    ops.version = UMF_POOL_OPS_VERSION_CURRENT;
     ops.finalize = [](void *obj) { delete reinterpret_cast<T *>(obj); };
     UMF_ASSIGN_OP(ops, T, malloc, ((void *)nullptr));
     UMF_ASSIGN_OP(ops, T, calloc, ((void *)nullptr));
@@ -81,7 +81,7 @@ template <typename T> umf_memory_pool_ops_t poolOpsBase() {
 
 template <typename T> constexpr umf_memory_provider_ops_t providerOpsBase() {
     umf_memory_provider_ops_t ops{};
-    ops.version = UMF_VERSION_CURRENT;
+    ops.version = UMF_PROVIDER_OPS_VERSION_CURRENT;
     ops.finalize = [](void *obj) { delete reinterpret_cast<T *>(obj); };
     UMF_ASSIGN_OP(ops, T, alloc, UMF_RESULT_ERROR_UNKNOWN);
     UMF_ASSIGN_OP(ops, T, free, UMF_RESULT_ERROR_UNKNOWN);

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -15,6 +15,7 @@
 #include "base_alloc_global.h"
 #include "ipc_internal.h"
 #include "memory_pool_internal.h"
+#include "memory_provider_internal.h"
 #include "provider/provider_tracking.h"
 #include "utils_common.h"
 #include "utils_log.h"
@@ -123,14 +124,14 @@ umf_result_t umfOpenIPCHandle(umf_ipc_handler_handle_t hIPCHandler,
                               umf_ipc_handle_t umfIPCHandle, void **ptr) {
 
     // IPC handler is an instance of tracking memory provider
-    if (*(uint32_t *)hIPCHandler != UMF_VERSION_CURRENT) {
+    umf_memory_provider_handle_t hProvider = hIPCHandler;
+    if (hProvider->ops.version != UMF_PROVIDER_OPS_VERSION_CURRENT) {
         // It is a temporary hack to verify that user passes correct IPC handler,
         // not a pool handle, as it was required in previous version.
         LOG_ERR("Invalid IPC handler.");
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
 
-    umf_memory_provider_handle_t hProvider = hIPCHandler;
     void *base = NULL;
 
     umf_result_t ret = umfMemoryProviderOpenIPCHandle(

--- a/src/memory_pool.c
+++ b/src/memory_pool.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -38,7 +38,11 @@ static umf_result_t umfPoolCreateInternal(const umf_memory_pool_ops_t *ops,
         return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
 
-    assert(ops->version == UMF_VERSION_CURRENT);
+    if (ops->version != UMF_POOL_OPS_VERSION_CURRENT) {
+        LOG_WARN("Memory Pool ops version \"%d\" is different than the current "
+                 "version \"%d\"",
+                 ops->version, UMF_POOL_OPS_VERSION_CURRENT);
+    }
 
     if (!(flags & UMF_POOL_CREATE_FLAG_DISABLE_TRACKING)) {
         // Wrap provider with memory tracking provider.

--- a/src/memory_provider.c
+++ b/src/memory_provider.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -19,11 +19,6 @@
 #include "libumf.h"
 #include "memory_provider_internal.h"
 #include "utils_assert.h"
-
-typedef struct umf_memory_provider_t {
-    umf_memory_provider_ops_t ops;
-    void *provider_priv;
-} umf_memory_provider_t;
 
 static umf_result_t umfDefaultPurgeLazy(void *provider, void *ptr,
                                         size_t size) {
@@ -167,13 +162,17 @@ umf_result_t umfMemoryProviderCreate(const umf_memory_provider_ops_t *ops,
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
 
+    if (ops->version != UMF_PROVIDER_OPS_VERSION_CURRENT) {
+        LOG_WARN("Memory Provider ops version \"%d\" is different than the "
+                 "current version \"%d\"",
+                 ops->version, UMF_PROVIDER_OPS_VERSION_CURRENT);
+    }
+
     umf_memory_provider_handle_t provider =
         umf_ba_global_alloc(sizeof(umf_memory_provider_t));
     if (!provider) {
         return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
-
-    assert(ops->version == UMF_VERSION_CURRENT);
 
     provider->ops = *ops;
 

--- a/src/memory_provider_internal.h
+++ b/src/memory_provider_internal.h
@@ -18,6 +18,11 @@
 extern "C" {
 #endif
 
+typedef struct umf_memory_provider_t {
+    umf_memory_provider_ops_t ops;
+    void *provider_priv;
+} umf_memory_provider_t;
+
 void *umfMemoryProviderGetPriv(umf_memory_provider_handle_t hProvider);
 umf_memory_provider_handle_t *umfGetLastFailedMemoryProviderPtr(void);
 

--- a/src/memtarget.c
+++ b/src/memtarget.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -15,6 +15,7 @@
 #include "memtarget_internal.h"
 #include "memtarget_ops.h"
 #include "utils_concurrency.h"
+#include "utils_log.h"
 
 umf_result_t umfMemtargetCreate(const umf_memtarget_ops_t *ops, void *params,
                                 umf_memtarget_handle_t *memoryTarget) {
@@ -29,7 +30,11 @@ umf_result_t umfMemtargetCreate(const umf_memtarget_ops_t *ops, void *params,
         return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
 
-    assert(ops->version == UMF_VERSION_CURRENT);
+    if (ops->version != UMF_MEMTARGET_OPS_VERSION_CURRENT) {
+        LOG_WARN("Memtarget ops version \"%d\" is different than the current "
+                 "version \"%d\"",
+                 ops->version, UMF_MEMTARGET_OPS_VERSION_CURRENT);
+    }
 
     target->ops = ops;
 

--- a/src/memtarget_internal.h
+++ b/src/memtarget_internal.h
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -16,7 +16,6 @@
 extern "C" {
 #endif
 
-struct umf_memtarget_ops_t;
 typedef struct umf_memtarget_ops_t umf_memtarget_ops_t;
 
 typedef struct umf_memtarget_t {

--- a/src/memtarget_ops.h
+++ b/src/memtarget_ops.h
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -18,9 +18,14 @@
 extern "C" {
 #endif
 
+// Version of the Memtarget ops structure.
+// NOTE: This is equal to the latest UMF version, in which the ops structure
+// has been modified.
+#define UMF_MEMTARGET_OPS_VERSION_CURRENT UMF_MAKE_VERSION(0, 11)
+
 typedef struct umf_memtarget_ops_t {
     /// Version of the ops structure.
-    /// Should be initialized using UMF_VERSION_CURRENT
+    /// Should be initialized using UMF_MEMTARGET_OPS_VERSION_CURRENT
     uint32_t version;
 
     umf_result_t (*initialize)(void *params, void **memoryTarget);

--- a/src/memtargets/memtarget_numa.c
+++ b/src/memtargets/memtarget_numa.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -390,7 +390,7 @@ static umf_result_t numa_compare(void *memTarget, void *otherMemTarget,
 }
 
 struct umf_memtarget_ops_t UMF_MEMTARGET_NUMA_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_MEMTARGET_OPS_VERSION_CURRENT,
     .initialize = numa_initialize,
     .finalize = numa_finalize,
     .pool_create_from_memspace = numa_pool_create_from_memspace,

--- a/src/pool/pool_jemalloc.c
+++ b/src/pool/pool_jemalloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2022-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -454,7 +454,7 @@ static umf_result_t op_get_last_allocation_error(void *pool) {
 }
 
 static umf_memory_pool_ops_t UMF_JEMALLOC_POOL_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_POOL_OPS_VERSION_CURRENT,
     .initialize = op_initialize,
     .finalize = op_finalize,
     .malloc = op_malloc,

--- a/src/pool/pool_proxy.c
+++ b/src/pool/pool_proxy.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2024 Intel Corporation
+ * Copyright (C) 2024-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -123,7 +123,7 @@ static umf_result_t proxy_get_last_allocation_error(void *pool) {
 }
 
 static umf_memory_pool_ops_t UMF_PROXY_POOL_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_POOL_OPS_VERSION_CURRENT,
     .initialize = proxy_pool_initialize,
     .finalize = proxy_pool_finalize,
     .malloc = proxy_malloc,

--- a/src/pool/pool_scalable.c
+++ b/src/pool/pool_scalable.c
@@ -382,7 +382,7 @@ static umf_result_t tbb_get_last_allocation_error(void *pool) {
 }
 
 static umf_memory_pool_ops_t UMF_SCALABLE_POOL_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_POOL_OPS_VERSION_CURRENT,
     .initialize = tbb_pool_initialize,
     .finalize = tbb_pool_finalize,
     .malloc = tbb_malloc,

--- a/src/provider/provider_cuda.c
+++ b/src/provider/provider_cuda.c
@@ -680,8 +680,8 @@ cu_memory_provider_close_ipc_handle(void *provider, void *ptr, size_t size) {
     return UMF_RESULT_SUCCESS;
 }
 
-static struct umf_memory_provider_ops_t UMF_CUDA_MEMORY_PROVIDER_OPS = {
-    .version = UMF_VERSION_CURRENT,
+static umf_memory_provider_ops_t UMF_CUDA_MEMORY_PROVIDER_OPS = {
+    .version = UMF_PROVIDER_OPS_VERSION_CURRENT,
     .initialize = cu_memory_provider_initialize,
     .finalize = cu_memory_provider_finalize,
     .alloc = cu_memory_provider_alloc,

--- a/src/provider/provider_devdax_memory.c
+++ b/src/provider/provider_devdax_memory.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Intel Corporation
+ * Copyright (C) 2024-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -530,7 +530,7 @@ static umf_result_t devdax_free(void *provider, void *ptr, size_t size) {
 }
 
 static umf_memory_provider_ops_t UMF_DEVDAX_MEMORY_PROVIDER_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_PROVIDER_OPS_VERSION_CURRENT,
     .initialize = devdax_initialize,
     .finalize = devdax_finalize,
     .alloc = devdax_alloc,

--- a/src/provider/provider_file_memory.c
+++ b/src/provider/provider_file_memory.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Intel Corporation
+ * Copyright (C) 2024-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -107,7 +107,7 @@ typedef struct file_memory_provider_t {
     // A critnib map storing (ptr, fd_offset + 1) pairs. We add 1 to fd_offset
     // in order to be able to store fd_offset equal 0, because
     // critnib_get() returns value or NULL, so a value cannot equal 0.
-    // It is needed mainly in the get_ipc_handle and open_ipc_handle hooks
+    // It is needed mainly in the ipc_get_handle and ipc_open_handle hooks
     // to mmap a specific part of a file.
     critnib *fd_offset_map;
 
@@ -848,7 +848,7 @@ static umf_result_t file_free(void *provider, void *ptr, size_t size) {
 }
 
 static umf_memory_provider_ops_t UMF_FILE_MEMORY_PROVIDER_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_PROVIDER_OPS_VERSION_CURRENT,
     .initialize = file_initialize,
     .finalize = file_finalize,
     .alloc = file_alloc,

--- a/src/provider/provider_fixed_memory.c
+++ b/src/provider/provider_fixed_memory.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Intel Corporation
+ * Copyright (C) 2024-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -254,7 +254,7 @@ static umf_result_t fixed_free(void *provider, void *ptr, size_t size) {
 }
 
 static umf_memory_provider_ops_t UMF_FIXED_MEMORY_PROVIDER_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_PROVIDER_OPS_VERSION_CURRENT,
     .initialize = fixed_initialize,
     .finalize = fixed_finalize,
     .alloc = fixed_alloc,

--- a/src/provider/provider_level_zero.c
+++ b/src/provider/provider_level_zero.c
@@ -843,8 +843,8 @@ ze_memory_provider_close_ipc_handle(void *provider, void *ptr, size_t size) {
     return UMF_RESULT_SUCCESS;
 }
 
-static struct umf_memory_provider_ops_t UMF_LEVEL_ZERO_MEMORY_PROVIDER_OPS = {
-    .version = UMF_VERSION_CURRENT,
+static umf_memory_provider_ops_t UMF_LEVEL_ZERO_MEMORY_PROVIDER_OPS = {
+    .version = UMF_PROVIDER_OPS_VERSION_CURRENT,
     .initialize = ze_memory_provider_initialize,
     .finalize = ze_memory_provider_finalize,
     .alloc = ze_memory_provider_alloc,

--- a/src/provider/provider_os_memory.c
+++ b/src/provider/provider_os_memory.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Intel Corporation
+ * Copyright (C) 2022-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -1402,7 +1402,7 @@ static umf_result_t os_close_ipc_handle(void *provider, void *ptr,
 }
 
 static umf_memory_provider_ops_t UMF_OS_MEMORY_PROVIDER_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_PROVIDER_OPS_VERSION_CURRENT,
     .initialize = os_initialize,
     .finalize = os_finalize,
     .alloc = os_alloc,

--- a/src/provider/provider_tracking.c
+++ b/src/provider/provider_tracking.c
@@ -749,7 +749,7 @@ static umf_result_t trackingCloseIpcHandle(void *provider, void *ptr,
 }
 
 umf_memory_provider_ops_t UMF_TRACKING_MEMORY_PROVIDER_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_PROVIDER_OPS_VERSION_CURRENT,
     .initialize = trackingInitialize,
     .finalize = trackingFinalize,
     .alloc = trackingAlloc,

--- a/test/common/pool_null.c
+++ b/test/common/pool_null.c
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -64,7 +64,7 @@ static umf_result_t nullGetLastStatus(void *pool) {
 }
 
 umf_memory_pool_ops_t UMF_NULL_POOL_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_POOL_OPS_VERSION_CURRENT,
     .initialize = nullInitialize,
     .finalize = nullFinalize,
     .malloc = nullMalloc,

--- a/test/common/pool_trace.c
+++ b/test/common/pool_trace.c
@@ -90,7 +90,7 @@ static umf_result_t traceGetLastStatus(void *pool) {
 }
 
 umf_memory_pool_ops_t UMF_TRACE_POOL_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_POOL_OPS_VERSION_CURRENT,
     .initialize = traceInitialize,
     .finalize = traceFinalize,
     .malloc = traceMalloc,

--- a/test/common/provider_null.c
+++ b/test/common/provider_null.c
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -130,7 +130,7 @@ static umf_result_t nullCloseIpcHandle(void *provider, void *ptr, size_t size) {
 }
 
 umf_memory_provider_ops_t UMF_NULL_PROVIDER_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_PROVIDER_OPS_VERSION_CURRENT,
     .initialize = nullInitialize,
     .finalize = nullFinalize,
     .alloc = nullAlloc,

--- a/test/common/provider_trace.c
+++ b/test/common/provider_trace.c
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -191,7 +191,7 @@ static umf_result_t traceCloseIpcHandle(void *provider, void *ptr,
 }
 
 umf_memory_provider_ops_t UMF_TRACE_PROVIDER_OPS = {
-    .version = UMF_VERSION_CURRENT,
+    .version = UMF_PROVIDER_OPS_VERSION_CURRENT,
     .initialize = traceInitialize,
     .finalize = traceFinalize,
     .alloc = traceAlloc,

--- a/test/memspaces/mempolicy.cpp
+++ b/test/memspaces/mempolicy.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2025 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -7,11 +7,7 @@
 #include "provider_os_memory_internal.h"
 
 os_memory_provider_t *providerGetPriv(umf_memory_provider_handle_t hProvider) {
-    // hack to have access to fields in structure defined in memory_provider.c
-    struct umf_memory_provider_t {
-        umf_memory_provider_ops_t ops;
-        void *provider_priv;
-    } *provider = (struct umf_memory_provider_t *)hProvider;
+    umf_memory_provider_t *provider = (umf_memory_provider_t *)hProvider;
     return (os_memory_provider_t *)provider->provider_priv;
 }
 


### PR DESCRIPTION
Add backward compatibility workflow and tests.

Major changes:
* use UMF_PROVIDER_OPS_VERSION_CURRENT and UMF_POOL_OPS_VERSION_CURRENT for versioning memory provider and pools struct instead of UMF_VERSION_CURRENT that would be used only for versioning the lib
* do not assert when the user pass an old provider/pool version of ops to umfMemoryProvider/PoolCreate and print a warning instead

fixes https://github.com/oneapi-src/unified-memory-framework/issues/908
