### PR TITLE
Disable building and installing the jemalloc's documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,11 +186,12 @@ else()
         # --disable-initial-exec-tls - Disable the initial-exec TLS model for
         # jemalloc's internal thread-local storage (on those platforms that
         # support explicit settings). This can allow jemalloc to be dynamically
-        # loaded after program startup (e.g. using dlopen).
+        # loaded after program startup (e.g. using dlopen). --disable-doc -
+        # Disable building and installing the documentation.
         COMMAND
             ./configure --prefix=${jemalloc_targ_BINARY_DIR}
             --with-jemalloc-prefix=je_ --disable-cxx --disable-initial-exec-tls
-            CFLAGS=-fPIC
+            --disable-doc CFLAGS=-fPIC
         WORKING_DIRECTORY ${jemalloc_targ_SOURCE_DIR}
         OUTPUT ${jemalloc_targ_SOURCE_DIR}/Makefile
         DEPENDS ${jemalloc_targ_SOURCE_DIR}/configure)


### PR DESCRIPTION
Disable building and installing the jemalloc's documentation, because it is not needed at all.

Fixes: #1128

<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
