### PR TITLE
temporary disable DP MT benchmark

### DIFF
--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -89,8 +89,9 @@ UMF_BENCHMARK_TEMPLATE_DEFINE(multiple_malloc_free_benchmark,
                               disjoint_pool_uniform, uniform_alloc_size,
                               pool_allocator<disjoint_pool<os_provider>>);
 UMF_BENCHMARK_REGISTER_F(multiple_malloc_free_benchmark, disjoint_pool_uniform)
-    ->Apply(&default_multiple_alloc_uniform_size)
-    ->Apply(&multithreaded);
+    ->Apply(&default_multiple_alloc_uniform_size);
+// TODO: enable
+//->Apply(&multithreaded);
 
 #ifdef UMF_POOL_JEMALLOC_ENABLED
 UMF_BENCHMARK_TEMPLATE_DEFINE(multiple_malloc_free_benchmark, jemalloc_pool_fix,


### PR DESCRIPTION
temporary disable DP MT benchmark
as we observe very sporadic deadlock related to utils_compare_exchange() in the Disjoint Pool

enabling of DP MT benchmark was introduced in https://github.com/oneapi-src/unified-memory-framework/pull/1112

issue: https://github.com/oneapi-src/unified-memory-framework/issues/1125

