### PR TITLE
disable umf mt bench in GPU workflow

### DIFF
--- a/.github/workflows/reusable_gpu.yml
+++ b/.github/workflows/reusable_gpu.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Run benchmarks
         if: matrix.build_type == 'Release'
         working-directory: ${{env.BUILD_DIR}}
-        run: ctest --output-on-failure --test-dir benchmark -C ${{matrix.build_type}} --exclude-regex umf-bench-multithreaded
+        run: ctest --output-on-failure --test-dir benchmark -C ${{matrix.build_type}} --exclude-regex umf-multithreaded
 
       - name: Check coverage
         if: ${{ matrix.build_type == 'Debug' && matrix.os == 'Ubuntu' }}


### PR DESCRIPTION
disable the UMF MT bench in the GPU workflow as it crashes on GitHub machines. 

see https://github.com/oneapi-src/unified-memory-framework/actions/runs/13255586163/job/37001810256 

it will only be built