### PR TITLE
Add CMake vars to dll's metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,9 @@
     - [Adding new dependency](#adding-new-dependency)
   - [Code coverage](#code-coverage)
   - [Debugging](#debugging)
-    - [Checking the UMF version and CMake variables (Linux only)](#checking-the-umf-version-and-cmake-variables-linux-only)
-      - [Requirements](#requirements)
+    - [Checking UMF version and build options](#checking-umf-version-and-build-options)
+      - [Linux](#linux)
+      - [Windows](#windows)
 
 Below you'll find instructions on how to contribute to UMF, either with code changes
 or issues. All contributions are most welcome!
@@ -229,9 +230,17 @@ $ genhtml -o html_report coverage.info
 
 ## Debugging
 
-### Checking the UMF version and CMake variables (Linux only)
+### Checking UMF version and build options
 
-Strings with the UMF version and useful CMake variables can be grepped in the following way:
+From an already built UMF shared library you can obtain UMF precise version and
+CMake variables/options it was built with. It's not only useful to verify what should
+be included within the library, but also for debugging. If you're filing an issue to
+UMF project, please include this information in your ticket.
+
+#### Linux
+
+Make sure the `binutils` package is installed in your system. Then, you can use
+the following grep command:
 
 ```bash
 $ strings libumf.so | grep "@(#)"
@@ -239,6 +248,11 @@ $ strings libumf.so | grep "@(#)"
 @(#) Intel(R) UMF CMake variables: "CMAKE_BUILD_TYPE:Debug,...
 ```
 
-#### Requirements
+Please note, that version available in the name of library file (e.g. `libumf.so.0.11.0`)
+may be not accurate - version coded inside of the library is far more precise.
 
-- binutils package (Linux)
+#### Windows
+
+On Windows, DLL's metadata can be accessed e.g. looking into *Properties* of the dll file
+in the explorer. Look into the *Details* tab for "Product version" and "File description"
+(it contains UMF's build options).

--- a/src/libumf.rc.in
+++ b/src/libumf.rc.in
@@ -10,6 +10,8 @@
 
 #define UMF_VERNUMBERS @PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,@PROJECT_VERSION_PATCH@,@UMF_VERSION_REVISION@
 #define _UMF_VERSION "@UMF_VERSION@"
+// Store our CMake vars in the "FileDescription" block, as the custom fields require special parsing.
+#define _UMF_CMAKE_VARS "@UMF_ALL_CMAKE_VARIABLES@"
 
 #ifdef _DEBUG
 #define VERSION_DEBUG VS_FF_DEBUG
@@ -49,7 +51,7 @@ BEGIN
         BLOCK "040904b0" // U.S. English, Unicode (0x04b0 == 1200)
         BEGIN
             VALUE "CompanyName", "Intel Corporation\0"
-            VALUE "FileDescription", "Unified Memory Framework (UMF) library\0"
+            VALUE "FileDescription", "Unified Memory Framework (UMF) library (build options: " _UMF_CMAKE_VARS ")\0"
             VALUE "FileVersion", _UMF_VERSION "\0"
             VALUE "LegalCopyright", "Copyright 2024-2025, Intel Corporation. All rights reserved.\0"
             VALUE "LegalTrademarks", "\0"

--- a/src/proxy_lib/proxy_lib.rc.in
+++ b/src/proxy_lib/proxy_lib.rc.in
@@ -10,6 +10,8 @@
 
 #define UMF_VERNUMBERS @PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,@PROJECT_VERSION_PATCH@,@UMF_VERSION_REVISION@
 #define _UMF_VERSION "@UMF_VERSION@"
+// Store our CMake vars in the "FileDescription" block, as the custom fields require special parsing.
+#define _UMF_CMAKE_VARS "@UMF_ALL_CMAKE_VARIABLES@"
 
 #ifdef _DEBUG
 #define VERSION_DEBUG VS_FF_DEBUG
@@ -49,7 +51,7 @@ BEGIN
         BLOCK "040904b0" // U.S. English, Unicode (0x04b0 == 1200)
         BEGIN
             VALUE "CompanyName", "Intel Corporation\0"
-            VALUE "FileDescription", "Unified Memory Framework (UMF) proxy library\0"
+            VALUE "FileDescription", "Unified Memory Framework (UMF) proxy library (build options: " _UMF_CMAKE_VARS ")\0"
             VALUE "FileVersion", _UMF_VERSION "\0"
             VALUE "LegalCopyright", "Copyright 2024-2025, Intel Corporation. All rights reserved.\0"
             VALUE "LegalTrademarks", "\0"


### PR DESCRIPTION
We already have "strings" on Linux, so add similar metadata to dll's rc files.

Describe it a little more in CONTRIBUTING.md