### PR TITLE
Remove umfFixedMemoryProviderParamsSetMemory() from public header

### DIFF
--- a/include/umf/providers/provider_fixed_memory.h
+++ b/include/umf/providers/provider_fixed_memory.h
@@ -31,16 +31,6 @@ typedef struct umf_fixed_memory_provider_params_t
 umf_result_t umfFixedMemoryProviderParamsCreate(
     umf_fixed_memory_provider_params_handle_t *hParams, void *ptr, size_t size);
 
-/// @brief  Set the memory region in params struct. Overwrites the previous value.
-///         It provides an ability to use the same instance of params to create multiple
-///         instances of the provider for different memory regions.
-/// @param  hParams [in] handle to the parameters of the Fixed Memory Provider.
-/// @param  ptr [in] pointer to the memory region.
-/// @param  size [in] size of the memory region in bytes.
-/// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
-umf_result_t umfFixedMemoryProviderParamsSetMemory(
-    umf_fixed_memory_provider_params_handle_t hParams, void *ptr, size_t size);
-
 /// @brief  Destroy parameters struct.
 /// @param  hParams [in] handle to the parameters of the Fixed Memory Provider.
 /// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure.

--- a/src/provider/provider_fixed_memory.c
+++ b/src/provider/provider_fixed_memory.c
@@ -277,6 +277,29 @@ umf_memory_provider_ops_t *umfFixedMemoryProviderOps(void) {
     return &UMF_FIXED_MEMORY_PROVIDER_OPS;
 }
 
+umf_result_t umfFixedMemoryProviderParamsSetMemory(
+    umf_fixed_memory_provider_params_handle_t hParams, void *ptr, size_t size) {
+
+    if (hParams == NULL) {
+        LOG_ERR("Memory Provider params handle is NULL");
+        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (ptr == NULL) {
+        LOG_ERR("Memory pointer is NULL");
+        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (size == 0) {
+        LOG_ERR("Size must be greater than 0");
+        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
+    hParams->ptr = ptr;
+    hParams->size = size;
+    return UMF_RESULT_SUCCESS;
+}
+
 umf_result_t umfFixedMemoryProviderParamsCreate(
     umf_fixed_memory_provider_params_handle_t *hParams, void *ptr,
     size_t size) {
@@ -310,28 +333,5 @@ umf_result_t umfFixedMemoryProviderParamsDestroy(
         umf_ba_global_free(hParams);
     }
 
-    return UMF_RESULT_SUCCESS;
-}
-
-umf_result_t umfFixedMemoryProviderParamsSetMemory(
-    umf_fixed_memory_provider_params_handle_t hParams, void *ptr, size_t size) {
-
-    if (hParams == NULL) {
-        LOG_ERR("Memory Provider params handle is NULL");
-        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
-    }
-
-    if (ptr == NULL) {
-        LOG_ERR("Memory pointer is NULL");
-        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
-    }
-
-    if (size == 0) {
-        LOG_ERR("Size must be greater than 0");
-        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
-    }
-
-    hParams->ptr = ptr;
-    hParams->size = size;
     return UMF_RESULT_SUCCESS;
 }


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

Remove `umfFixedMemoryProviderParamsSetMemory()` from the public header.

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
