### PR TITLE
Add tests for pool from pointer to poolFixtures.hpp

### DIFF
--- a/test/provider_fixed_memory.cpp
+++ b/test/provider_fixed_memory.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2025 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -11,10 +11,12 @@
 #endif
 
 #include <umf/memory_provider.h>
+#include <umf/pools/pool_proxy.h>
 #include <umf/providers/provider_fixed_memory.h>
 
 using umf_test::test;
 
+#define FIXED_BUFFER_SIZE (10 * utils_get_page_size())
 #define INVALID_PTR ((void *)0x01)
 
 typedef enum purge_t {
@@ -59,7 +61,7 @@ struct FixedProviderTest
         test::SetUp();
 
         // Allocate a memory buffer to use with the fixed memory provider
-        memory_size = utils_get_page_size() * 10; // Allocate 10 pages
+        memory_size = FIXED_BUFFER_SIZE; // Allocate 10 pages
         memory_buffer = malloc(memory_size);
         ASSERT_NE(memory_buffer, nullptr);
 
@@ -390,4 +392,110 @@ TEST_P(FixedProviderTest, split) {
     memset(ptr2, 0x22, size);
     umf_result = umfMemoryProviderFree(provider.get(), ptr2, size);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+}
+
+TEST_P(FixedProviderTest, pool_from_ptr_whole_size_success) {
+    umf_result_t umf_result;
+    size_t size_of_first_alloc;
+    size_t size_of_pool_from_ptr;
+    void *ptr_for_pool = nullptr;
+    void *ptr = nullptr;
+
+    umf_memory_pool_handle_t proxyFixedPool = nullptr;
+    umf_result = umfPoolCreate(umfProxyPoolOps(), provider.get(), nullptr, 0,
+                               &proxyFixedPool);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    size_of_first_alloc = FIXED_BUFFER_SIZE - (2 * page_size);
+    ptr_for_pool = umfPoolMalloc(proxyFixedPool, size_of_first_alloc);
+    ASSERT_NE(ptr_for_pool, nullptr);
+
+    // Create provider parameters
+    size_of_pool_from_ptr = size_of_first_alloc; // whole size
+    umf_fixed_memory_provider_params_handle_t params = nullptr;
+    umf_result = umfFixedMemoryProviderParamsCreate(&params, ptr_for_pool,
+                                                    size_of_pool_from_ptr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(params, nullptr);
+
+    umf_memory_provider_handle_t providerFromPtr = nullptr;
+    umf_result = umfMemoryProviderCreate(umfFixedMemoryProviderOps(), params,
+                                         &providerFromPtr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(providerFromPtr, nullptr);
+
+    umf_memory_pool_handle_t poolFromPtr = nullptr;
+    umf_result = umfPoolCreate(umfProxyPoolOps(), providerFromPtr, nullptr, 0,
+                               &poolFromPtr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    ptr = umfPoolMalloc(poolFromPtr, size_of_pool_from_ptr);
+    ASSERT_NE(ptr, nullptr);
+
+    memset(ptr, 0xFF, size_of_pool_from_ptr);
+
+    umf_result = umfPoolFree(poolFromPtr, ptr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umfPoolDestroy(poolFromPtr);
+    umfMemoryProviderDestroy(providerFromPtr);
+    umfFixedMemoryProviderParamsDestroy(params);
+
+    umf_result = umfPoolFree(proxyFixedPool, ptr_for_pool);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umfPoolDestroy(proxyFixedPool);
+}
+
+TEST_P(FixedProviderTest, pool_from_ptr_half_size_success) {
+    umf_result_t umf_result;
+    size_t size_of_first_alloc;
+    size_t size_of_pool_from_ptr;
+    void *ptr_for_pool = nullptr;
+    void *ptr = nullptr;
+
+    umf_memory_pool_handle_t proxyFixedPool = nullptr;
+    umf_result = umfPoolCreate(umfProxyPoolOps(), provider.get(), nullptr, 0,
+                               &proxyFixedPool);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    size_of_first_alloc = FIXED_BUFFER_SIZE - (2 * page_size);
+    ptr_for_pool = umfPoolMalloc(proxyFixedPool, size_of_first_alloc);
+    ASSERT_NE(ptr_for_pool, nullptr);
+
+    // Create provider parameters
+    size_of_pool_from_ptr = size_of_first_alloc / 2; // half size
+    umf_fixed_memory_provider_params_handle_t params = nullptr;
+    umf_result = umfFixedMemoryProviderParamsCreate(&params, ptr_for_pool,
+                                                    size_of_pool_from_ptr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(params, nullptr);
+
+    umf_memory_provider_handle_t providerFromPtr = nullptr;
+    umf_result = umfMemoryProviderCreate(umfFixedMemoryProviderOps(), params,
+                                         &providerFromPtr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(providerFromPtr, nullptr);
+
+    umf_memory_pool_handle_t poolFromPtr = nullptr;
+    umf_result = umfPoolCreate(umfProxyPoolOps(), providerFromPtr, nullptr, 0,
+                               &poolFromPtr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    ptr = umfPoolMalloc(poolFromPtr, size_of_pool_from_ptr);
+    ASSERT_NE(ptr, nullptr);
+
+    memset(ptr, 0xFF, size_of_pool_from_ptr);
+
+    umf_result = umfPoolFree(poolFromPtr, ptr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umfPoolDestroy(poolFromPtr);
+    umfMemoryProviderDestroy(providerFromPtr);
+    umfFixedMemoryProviderParamsDestroy(params);
+
+    umf_result = umfPoolFree(proxyFixedPool, ptr_for_pool);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umfPoolDestroy(proxyFixedPool);
 }


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

Add tests for pool from pointer to poolFixtures.hpp.

Depends on: https://github.com/oneapi-src/unified-memory-framework/pull/1134

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
