### PR TITLE
Fix: remove `CUDA_ERROR_INVALID_RESOURCE_TYPE`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,11 +454,11 @@ if(UMF_BUILD_CUDA_PROVIDER AND (NOT UMF_CUDA_INCLUDE_DIR))
     set(CUDA_INCLUDE_DIRS
         ${cuda-headers_SOURCE_DIR}
         CACHE PATH "Path to CUDA headers")
-    message(STATUS "CUDA include directory: ${CUDA_INCLUDE_DIRS}")
+    message(STATUS "CUDA_INCLUDE_DIRS = ${CUDA_INCLUDE_DIRS}")
 elseif(UMF_BUILD_CUDA_PROVIDER)
     # Only header is needed to build UMF
     set(CUDA_INCLUDE_DIRS ${UMF_CUDA_INCLUDE_DIR})
-    message(STATUS "CUDA include directory: ${CUDA_INCLUDE_DIRS}")
+    message(STATUS "CUDA_INCLUDE_DIRS = ${CUDA_INCLUDE_DIRS}")
 endif()
 
 # This build type check is not possible on Windows when CMAKE_BUILD_TYPE is not

--- a/src/provider/provider_cuda.c
+++ b/src/provider/provider_cuda.c
@@ -150,7 +150,6 @@ static umf_result_t cu2umf_result(CUresult result) {
         return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     case CUDA_ERROR_INVALID_VALUE:
     case CUDA_ERROR_INVALID_HANDLE:
-    case CUDA_ERROR_INVALID_RESOURCE_TYPE:
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     default:
         cu_store_last_native_error(result);


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

Fix: remove `CUDA_ERROR_INVALID_RESOURCE_TYPE`.

`CUDA_ERROR_INVALID_RESOURCE_TYPE` is not defined in CUDA v10.1 that is used in UR.

PR in UR: https://github.com/oneapi-src/unified-runtime/pull/2680

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
