### PR TITLE
Workaround failing MacOS CI builds

### DIFF
--- a/.github/workflows/reusable_basic.yml
+++ b/.github/workflows/reusable_basic.yml
@@ -496,7 +496,7 @@ jobs:
         ${{matrix.static_hwloc}}
 
     - name: Build UMF
-      run: cmake --build ${{env.BUILD_DIR}} -j $(sysctl -n hw.logicalcpu)
+      run: cmake --build ${{env.BUILD_DIR}} -j $(sysctl -n hw.logicalcpu) || ( rm -rf ${{env.BUILD_DIR}}/_deps/jemalloc_targ-build && cmake --build ${{env.BUILD_DIR}} -j 1 )
 
     - name: Test UMF installation and uninstallation
       run: >


### PR DESCRIPTION
Building of UMF sometimes fails on MacOS, because of multi-job compilation of jemalloc built from sources:
```
install: mkdir /Users/runner/work/unified-memory-framework/unified-memory-framework/build/_deps/jemalloc_targ-build/share: File exists
```
See: https://github.com/oneapi-src/unified-memory-framework/actions/runs/13454622713/job/37596581185

Add one-job compilation to workaround this error.

Ref: https://github.com/oneapi-src/unified-memory-framework/issues/1128

<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
