### PR TITLE
Check if tracker is empty instead of clearing it

### DIFF
--- a/src/provider/provider_tracking.c
+++ b/src/provider/provider_tracking.c
@@ -425,10 +425,9 @@ static umf_result_t trackingInitialize(void *params, void **ret) {
     return UMF_RESULT_SUCCESS;
 }
 
-// TODO clearing the tracker is a temporary solution and should be removed.
-// The tracker should be cleared using the provider's free() operation.
-static void clear_tracker_for_the_pool(umf_memory_tracker_handle_t hTracker,
-                                       umf_memory_pool_handle_t pool) {
+#ifndef NDEBUG
+static void check_if_tracker_is_empty(umf_memory_tracker_handle_t hTracker,
+                                      umf_memory_pool_handle_t pool) {
     uintptr_t rkey;
     void *rvalue;
     size_t n_items = 0;
@@ -437,41 +436,30 @@ static void clear_tracker_for_the_pool(umf_memory_tracker_handle_t hTracker,
     while (1 == critnib_find((critnib *)hTracker->alloc_segments_map, last_key,
                              FIND_G, &rkey, &rvalue)) {
         tracker_alloc_info_t *value = (tracker_alloc_info_t *)rvalue;
-        if (value->pool != pool && pool != NULL) {
-            last_key = rkey;
-            continue;
+        if (value->pool == pool || pool == NULL) {
+            n_items++;
         }
-
-        n_items++;
-
-        void *removed_value =
-            critnib_remove(hTracker->alloc_segments_map, rkey);
-        assert(removed_value == rvalue);
-        umf_ba_free(hTracker->alloc_info_allocator, removed_value);
 
         last_key = rkey;
     }
 
-#ifndef NDEBUG
-    // print error messages only if provider supports the free() operation
     if (n_items) {
-        if (pool) {
-            LOG_ERR(
-                "tracking provider of pool %p is not empty! (%zu items left)",
-                (void *)pool, n_items);
-        } else {
-            LOG_ERR("tracking provider is not empty! (%zu items left)",
-                    n_items);
+        // Do not log the error if we are running in the proxy library,
+        // because it may need those resources till
+        // the very end of exiting the application.
+        if (!utils_is_running_in_proxy_lib()) {
+            if (pool) {
+                LOG_ERR("tracking provider of pool %p is not empty! (%zu items "
+                        "left)",
+                        (void *)pool, n_items);
+            } else {
+                LOG_ERR("tracking provider is not empty! (%zu items left)",
+                        n_items);
+            }
         }
     }
-#else  /* DEBUG */
-    (void)n_items; // unused in DEBUG build
-#endif /* DEBUG */
 }
-
-static void clear_tracker(umf_memory_tracker_handle_t hTracker) {
-    clear_tracker_for_the_pool(hTracker, NULL);
-}
+#endif /* NDEBUG */
 
 static void trackingFinalize(void *provider) {
     umf_tracking_memory_provider_t *p =
@@ -481,12 +469,9 @@ static void trackingFinalize(void *provider) {
 
     critnib_delete(p->ipcCache);
 
-    // Do not clear the tracker if we are running in the proxy library,
-    // because it may need those resources till
-    // the very end of exiting the application.
-    if (!utils_is_running_in_proxy_lib()) {
-        clear_tracker_for_the_pool(p->hTracker, p->pool);
-    }
+#ifndef NDEBUG
+    check_if_tracker_is_empty(p->hTracker, p->pool);
+#endif /* NDEBUG */
 
     umf_ba_global_free(provider);
 }
@@ -870,7 +855,9 @@ void umfMemoryTrackerDestroy(umf_memory_tracker_handle_t handle) {
         return;
     }
 
-    clear_tracker(handle);
+#ifndef NDEBUG
+    check_if_tracker_is_empty(handle, NULL);
+#endif /* NDEBUG */
 
     // We have to zero all inner pointers,
     // because the tracker handle can be copied

--- a/src/provider/provider_tracking.c
+++ b/src/provider/provider_tracking.c
@@ -456,6 +456,10 @@ static void check_if_tracker_is_empty(umf_memory_tracker_handle_t hTracker,
                 LOG_ERR("tracking provider is not empty! (%zu items left)",
                         n_items);
             }
+
+#ifdef UMF_DEVELOPER_MODE
+            assert(n_items == 0 && "tracking provider is not empty!");
+#endif
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

Clearing the tracker was a temporary solution and should be removed.
The tracker should be cleared using the provider's free() operation.

Replace `clear_tracker_for_the_pool()` with `check_if_tracker_is_empty()`.

This patch reverts commit 2766a21681c1e395d4bcd4c0f178a2627cf56d23

Ref: #759

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
