### PR TITLE
Do not overwrite ret code in level_zero_shared_memory example

### DIFF
--- a/examples/level_zero_shared_memory/level_zero_shared_memory.c
+++ b/examples/level_zero_shared_memory/level_zero_shared_memory.c
@@ -189,6 +189,6 @@ provider_params_destroy:
     umfLevelZeroMemoryProviderParamsDestroy(ze_memory_provider_params);
 
 level_zero_destroy:
-    ret = destroy_context(hContext);
+    destroy_context(hContext);
     return ret;
 }


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description
While working on the #1086 I found that the `umf_example_level_zero_shared_memory` returns success even the actual flow failed. See the output below:

```bash
test 1
    Start 1: umf_example_level_zero_shared_memory

1: Test command: /home/test-user/actions-runner/_work/unified-memory-framework/unified-memory-framework/build/examples-standalone/level_zero_shared_memory/umf_example_level_zero_shared_memory
1: Test timeout computed to be: 10000000
1: [FATAL UMF] utils_open_library: dlopen(libze_loader.so) failed with error: (null)
1: [FATAL UMF] ze_memory_provider_initialize: Loading Level Zero symbols failed
1: Failed to create a memory provider!
1/1 Test #1: umf_example_level_zero_shared_memory ...   Passed    0.06 sec
```

### Checklist
- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly

