### PR TITLE
Use `LOG_FATAL()` in case of critical errors

### DIFF
--- a/src/provider/provider_tracking.c
+++ b/src/provider/provider_tracking.c
@@ -291,26 +291,26 @@ static umf_result_t trackingAllocationMerge(void *hProvider, void *lowPtr,
     tracker_alloc_info_t *lowValue = (tracker_alloc_info_t *)critnib_get(
         provider->hTracker->alloc_segments_map, (uintptr_t)lowPtr);
     if (!lowValue) {
-        LOG_ERR("no left value");
+        LOG_FATAL("no left value");
         ret = UMF_RESULT_ERROR_INVALID_ARGUMENT;
-        goto err;
+        goto err_assert;
     }
     tracker_alloc_info_t *highValue = (tracker_alloc_info_t *)critnib_get(
         provider->hTracker->alloc_segments_map, (uintptr_t)highPtr);
     if (!highValue) {
-        LOG_ERR("no right value");
+        LOG_FATAL("no right value");
         ret = UMF_RESULT_ERROR_INVALID_ARGUMENT;
-        goto err;
+        goto err_assert;
     }
     if (lowValue->pool != highValue->pool) {
-        LOG_ERR("pool mismatch");
+        LOG_FATAL("pool mismatch");
         ret = UMF_RESULT_ERROR_INVALID_ARGUMENT;
-        goto err;
+        goto err_assert;
     }
     if (lowValue->size + highValue->size != totalSize) {
-        LOG_ERR("lowValue->size + highValue->size != totalSize");
+        LOG_FATAL("lowValue->size + highValue->size != totalSize");
         ret = UMF_RESULT_ERROR_INVALID_ARGUMENT;
-        goto err;
+        goto err_assert;
     }
 
     ret = umfMemoryProviderAllocationMerge(provider->hUpstream, lowPtr, highPtr,
@@ -342,7 +342,7 @@ static umf_result_t trackingAllocationMerge(void *hProvider, void *lowPtr,
 
     return UMF_RESULT_SUCCESS;
 
-err:
+err_assert:
     assert(0);
 
 not_merged:


### PR DESCRIPTION

<!-- Provide a short summary of your changes in the Title above -->

### Description

Use `LOG_FATAL()` in case of critical errors.

Ref: #1095

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
