### PR TITLE
Revert "Temporarily disable failing windows-2022 clang CI job"

### DIFF
--- a/.github/workflows/reusable_basic.yml
+++ b/.github/workflows/reusable_basic.yml
@@ -226,14 +226,13 @@ jobs:
         level_zero_provider: ['ON']
         cuda_provider: ['ON']
         include:
-          # temporarily disable failing CI job
-          #- os: 'windows-2022'
-          #  build_type: Release
-          #  compiler: {c: clang-cl, cxx: clang-cl}
-          #  shared_library: 'ON'
-          #  level_zero_provider: 'ON'
-          #  cuda_provider: 'ON'
-          #  toolset: "-T ClangCL"
+          - os: 'windows-2022'
+            build_type: Release
+            compiler: {c: clang-cl, cxx: clang-cl}
+            shared_library: 'ON'
+            level_zero_provider: 'ON'
+            cuda_provider: 'ON'
+            toolset: "-T ClangCL"
           - os: 'windows-2022'
             build_type: Release
             compiler: {c: cl, cxx: cl}

--- a/.github/workflows/reusable_basic.yml
+++ b/.github/workflows/reusable_basic.yml
@@ -226,7 +226,8 @@ jobs:
         level_zero_provider: ['ON']
         cuda_provider: ['ON']
         include:
-          - os: 'windows-2022'
+          - os: 'windows-2019'
+            # clang build fails on Windows 2022
             build_type: Release
             compiler: {c: clang-cl, cxx: clang-cl}
             shared_library: 'ON'

--- a/src/coarse/CMakeLists.txt
+++ b/src/coarse/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2024-2025 Intel Corporation
 # Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -6,7 +6,7 @@ include(${UMF_CMAKE_SOURCE_DIR}/cmake/helpers.cmake)
 
 set(COARSE_SOURCES coarse.c ../ravl/ravl.c)
 
-if(UMF_BUILD_SHARED_LIBRARY)
+if(UMF_BUILD_SHARED_LIBRARY AND (NOT WINDOWS))
     set(COARSE_EXTRA_SRCS ${BA_SOURCES})
     set(COARSE_EXTRA_LIBS $<BUILD_INTERFACE:umf_utils>)
 endif()


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

Revert "Temporarily disable failing windows-2022 clang CI job".

This reverts commit 467be1753b0274169666da6dc15c21ede8b1286d.

Fixes: #910

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
