### PR TITLE
explicitly declare single threaded benchmark

### DIFF
--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -35,6 +35,10 @@ static void multithreaded(benchmark::internal::Benchmark *benchmark) {
     benchmark->Threads(1);
 }
 
+static void singlethreaded(benchmark::internal::Benchmark *benchmark) {
+    benchmark->Threads(1);
+}
+
 static void
 default_multiple_alloc_fix_size(benchmark::internal::Benchmark *benchmark) {
     benchmark->Args({10000, 1, 4096});
@@ -68,7 +72,8 @@ UMF_BENCHMARK_TEMPLATE_DEFINE(multiple_malloc_free_benchmark, proxy_pool,
 UMF_BENCHMARK_REGISTER_F(multiple_malloc_free_benchmark, proxy_pool)
     ->Apply(&default_multiple_alloc_fix_size)
     // reduce iterations, as this benchmark is slower than others
-    ->Iterations(50000);
+    ->Iterations(50000)
+    ->Apply(&singlethreaded);
 
 UMF_BENCHMARK_TEMPLATE_DEFINE(multiple_malloc_free_benchmark, os_provider,
                               fixed_alloc_size,
@@ -76,7 +81,8 @@ UMF_BENCHMARK_TEMPLATE_DEFINE(multiple_malloc_free_benchmark, os_provider,
 UMF_BENCHMARK_REGISTER_F(multiple_malloc_free_benchmark, os_provider)
     ->Apply(&default_multiple_alloc_fix_size)
     // reduce iterations, as this benchmark is slower than others
-    ->Iterations(50000);
+    ->Iterations(50000)
+    ->Apply(&singlethreaded);
 
 UMF_BENCHMARK_TEMPLATE_DEFINE(multiple_malloc_free_benchmark, disjoint_pool_fix,
                               fixed_alloc_size,
@@ -89,8 +95,9 @@ UMF_BENCHMARK_TEMPLATE_DEFINE(multiple_malloc_free_benchmark,
                               disjoint_pool_uniform, uniform_alloc_size,
                               pool_allocator<disjoint_pool<os_provider>>);
 UMF_BENCHMARK_REGISTER_F(multiple_malloc_free_benchmark, disjoint_pool_uniform)
-    ->Apply(&default_multiple_alloc_uniform_size);
-// TODO: enable
+    ->Apply(&default_multiple_alloc_uniform_size)
+    ->Apply(&singlethreaded);
+// TODO: change to multithreaded
 //->Apply(&multithreaded);
 
 #ifdef UMF_POOL_JEMALLOC_ENABLED


### PR DESCRIPTION
This causes that information about threads count is appended to benchmark name which makes it consistent with other bechmarks.

<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
- [ ] All API changes are reflected in docs and def/map files, and are tested
