### PR TITLE
Make it possible to create Fixed Provider from pointer of UMF memory pool

### DIFF
--- a/include/umf/providers/provider_fixed_memory.h
+++ b/include/umf/providers/provider_fixed_memory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Intel Corporation
+ * Copyright (C) 2024-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -17,6 +17,14 @@ extern "C" {
 /// @cond
 #define UMF_FIXED_RESULTS_START_FROM 4000
 /// @endcond
+
+/// @brief Fixed Memory Provider flags
+typedef enum umf_fixed_memory_provider_flag {
+    UMF_FIXED_FLAG_DEFAULT = 0, ///< the default - no flags set
+    UMF_FIXED_FLAG_CREATE_FROM_POOL_PTR =
+        (1
+         << 0), ///< The Fixed Memory Provider is created from the UMF pool's pointer
+} umf_fixed_memory_provider_flag_t;
 
 struct umf_fixed_memory_provider_params_t;
 
@@ -40,6 +48,13 @@ umf_result_t umfFixedMemoryProviderParamsCreate(
 /// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
 umf_result_t umfFixedMemoryProviderParamsSetMemory(
     umf_fixed_memory_provider_params_handle_t hParams, void *ptr, size_t size);
+
+/// @brief  Set the memory region flags in params struct.
+/// @param  hParams [in] handle to the parameters of the Fixed Memory Provider.
+/// @param  flags [in] flags for the memory region.
+/// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
+umf_result_t umfFixedMemoryProviderParamsSetFlags(
+    umf_fixed_memory_provider_params_handle_t hParams, unsigned int flags);
 
 /// @brief  Destroy parameters struct.
 /// @param  hParams [in] handle to the parameters of the Fixed Memory Provider.

--- a/src/libumf.def
+++ b/src/libumf.def
@@ -134,5 +134,6 @@ EXPORTS
     umfFixedMemoryProviderOps
     umfFixedMemoryProviderParamsCreate
     umfFixedMemoryProviderParamsDestroy
+    umfFixedMemoryProviderParamsSetFlags
     umfLevelZeroMemoryProviderParamsSetFreePolicy
     umfLevelZeroMemoryProviderParamsSetDeviceOrdinal

--- a/src/libumf.map
+++ b/src/libumf.map
@@ -132,6 +132,7 @@ UMF_0.11 {
         umfFixedMemoryProviderOps;
         umfFixedMemoryProviderParamsCreate;
         umfFixedMemoryProviderParamsDestroy;
+        umfFixedMemoryProviderParamsSetFlags;
         umfLevelZeroMemoryProviderParamsSetFreePolicy;
         umfLevelZeroMemoryProviderParamsSetDeviceOrdinal;
 } UMF_0.10;

--- a/src/memory_pool.c
+++ b/src/memory_pool.c
@@ -136,6 +136,22 @@ umf_result_t umfPoolGetMemoryProvider(umf_memory_pool_handle_t hPool,
     return UMF_RESULT_SUCCESS;
 }
 
+umf_result_t
+umfPoolGetTrackingProvider(umf_memory_pool_handle_t hPool,
+                           umf_memory_provider_handle_t *hProvider) {
+    if (!hPool || !hProvider) {
+        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (hPool->flags & UMF_POOL_CREATE_FLAG_DISABLE_TRACKING) {
+        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
+    *hProvider = umfMemoryProviderGetPriv(hPool->provider);
+
+    return UMF_RESULT_SUCCESS;
+}
+
 umf_result_t umfPoolCreate(const umf_memory_pool_ops_t *ops,
                            umf_memory_provider_handle_t provider, void *params,
                            umf_pool_create_flags_t flags,

--- a/src/memory_pool_internal.h
+++ b/src/memory_pool_internal.h
@@ -36,6 +36,10 @@ typedef struct umf_memory_pool_t {
     void *tag;
 } umf_memory_pool_t;
 
+umf_result_t
+umfPoolGetTrackingProvider(umf_memory_pool_handle_t hPool,
+                           umf_memory_provider_handle_t *hProvider);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/provider/provider_tracking.h
+++ b/src/provider/provider_tracking.h
@@ -55,6 +55,12 @@ void umfTrackingMemoryProviderGetUpstreamProvider(
     umf_memory_provider_handle_t hTrackingProvider,
     umf_memory_provider_handle_t *hUpstream);
 
+umf_result_t trackerShrinkEntry(void *hProvider, void *ptr, size_t shrinkSize,
+                                size_t *totalSize);
+
+umf_result_t trackerGrowEntry(void *hProvider, void *ptr, size_t growSize,
+                              size_t origSize);
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/provider_fixed_memory.cpp
+++ b/test/provider_fixed_memory.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2025 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -11,10 +11,12 @@
 #endif
 
 #include <umf/memory_provider.h>
+#include <umf/pools/pool_proxy.h>
 #include <umf/providers/provider_fixed_memory.h>
 
 using umf_test::test;
 
+#define FIXED_BUFFER_SIZE (10 * utils_get_page_size())
 #define INVALID_PTR ((void *)0x01)
 
 typedef enum purge_t {
@@ -59,7 +61,7 @@ struct FixedProviderTest
         test::SetUp();
 
         // Allocate a memory buffer to use with the fixed memory provider
-        memory_size = utils_get_page_size() * 10; // Allocate 10 pages
+        memory_size = FIXED_BUFFER_SIZE; // Allocate 10 pages
         memory_buffer = malloc(memory_size);
         ASSERT_NE(memory_buffer, nullptr);
 
@@ -390,4 +392,223 @@ TEST_P(FixedProviderTest, split) {
     memset(ptr2, 0x22, size);
     umf_result = umfMemoryProviderFree(provider.get(), ptr2, size);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+}
+
+TEST_P(FixedProviderTest, params_set_flags_negative) {
+    umf_result_t umf_result;
+
+    // Create provider parameters
+    umf_fixed_memory_provider_params_handle_t params = nullptr;
+    umf_result =
+        umfFixedMemoryProviderParamsCreate(&params, memory_buffer, memory_size);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(params, nullptr);
+
+    // params is NULL
+    umf_result = umfFixedMemoryProviderParamsSetFlags(
+        NULL, UMF_FIXED_FLAG_CREATE_FROM_POOL_PTR);
+    ASSERT_EQ(umf_result, UMF_RESULT_ERROR_INVALID_ARGUMENT);
+
+    // the pointer does not belong to any UMF pool
+    umf_result = umfFixedMemoryProviderParamsSetFlags(
+        params, UMF_FIXED_FLAG_CREATE_FROM_POOL_PTR);
+    ASSERT_EQ(umf_result, UMF_RESULT_ERROR_INVALID_ARGUMENT);
+
+    umfFixedMemoryProviderParamsDestroy(params);
+}
+
+TEST_P(FixedProviderTest, pool_from_ptr_negative_wrong_ptr) {
+    umf_result_t umf_result;
+    size_t size_of_first_alloc;
+    size_t size_of_pool_from_ptr;
+    void *ptr_for_pool = nullptr;
+
+    umf_memory_pool_handle_t proxyFixedPool = nullptr;
+    umf_result = umfPoolCreate(umfProxyPoolOps(), provider.get(), nullptr, 0,
+                               &proxyFixedPool);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    size_of_first_alloc = FIXED_BUFFER_SIZE - (2 * page_size);
+    ptr_for_pool = umfPoolMalloc(proxyFixedPool, size_of_first_alloc);
+    ASSERT_NE(ptr_for_pool, nullptr);
+
+    // Create provider parameters
+    size_of_pool_from_ptr = size_of_first_alloc; // whole size
+    umf_fixed_memory_provider_params_handle_t params = nullptr;
+    umf_result = umfFixedMemoryProviderParamsCreate(&params, ptr_for_pool,
+                                                    size_of_pool_from_ptr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(params, nullptr);
+
+    umf_result = umfFixedMemoryProviderParamsSetFlags(
+        params, UMF_FIXED_FLAG_CREATE_FROM_POOL_PTR);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umf_result = umfPoolFree(proxyFixedPool, ptr_for_pool);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    // the pointer (ptr_for_pool) does not belong to any UMF pool
+    umf_memory_provider_handle_t providerFromPtr = nullptr;
+    umf_result = umfMemoryProviderCreate(umfFixedMemoryProviderOps(), params,
+                                         &providerFromPtr);
+    ASSERT_EQ(umf_result, UMF_RESULT_ERROR_INVALID_ARGUMENT);
+    ASSERT_EQ(providerFromPtr, nullptr);
+
+    umfFixedMemoryProviderParamsDestroy(params);
+    umfPoolDestroy(proxyFixedPool);
+}
+
+TEST_P(FixedProviderTest, pool_from_ptr_negative_shrink_size_too_big) {
+    umf_result_t umf_result;
+    size_t size_of_first_alloc;
+    size_t size_of_pool_from_ptr;
+    void *ptr_for_pool = nullptr;
+
+    umf_memory_pool_handle_t proxyFixedPool = nullptr;
+    umf_result = umfPoolCreate(umfProxyPoolOps(), provider.get(), nullptr, 0,
+                               &proxyFixedPool);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    size_of_first_alloc = FIXED_BUFFER_SIZE - (2 * page_size);
+    ptr_for_pool = umfPoolMalloc(proxyFixedPool, size_of_first_alloc);
+    ASSERT_NE(ptr_for_pool, nullptr);
+
+    // Create provider parameters
+    size_of_pool_from_ptr = size_of_first_alloc + 1; // size too big
+    umf_fixed_memory_provider_params_handle_t params = nullptr;
+    umf_result = umfFixedMemoryProviderParamsCreate(&params, ptr_for_pool,
+                                                    size_of_pool_from_ptr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(params, nullptr);
+
+    umf_result = umfFixedMemoryProviderParamsSetFlags(
+        params, UMF_FIXED_FLAG_CREATE_FROM_POOL_PTR);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umf_memory_provider_handle_t providerFromPtr = nullptr;
+    umf_result = umfMemoryProviderCreate(umfFixedMemoryProviderOps(), params,
+                                         &providerFromPtr);
+    ASSERT_EQ(umf_result, UMF_RESULT_ERROR_INVALID_ARGUMENT);
+    ASSERT_EQ(providerFromPtr, nullptr);
+
+    umfFixedMemoryProviderParamsDestroy(params);
+
+    umf_result = umfPoolFree(proxyFixedPool, ptr_for_pool);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umfPoolDestroy(proxyFixedPool);
+}
+
+TEST_P(FixedProviderTest, pool_from_ptr_whole_size_success) {
+    umf_result_t umf_result;
+    size_t size_of_first_alloc;
+    size_t size_of_pool_from_ptr;
+    void *ptr_for_pool = nullptr;
+    void *ptr = nullptr;
+
+    umf_memory_pool_handle_t proxyFixedPool = nullptr;
+    umf_result = umfPoolCreate(umfProxyPoolOps(), provider.get(), nullptr, 0,
+                               &proxyFixedPool);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    size_of_first_alloc = FIXED_BUFFER_SIZE - (2 * page_size);
+    ptr_for_pool = umfPoolMalloc(proxyFixedPool, size_of_first_alloc);
+    ASSERT_NE(ptr_for_pool, nullptr);
+
+    // Create provider parameters
+    size_of_pool_from_ptr = size_of_first_alloc; // whole size
+    umf_fixed_memory_provider_params_handle_t params = nullptr;
+    umf_result = umfFixedMemoryProviderParamsCreate(&params, ptr_for_pool,
+                                                    size_of_pool_from_ptr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(params, nullptr);
+
+    umf_result = umfFixedMemoryProviderParamsSetFlags(
+        params, UMF_FIXED_FLAG_CREATE_FROM_POOL_PTR);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umf_memory_provider_handle_t providerFromPtr = nullptr;
+    umf_result = umfMemoryProviderCreate(umfFixedMemoryProviderOps(), params,
+                                         &providerFromPtr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(providerFromPtr, nullptr);
+
+    umf_memory_pool_handle_t poolFromPtr = nullptr;
+    umf_result = umfPoolCreate(umfProxyPoolOps(), providerFromPtr, nullptr, 0,
+                               &poolFromPtr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    ptr = umfPoolMalloc(poolFromPtr, size_of_pool_from_ptr);
+    ASSERT_NE(ptr, nullptr);
+
+    memset(ptr, 0xFF, size_of_pool_from_ptr);
+
+    umf_result = umfPoolFree(poolFromPtr, ptr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umfPoolDestroy(poolFromPtr);
+    umfMemoryProviderDestroy(providerFromPtr);
+    umfFixedMemoryProviderParamsDestroy(params);
+
+    umf_result = umfPoolFree(proxyFixedPool, ptr_for_pool);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umfPoolDestroy(proxyFixedPool);
+}
+
+TEST_P(FixedProviderTest, pool_from_ptr_half_size_success) {
+    umf_result_t umf_result;
+    size_t size_of_first_alloc;
+    size_t size_of_pool_from_ptr;
+    void *ptr_for_pool = nullptr;
+    void *ptr = nullptr;
+
+    umf_memory_pool_handle_t proxyFixedPool = nullptr;
+    umf_result = umfPoolCreate(umfProxyPoolOps(), provider.get(), nullptr, 0,
+                               &proxyFixedPool);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    size_of_first_alloc = FIXED_BUFFER_SIZE - (2 * page_size);
+    ptr_for_pool = umfPoolMalloc(proxyFixedPool, size_of_first_alloc);
+    ASSERT_NE(ptr_for_pool, nullptr);
+
+    // Create provider parameters
+    size_of_pool_from_ptr = size_of_first_alloc / 2; // half size
+    umf_fixed_memory_provider_params_handle_t params = nullptr;
+    umf_result = umfFixedMemoryProviderParamsCreate(&params, ptr_for_pool,
+                                                    size_of_pool_from_ptr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(params, nullptr);
+
+    umf_result = umfFixedMemoryProviderParamsSetFlags(
+        params, UMF_FIXED_FLAG_CREATE_FROM_POOL_PTR);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umf_memory_provider_handle_t providerFromPtr = nullptr;
+    umf_result = umfMemoryProviderCreate(umfFixedMemoryProviderOps(), params,
+                                         &providerFromPtr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(providerFromPtr, nullptr);
+
+    umf_memory_pool_handle_t poolFromPtr = nullptr;
+    umf_result = umfPoolCreate(umfProxyPoolOps(), providerFromPtr, nullptr, 0,
+                               &poolFromPtr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    ptr = umfPoolMalloc(poolFromPtr, size_of_pool_from_ptr);
+    ASSERT_NE(ptr, nullptr);
+
+    memset(ptr, 0xFF, size_of_pool_from_ptr);
+
+    umf_result = umfPoolFree(poolFromPtr, ptr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umfPoolDestroy(poolFromPtr);
+    umfMemoryProviderDestroy(providerFromPtr);
+    umfFixedMemoryProviderParamsDestroy(params);
+
+    umf_result = umfPoolFree(proxyFixedPool, ptr_for_pool);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umfPoolDestroy(proxyFixedPool);
 }


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

Make it possible to create Fixed-size Memory Provider
from a pointer belonging to a UMF memory pool.
This pointer is already tracked in the UMF tracker,
so we have to remove this memory range
`<pointer, pointer + length)` from the tracker.

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
