### PR TITLE
Remove old SHM files left from the previous runs because of crashes

### DIFF
--- a/test/ipc_file_prov.sh
+++ b/test/ipc_file_prov.sh
@@ -9,7 +9,12 @@
 
 set -e
 
-FILE_NAME="/tmp/umf_file_provider_$$"
+FILE_BASE="/tmp/umf_file_provider"
+
+# remove old SHM files (left from the previous runs, because of crashes)
+rm -f ${FILE_BASE}*
+
+FILE_NAME="${FILE_BASE}_$$"
 
 # port should be a number from the range <1024, 65535>
 PORT=$(( 1024 + ( $$ % ( 65535 - 1024 ))))


### PR DESCRIPTION

<!-- Provide a short summary of your changes in the Title above -->

### Description

Remove old SHM files `/tmp/umf_file_provider_*`
(at the beginning of the test)
left from the previous runs, because of crashes
of the `ipc_file_prov` test.

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
