### PR TITLE
Fix ubench for CUDA provider

### DIFF
--- a/.github/workflows/reusable_gpu.yml
+++ b/.github/workflows/reusable_gpu.yml
@@ -88,6 +88,7 @@ jobs:
           -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
           -DUMF_BUILD_SHARED_LIBRARY=${{matrix.shared_library}}
           -DUMF_BUILD_BENCHMARKS=ON
+          -DUMF_BUILD_BENCHMARKS_MT=ON
           -DUMF_BUILD_TESTS=ON
           -DUMF_BUILD_GPU_TESTS=ON
           -DUMF_BUILD_GPU_EXAMPLES=ON

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 Intel Corporation
+# Copyright (C) 2023-2025 Intel Corporation
 # Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -109,6 +109,9 @@ function(add_umf_benchmark)
     if(UMF_BUILD_CUDA_PROVIDER)
         target_compile_definitions(${BENCH_NAME}
                                    PRIVATE UMF_BUILD_CUDA_PROVIDER=1)
+        target_include_directories(
+            ${BENCH_NAME} PRIVATE ${UMF_CMAKE_SOURCE_DIR}/test/common
+                                  ${CUDA_INCLUDE_DIRS})
     endif()
     if(UMF_BUILD_GPU_TESTS)
         target_compile_definitions(${BENCH_NAME} PRIVATE UMF_BUILD_GPU_TESTS=1)


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description
This PR fixes the compilation error during `ubench` compilation when `-DUMF_BUILD_CUDA_PROVIDER=ON -DUMF_BUILD_LEVEL_ZERO_PROVIDER=OFF`.

Here is the compilation error:
```bash
[ 24%] Built target umf-ubench
In file included from /nfs/pdx/home/svinogra/unified-memory-framework/benchmark/multithread.cpp:10:
/nfs/pdx/home/svinogra/unified-memory-framework/benchmark/multithread.hpp:24:10: fatal error: multithread_helpers.hpp: No such file or directory
   24 | #include "multithread_helpers.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [benchmark/CMakeFiles/umf-multithreaded.dir/build.make:76: benchmark/CMakeFiles/umf-multithreaded.dir/multithread.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:3034: benchmark/CMakeFiles/umf-multithreaded.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

@lukaszstolarczuk @lplewa Looks like we do not test such a combination of CMake flags

### Checklist

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [ ] CI workflows execute properly
