### PR TITLE
Fix Windows Unix Makefiles generator builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,7 +283,8 @@ else()
 
         message(STATUS "hwloc CMAKE_GENERATOR: ${CMAKE_GENERATOR}")
 
-        if(CMAKE_GENERATOR STREQUAL "Ninja")
+        if(CMAKE_GENERATOR STREQUAL "Ninja" OR CMAKE_GENERATOR STREQUAL
+                                               "Unix Makefiles")
             add_custom_command(
                 COMMAND ${CMAKE_COMMAND}
                         -DCMAKE_INSTALL_PREFIX=${hwloc_targ_BINARY_DIR} -B build


### PR DESCRIPTION
Using Unix Makefiles CMake generator on Windows with `hwloc` statically linked results in a build error. Now fetched `hwloc` is explicitly built before `hwloc.lib` is linked with other UMF targets.

// tested [on sycl](https://github.com/intel/llvm/pull/17134) + extended testing

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
- [ ] All API changes are reflected in docs and def/map files, and are tested
