### PR TITLE
Use eight level of critnibs in the tracker

### DIFF
--- a/include/umf/base.h
+++ b/include/umf/base.h
@@ -47,7 +47,8 @@ typedef enum umf_result_t {
         6, ///< Failure in user provider code (i.e in user provided callback)
     UMF_RESULT_ERROR_DEPENDENCY_UNAVAILABLE =
         7, ///< External required dependency is unavailable or missing
-    UMF_RESULT_ERROR_UNKNOWN = 0x7ffffffe ///< Unknown or internal error
+    UMF_RESULT_ERROR_OUT_OF_RESOURCES = 8, ///< Out of internal resources
+    UMF_RESULT_ERROR_UNKNOWN = 0x7ffffffe  ///< Unknown error
 } umf_result_t;
 
 #ifdef __cplusplus

--- a/src/critnib/critnib.c
+++ b/src/critnib/critnib.c
@@ -645,7 +645,9 @@ static struct critnib_leaf *find_successor(struct critnib_node *__restrict n) {
     while (1) {
         unsigned nib;
         for (nib = 0; nib <= NIB; nib++) {
-            if (n->child[nib]) {
+            struct critnib_node *m;
+            utils_atomic_load_acquire_ptr((void **)&n->child[nib], (void **)&m);
+            if (m) {
                 break;
             }
         }
@@ -654,7 +656,7 @@ static struct critnib_leaf *find_successor(struct critnib_node *__restrict n) {
             return NULL;
         }
 
-        n = n->child[nib];
+        utils_atomic_load_acquire_ptr((void **)&n->child[nib], (void **)&n);
 
         if (!n) {
             return NULL;

--- a/src/utils/utils_concurrency.h
+++ b/src/utils/utils_concurrency.h
@@ -152,6 +152,17 @@ static inline bool utils_compare_exchange_u64(uint64_t *ptr, uint64_t *expected,
     return false;
 }
 
+static inline void utils_atomic_store_release_u64(void *ptr, uint64_t val) {
+    ASSERT_IS_ALIGNED((uintptr_t)ptr, 8);
+    LONG64 out;
+    LONG64 desired = (LONG64)val;
+    LONG64 expected = 0;
+    while (expected != (out = InterlockedCompareExchange64(
+                            (LONG64 volatile *)ptr, desired, expected))) {
+        expected = out;
+    }
+}
+
 #else // !defined(_WIN32)
 
 static inline void utils_atomic_load_acquire_u64(uint64_t *ptr, uint64_t *out) {
@@ -166,6 +177,11 @@ static inline void utils_atomic_load_acquire_ptr(void **ptr, void **out) {
     ASSERT_IS_ALIGNED((uintptr_t)out, 8);
     __atomic_load((uintptr_t *)ptr, (uintptr_t *)out, memory_order_acquire);
     utils_annotate_acquire(ptr);
+}
+
+static inline void utils_atomic_store_release_u64(void *ptr, uint64_t val) {
+    ASSERT_IS_ALIGNED((uintptr_t)ptr, 8);
+    __atomic_store_n((uintptr_t *)ptr, (uintptr_t)val, memory_order_release);
 }
 
 static inline void utils_atomic_store_release_ptr(void **ptr, void *val) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -347,6 +347,11 @@ if(LINUX AND (NOT UMF_DISABLE_HWLOC)) # OS-specific functions are implemented
         NAME provider_tracking
         SRCS provider_tracking.cpp
         LIBS ${UMF_UTILS_FOR_TEST})
+    add_umf_test(
+        NAME provider_tracking_fixture_tests
+        SRCS provider_tracking_fixture_tests.cpp malloc_compliance_tests.cpp
+             ${BA_SOURCES_FOR_TEST}
+        LIBS ${UMF_UTILS_FOR_TEST})
 
     # This test requires Linux-only file memory provider
     if(UMF_POOL_JEMALLOC_ENABLED)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -343,6 +343,10 @@ if(LINUX AND (NOT UMF_DISABLE_HWLOC)) # OS-specific functions are implemented
         NAME provider_fixed_memory
         SRCS provider_fixed_memory.cpp
         LIBS ${UMF_UTILS_FOR_TEST})
+    add_umf_test(
+        NAME provider_tracking
+        SRCS provider_tracking.cpp
+        LIBS ${UMF_UTILS_FOR_TEST})
 
     # This test requires Linux-only file memory provider
     if(UMF_POOL_JEMALLOC_ENABLED)

--- a/test/poolFixtures.hpp
+++ b/test/poolFixtures.hpp
@@ -5,11 +5,6 @@
 #ifndef UMF_TEST_POOL_FIXTURES_HPP
 #define UMF_TEST_POOL_FIXTURES_HPP 1
 
-#include "pool.hpp"
-#include "provider.hpp"
-#include "umf/providers/provider_devdax_memory.h"
-#include "utils/utils_sanitizers.h"
-
 #include <array>
 #include <cstring>
 #include <functional>
@@ -17,7 +12,14 @@
 #include <string>
 #include <thread>
 
+#include <umf/pools/pool_proxy.h>
+#include <umf/providers/provider_devdax_memory.h>
+#include <umf/providers/provider_fixed_memory.h>
+
 #include "../malloc_compliance_tests.hpp"
+#include "pool.hpp"
+#include "provider.hpp"
+#include "utils/utils_sanitizers.h"
 
 typedef void *(*pfnPoolParamsCreate)();
 typedef umf_result_t (*pfnPoolParamsDestroy)(void *);
@@ -491,6 +493,143 @@ TEST_P(umfPoolTest, mallocUsableSize) {
             umfPoolFree(pool.get(), ptr);
         }
     }
+}
+
+TEST_P(umfPoolTest, umfPoolAlignedMalloc) {
+#ifdef _WIN32
+    // TODO: implement support for windows
+    GTEST_SKIP() << "umfPoolAlignedMalloc() is not supported on Windows";
+#else  /* !_WIN32 */
+    umf_result_t umf_result;
+    void *ptr = nullptr;
+    const size_t size = 2 * 1024 * 1024; // 2MB
+
+    umf_memory_pool_handle_t pool_get = pool.get();
+
+    if (!umf_test::isAlignedAllocSupported(pool_get)) {
+        GTEST_SKIP();
+    }
+
+    ptr = umfPoolAlignedMalloc(pool_get, size, utils_get_page_size());
+    ASSERT_NE(ptr, nullptr);
+
+    umf_result = umfPoolFree(pool_get, ptr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+#endif /* !_WIN32 */
+}
+
+TEST_P(umfPoolTest, pool_from_ptr_whole_size_success) {
+#ifdef _WIN32
+    // TODO: implement support for windows
+    GTEST_SKIP() << "umfPoolAlignedMalloc() is not supported on Windows";
+#else  /* !_WIN32 */
+    umf_result_t umf_result;
+    size_t size_of_pool_from_ptr;
+    void *ptr_for_pool = nullptr;
+    void *ptr = nullptr;
+
+    umf_memory_pool_handle_t pool_get = pool.get();
+    const size_t size_of_first_alloc = 2 * 1024 * 1024; // 2MB
+
+    if (!umf_test::isAlignedAllocSupported(pool_get)) {
+        GTEST_SKIP();
+    }
+
+    ptr_for_pool = umfPoolAlignedMalloc(pool_get, size_of_first_alloc,
+                                        utils_get_page_size());
+    ASSERT_NE(ptr_for_pool, nullptr);
+
+    // Create provider parameters
+    size_of_pool_from_ptr = size_of_first_alloc; // whole size
+    umf_fixed_memory_provider_params_handle_t params = nullptr;
+    umf_result = umfFixedMemoryProviderParamsCreate(&params, ptr_for_pool,
+                                                    size_of_pool_from_ptr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(params, nullptr);
+
+    umf_memory_provider_handle_t providerFromPtr = nullptr;
+    umf_result = umfMemoryProviderCreate(umfFixedMemoryProviderOps(), params,
+                                         &providerFromPtr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(providerFromPtr, nullptr);
+
+    umf_memory_pool_handle_t poolFromPtr = nullptr;
+    umf_result = umfPoolCreate(umfProxyPoolOps(), providerFromPtr, nullptr, 0,
+                               &poolFromPtr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    ptr = umfPoolMalloc(poolFromPtr, size_of_pool_from_ptr);
+    ASSERT_NE(ptr, nullptr);
+
+    memset(ptr, 0xFF, size_of_pool_from_ptr);
+
+    umf_result = umfPoolFree(poolFromPtr, ptr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umfPoolDestroy(poolFromPtr);
+    umfMemoryProviderDestroy(providerFromPtr);
+    umfFixedMemoryProviderParamsDestroy(params);
+
+    umf_result = umfPoolFree(pool_get, ptr_for_pool);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+#endif /* !_WIN32 */
+}
+
+TEST_P(umfPoolTest, pool_from_ptr_half_size_success) {
+#ifdef _WIN32
+    // TODO: implement support for windows
+    GTEST_SKIP() << "umfPoolAlignedMalloc() is not supported on Windows";
+#else  /* !_WIN32 */
+    umf_result_t umf_result;
+    size_t size_of_pool_from_ptr;
+    void *ptr_for_pool = nullptr;
+    void *ptr = nullptr;
+
+    umf_memory_pool_handle_t pool_get = pool.get();
+    const size_t size_of_first_alloc = 2 * 1024 * 1024; // 2MB
+
+    if (!umf_test::isAlignedAllocSupported(pool_get)) {
+        GTEST_SKIP();
+    }
+
+    ptr_for_pool = umfPoolAlignedMalloc(pool_get, size_of_first_alloc,
+                                        utils_get_page_size());
+    ASSERT_NE(ptr_for_pool, nullptr);
+
+    // Create provider parameters
+    size_of_pool_from_ptr = size_of_first_alloc / 2; // half size
+    umf_fixed_memory_provider_params_handle_t params = nullptr;
+    umf_result = umfFixedMemoryProviderParamsCreate(&params, ptr_for_pool,
+                                                    size_of_pool_from_ptr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(params, nullptr);
+
+    umf_memory_provider_handle_t providerFromPtr = nullptr;
+    umf_result = umfMemoryProviderCreate(umfFixedMemoryProviderOps(), params,
+                                         &providerFromPtr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(providerFromPtr, nullptr);
+
+    umf_memory_pool_handle_t poolFromPtr = nullptr;
+    umf_result = umfPoolCreate(umfProxyPoolOps(), providerFromPtr, nullptr, 0,
+                               &poolFromPtr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    ptr = umfPoolMalloc(poolFromPtr, size_of_pool_from_ptr);
+    ASSERT_NE(ptr, nullptr);
+
+    memset(ptr, 0xFF, size_of_pool_from_ptr);
+
+    umf_result = umfPoolFree(poolFromPtr, ptr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umfPoolDestroy(poolFromPtr);
+    umfMemoryProviderDestroy(providerFromPtr);
+    umfFixedMemoryProviderParamsDestroy(params);
+
+    umf_result = umfPoolFree(pool_get, ptr_for_pool);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+#endif /* !_WIN32 */
 }
 
 #endif /* UMF_TEST_POOL_FIXTURES_HPP */

--- a/test/provider_fixed_memory.cpp
+++ b/test/provider_fixed_memory.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2025 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -11,10 +11,12 @@
 #endif
 
 #include <umf/memory_provider.h>
+#include <umf/pools/pool_proxy.h>
 #include <umf/providers/provider_fixed_memory.h>
 
 using umf_test::test;
 
+#define FIXED_BUFFER_SIZE (10 * utils_get_page_size())
 #define INVALID_PTR ((void *)0x01)
 
 typedef enum purge_t {
@@ -59,7 +61,7 @@ struct FixedProviderTest
         test::SetUp();
 
         // Allocate a memory buffer to use with the fixed memory provider
-        memory_size = utils_get_page_size() * 10; // Allocate 10 pages
+        memory_size = FIXED_BUFFER_SIZE; // Allocate 10 pages
         memory_buffer = malloc(memory_size);
         ASSERT_NE(memory_buffer, nullptr);
 
@@ -390,4 +392,110 @@ TEST_P(FixedProviderTest, split) {
     memset(ptr2, 0x22, size);
     umf_result = umfMemoryProviderFree(provider.get(), ptr2, size);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+}
+
+TEST_P(FixedProviderTest, pool_from_ptr_whole_size_success) {
+    umf_result_t umf_result;
+    size_t size_of_first_alloc;
+    size_t size_of_pool_from_ptr;
+    void *ptr_for_pool = nullptr;
+    void *ptr = nullptr;
+
+    umf_memory_pool_handle_t proxyFixedPool = nullptr;
+    umf_result = umfPoolCreate(umfProxyPoolOps(), provider.get(), nullptr, 0,
+                               &proxyFixedPool);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    size_of_first_alloc = FIXED_BUFFER_SIZE - (2 * page_size);
+    ptr_for_pool = umfPoolMalloc(proxyFixedPool, size_of_first_alloc);
+    ASSERT_NE(ptr_for_pool, nullptr);
+
+    // Create provider parameters
+    size_of_pool_from_ptr = size_of_first_alloc; // whole size
+    umf_fixed_memory_provider_params_handle_t params = nullptr;
+    umf_result = umfFixedMemoryProviderParamsCreate(&params, ptr_for_pool,
+                                                    size_of_pool_from_ptr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(params, nullptr);
+
+    umf_memory_provider_handle_t providerFromPtr = nullptr;
+    umf_result = umfMemoryProviderCreate(umfFixedMemoryProviderOps(), params,
+                                         &providerFromPtr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(providerFromPtr, nullptr);
+
+    umf_memory_pool_handle_t poolFromPtr = nullptr;
+    umf_result = umfPoolCreate(umfProxyPoolOps(), providerFromPtr, nullptr, 0,
+                               &poolFromPtr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    ptr = umfPoolMalloc(poolFromPtr, size_of_pool_from_ptr);
+    ASSERT_NE(ptr, nullptr);
+
+    memset(ptr, 0xFF, size_of_pool_from_ptr);
+
+    umf_result = umfPoolFree(poolFromPtr, ptr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umfPoolDestroy(poolFromPtr);
+    umfMemoryProviderDestroy(providerFromPtr);
+    umfFixedMemoryProviderParamsDestroy(params);
+
+    umf_result = umfPoolFree(proxyFixedPool, ptr_for_pool);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umfPoolDestroy(proxyFixedPool);
+}
+
+TEST_P(FixedProviderTest, pool_from_ptr_half_size_success) {
+    umf_result_t umf_result;
+    size_t size_of_first_alloc;
+    size_t size_of_pool_from_ptr;
+    void *ptr_for_pool = nullptr;
+    void *ptr = nullptr;
+
+    umf_memory_pool_handle_t proxyFixedPool = nullptr;
+    umf_result = umfPoolCreate(umfProxyPoolOps(), provider.get(), nullptr, 0,
+                               &proxyFixedPool);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    size_of_first_alloc = FIXED_BUFFER_SIZE - (2 * page_size);
+    ptr_for_pool = umfPoolMalloc(proxyFixedPool, size_of_first_alloc);
+    ASSERT_NE(ptr_for_pool, nullptr);
+
+    // Create provider parameters
+    size_of_pool_from_ptr = size_of_first_alloc / 2; // half size
+    umf_fixed_memory_provider_params_handle_t params = nullptr;
+    umf_result = umfFixedMemoryProviderParamsCreate(&params, ptr_for_pool,
+                                                    size_of_pool_from_ptr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(params, nullptr);
+
+    umf_memory_provider_handle_t providerFromPtr = nullptr;
+    umf_result = umfMemoryProviderCreate(umfFixedMemoryProviderOps(), params,
+                                         &providerFromPtr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(providerFromPtr, nullptr);
+
+    umf_memory_pool_handle_t poolFromPtr = nullptr;
+    umf_result = umfPoolCreate(umfProxyPoolOps(), providerFromPtr, nullptr, 0,
+                               &poolFromPtr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    ptr = umfPoolMalloc(poolFromPtr, size_of_pool_from_ptr);
+    ASSERT_NE(ptr, nullptr);
+
+    memset(ptr, 0xFF, size_of_pool_from_ptr);
+
+    umf_result = umfPoolFree(poolFromPtr, ptr);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umfPoolDestroy(poolFromPtr);
+    umfMemoryProviderDestroy(providerFromPtr);
+    umfFixedMemoryProviderParamsDestroy(params);
+
+    umf_result = umfPoolFree(proxyFixedPool, ptr_for_pool);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umfPoolDestroy(proxyFixedPool);
 }

--- a/test/provider_tracking.cpp
+++ b/test/provider_tracking.cpp
@@ -1,0 +1,374 @@
+// Copyright (C) 2025 Intel Corporation
+// Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "base.hpp"
+
+#include "cpp_helpers.hpp"
+#include "test_helpers.h"
+#ifndef _WIN32
+#include "test_helpers_linux.h"
+#endif
+
+#include <umf/memory_provider.h>
+#include <umf/pools/pool_proxy.h>
+#include <umf/providers/provider_fixed_memory.h>
+
+using umf_test::test;
+
+#define FIXED_BUFFER_SIZE (512 * utils_get_page_size())
+#define INVALID_PTR ((void *)0x01)
+
+using providerCreateExtParams = std::tuple<umf_memory_provider_ops_t *, void *>;
+
+static void providerCreateExt(providerCreateExtParams params,
+                              umf::provider_unique_handle_t *handle) {
+    umf_memory_provider_handle_t hProvider = nullptr;
+    auto [provider_ops, provider_params] = params;
+
+    auto ret =
+        umfMemoryProviderCreate(provider_ops, provider_params, &hProvider);
+    ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+    ASSERT_NE(hProvider, nullptr);
+
+    *handle =
+        umf::provider_unique_handle_t(hProvider, &umfMemoryProviderDestroy);
+}
+
+struct TrackingProviderTest
+    : umf_test::test,
+      ::testing::WithParamInterface<providerCreateExtParams> {
+    void SetUp() override {
+        test::SetUp();
+
+        // Allocate a memory buffer to use with the fixed memory provider
+        memory_size = FIXED_BUFFER_SIZE;
+        memory_buffer = malloc(memory_size);
+        ASSERT_NE(memory_buffer, nullptr);
+
+        // Create provider parameters
+        umf_fixed_memory_provider_params_handle_t params = nullptr;
+        umf_result_t res = umfFixedMemoryProviderParamsCreate(
+            &params, memory_buffer, memory_size);
+        ASSERT_EQ(res, UMF_RESULT_SUCCESS);
+        ASSERT_NE(params, nullptr);
+
+        providerCreateExt(std::make_tuple(umfFixedMemoryProviderOps(), params),
+                          &provider);
+
+        umfFixedMemoryProviderParamsDestroy(params);
+        umf_result_t umf_result =
+            umfMemoryProviderGetMinPageSize(provider.get(), NULL, &page_size);
+        ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+        page_plus_64 = page_size + 64;
+
+        umf_memory_pool_handle_t hPool = nullptr;
+        umf_result = umfPoolCreate(umfProxyPoolOps(), provider.get(), nullptr,
+                                   0, &hPool);
+        ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+        pool = umf::pool_unique_handle_t(hPool, &umfPoolDestroy);
+    }
+
+    void TearDown() override {
+        if (memory_buffer) {
+            free(memory_buffer);
+            memory_buffer = nullptr;
+        }
+        test::TearDown();
+    }
+
+    umf::provider_unique_handle_t provider;
+    umf::pool_unique_handle_t pool;
+    size_t page_size;
+    size_t page_plus_64;
+    void *memory_buffer = nullptr;
+    size_t memory_size = 0;
+};
+
+static void
+createPoolFromAllocation(void *ptr0, size_t size1,
+                         umf_memory_provider_handle_t *_providerFromPtr,
+                         umf_memory_pool_handle_t *_poolFromPtr) {
+    umf_result_t umf_result;
+
+    // Create provider parameters
+    umf_fixed_memory_provider_params_handle_t params = nullptr;
+    umf_result = umfFixedMemoryProviderParamsCreate(&params, ptr0, size1);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(params, nullptr);
+
+    umf_memory_provider_handle_t provider1 = nullptr;
+    umf_result = umfMemoryProviderCreate(umfFixedMemoryProviderOps(), params,
+                                         &provider1);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_NE(provider1, nullptr);
+
+    umf_memory_pool_handle_t pool1 = nullptr;
+    umf_result =
+        umfPoolCreate(umfProxyPoolOps(), provider1, nullptr, 0, &pool1);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umfFixedMemoryProviderParamsDestroy(params);
+
+    *_providerFromPtr = provider1;
+    *_poolFromPtr = pool1;
+}
+
+// TESTS
+
+INSTANTIATE_TEST_SUITE_P(trackingProviderTest, TrackingProviderTest,
+                         ::testing::Values(providerCreateExtParams{
+                             umfFixedMemoryProviderOps(), nullptr}));
+
+TEST_P(TrackingProviderTest, create_destroy) {
+    // Creation and destruction are handled in SetUp and TearDown
+}
+
+TEST_P(TrackingProviderTest, whole_size_success) {
+    umf_result_t umf_result;
+    size_t size0;
+    size_t size1;
+    void *ptr0 = nullptr;
+    void *ptr1 = nullptr;
+
+    umf_memory_pool_handle_t pool0 = pool.get();
+
+    size0 = FIXED_BUFFER_SIZE - (2 * page_size);
+    ptr0 = umfPoolAlignedMalloc(pool0, size0, utils_get_page_size());
+    ASSERT_NE(ptr0, nullptr);
+
+    size1 = size0; // whole size
+
+    umf_memory_provider_handle_t provider1 = nullptr;
+    umf_memory_pool_handle_t pool1 = nullptr;
+    createPoolFromAllocation(ptr0, size1, &provider1, &pool1);
+
+    ptr1 = umfPoolMalloc(pool1, size1);
+    ASSERT_NE(ptr1, nullptr);
+
+    umf_result = umfPoolFree(pool1, ptr1);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umfPoolDestroy(pool1);
+    umfMemoryProviderDestroy(provider1);
+
+    umf_result = umfPoolFree(pool0, ptr0);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+}
+
+TEST_P(TrackingProviderTest, half_size_success) {
+    umf_result_t umf_result;
+    size_t size0;
+    size_t size1;
+    void *ptr0 = nullptr;
+    void *ptr1 = nullptr;
+
+    umf_memory_pool_handle_t pool0 = pool.get();
+
+    size0 = FIXED_BUFFER_SIZE - (2 * page_size);
+    ptr0 = umfPoolAlignedMalloc(pool0, size0, utils_get_page_size());
+    ASSERT_NE(ptr0, nullptr);
+
+    size1 = size0 / 2; // half size
+
+    umf_memory_provider_handle_t provider1 = nullptr;
+    umf_memory_pool_handle_t pool1 = nullptr;
+    createPoolFromAllocation(ptr0, size1, &provider1, &pool1);
+
+    ptr1 = umfPoolMalloc(pool1, size1);
+    ASSERT_NE(ptr1, nullptr);
+
+    umf_result = umfPoolFree(pool1, ptr1);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umfPoolDestroy(pool1);
+    umfMemoryProviderDestroy(provider1);
+
+    umf_result = umfPoolFree(pool0, ptr0);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+}
+
+TEST_P(TrackingProviderTest, failure_exceeding_size) {
+    umf_result_t umf_result;
+    size_t size0;
+    size_t size1;
+    void *ptr0 = nullptr;
+    void *ptr1 = nullptr;
+
+    umf_memory_pool_handle_t pool0 = pool.get();
+
+    size0 = FIXED_BUFFER_SIZE - (2 * page_size);
+    ptr0 = umfPoolAlignedMalloc(pool0, size0, utils_get_page_size());
+    ASSERT_NE(ptr0, nullptr);
+
+    size1 = FIXED_BUFFER_SIZE - page_size; // exceeding size
+
+    umf_memory_provider_handle_t provider1 = nullptr;
+    umf_memory_pool_handle_t pool1 = nullptr;
+    createPoolFromAllocation(ptr0, size1, &provider1, &pool1);
+
+    ptr1 = umfPoolMalloc(pool1, size1);
+    ASSERT_EQ(ptr1, nullptr);
+
+    umfPoolDestroy(pool1);
+    umfMemoryProviderDestroy(provider1);
+
+    umf_result = umfPoolFree(pool0, ptr0);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+}
+
+#define MAX_ARRAY 9
+#define TEST_LEVEL_SUCCESS 7
+#define TEST_LEVEL_FAILURE 8
+
+TEST_P(TrackingProviderTest, success_max_levels) {
+    umf_result_t umf_result;
+    size_t size;
+    void *ptr[MAX_ARRAY] = {0};
+    umf_memory_provider_handle_t providers[MAX_ARRAY] = {0};
+    umf_memory_pool_handle_t pools[MAX_ARRAY] = {0};
+
+    size = FIXED_BUFFER_SIZE - (2 * page_size);
+    pools[0] = pool.get();
+
+    for (int i = 0; i < TEST_LEVEL_SUCCESS; i++) {
+        fprintf(stderr, "Alloc #%d\n", i);
+        ptr[i] = umfPoolAlignedMalloc(pools[i], size, utils_get_page_size());
+        ASSERT_NE(ptr[i], nullptr);
+
+        createPoolFromAllocation(ptr[i], size, &providers[i + 1],
+                                 &pools[i + 1]);
+    }
+
+    int s = TEST_LEVEL_SUCCESS;
+    fprintf(stderr, "Alloc #%d\n", s);
+    ptr[s] = umfPoolAlignedMalloc(pools[s], size, utils_get_page_size());
+    ASSERT_NE(ptr[s], nullptr);
+
+    fprintf(stderr, "Free #%d\n", s);
+    umf_result = umfPoolFree(pools[s], ptr[s]);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    for (int i = TEST_LEVEL_SUCCESS - 1; i >= 0; i--) {
+        umfPoolDestroy(pools[i + 1]);
+        umfMemoryProviderDestroy(providers[i + 1]);
+
+        fprintf(stderr, "Free #%d\n", i);
+        umf_result = umfPoolFree(pools[i], ptr[i]);
+        ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    }
+}
+
+TEST_P(TrackingProviderTest, failure_exceeding_levels) {
+    umf_result_t umf_result;
+    size_t size;
+    void *ptr[MAX_ARRAY] = {0};
+    umf_memory_provider_handle_t providers[MAX_ARRAY] = {0};
+    umf_memory_pool_handle_t pools[MAX_ARRAY] = {0};
+
+    size = FIXED_BUFFER_SIZE - (2 * page_size);
+    pools[0] = pool.get();
+
+    for (int i = 0; i < TEST_LEVEL_FAILURE; i++) {
+        fprintf(stderr, "Alloc #%d\n", i);
+        ptr[i] = umfPoolAlignedMalloc(pools[i], size, utils_get_page_size());
+        ASSERT_NE(ptr[i], nullptr);
+
+        createPoolFromAllocation(ptr[i], size, &providers[i + 1],
+                                 &pools[i + 1]);
+    }
+
+    // tracker level is too high
+    int f = TEST_LEVEL_FAILURE;
+    fprintf(stderr, "Alloc #%d\n", f);
+    ptr[f] = umfPoolAlignedMalloc(pools[f], size, utils_get_page_size());
+    ASSERT_EQ(ptr[f], nullptr);
+
+    for (int i = TEST_LEVEL_FAILURE - 1; i >= 0; i--) {
+        umfPoolDestroy(pools[i + 1]);
+        umfMemoryProviderDestroy(providers[i + 1]);
+
+        fprintf(stderr, "Free #%d\n", i);
+        umf_result = umfPoolFree(pools[i], ptr[i]);
+        ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    }
+}
+
+TEST_P(TrackingProviderTest, reverted_free_half_size) {
+    umf_result_t umf_result;
+    size_t size0;
+    size_t size1;
+    void *ptr0 = nullptr;
+    void *ptr1 = nullptr;
+
+    umf_memory_pool_handle_t pool0 = pool.get();
+
+    size0 = FIXED_BUFFER_SIZE - (2 * page_size);
+    ptr0 = umfPoolAlignedMalloc(pool0, size0, utils_get_page_size());
+    ASSERT_NE(ptr0, nullptr);
+
+    umf_memory_provider_handle_t provider1 = nullptr;
+    umf_memory_pool_handle_t pool1 = nullptr;
+    createPoolFromAllocation(ptr0, size0, &provider1, &pool1);
+
+    size1 = size0 / 2; // half size
+
+    ptr1 = umfPoolMalloc(pool1, size1);
+    ASSERT_NE(ptr1, nullptr);
+
+    // Freeing the "busy" pointer from the first pool is an Undefined Behavior
+    // It fails now if the sizes are different.
+    // see: https://github.com/oneapi-src/unified-memory-framework/pull/1161
+    umf_result = umfPoolFree(pool0, ptr0);
+
+    umf_result = umfPoolFree(pool1, ptr1);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umfPoolDestroy(pool1);
+    umfMemoryProviderDestroy(provider1);
+
+    // It could have been freed above,
+    // so we cannot verify the result here.
+    umf_result = umfPoolFree(pool0, ptr0);
+}
+
+TEST_P(TrackingProviderTest, reverted_free_the_same_size) {
+    umf_result_t umf_result;
+    size_t size0;
+    size_t size1;
+    void *ptr0 = nullptr;
+    void *ptr1 = nullptr;
+
+    umf_memory_pool_handle_t pool0 = pool.get();
+
+    size0 = FIXED_BUFFER_SIZE - (2 * page_size);
+    ptr0 = umfPoolAlignedMalloc(pool0, size0, utils_get_page_size());
+    ASSERT_NE(ptr0, nullptr);
+
+    umf_memory_provider_handle_t provider1 = nullptr;
+    umf_memory_pool_handle_t pool1 = nullptr;
+    createPoolFromAllocation(ptr0, size0, &provider1, &pool1);
+
+    size1 = size0; // the same size
+
+    ptr1 = umfPoolMalloc(pool1, size1);
+    ASSERT_NE(ptr1, nullptr);
+
+    // Freeing the "busy" pointer from the first pool is an Undefined Behavior
+    // It succeeds now if the sizes are equal.
+    // see: https://github.com/oneapi-src/unified-memory-framework/pull/1161
+    umf_result = umfPoolFree(pool0, ptr0);
+
+    // try to free the pointer from the second pool (the same size)
+    umf_result = umfPoolFree(pool1, ptr1);
+    ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+
+    umfPoolDestroy(pool1);
+    umfMemoryProviderDestroy(provider1);
+
+    // It could have been freed above,
+    // so we cannot verify the result here.
+    umf_result = umfPoolFree(pool0, ptr0);
+}

--- a/test/provider_tracking_fixture_tests.cpp
+++ b/test/provider_tracking_fixture_tests.cpp
@@ -1,0 +1,91 @@
+// Copyright (C) 2025 Intel Corporation
+// Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <umf/memory_provider.h>
+#include <umf/pools/pool_proxy.h>
+#include <umf/providers/provider_file_memory.h>
+
+#include "base.hpp"
+#include "provider.hpp"
+
+#include "cpp_helpers.hpp"
+#include "test_helpers.h"
+#ifndef _WIN32
+#include "test_helpers_linux.h"
+#endif
+
+#include "poolFixtures.hpp"
+
+#define FILE_PATH ((char *)"tmp_file")
+
+struct provider_from_pool : public umf_test::provider_base_t {
+    umf_memory_pool_handle_t pool;
+    umf_result_t initialize(umf_memory_pool_handle_t _pool) noexcept {
+        if (!_pool) {
+            return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+        }
+        pool = _pool;
+        return UMF_RESULT_SUCCESS;
+    }
+    umf_result_t alloc(size_t size, size_t align, void **ptr) noexcept {
+        *ptr = umfPoolAlignedMalloc(pool, size, align);
+        return (*ptr) ? UMF_RESULT_SUCCESS
+                      : UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+    umf_result_t free(void *ptr, size_t) noexcept {
+        return umfPoolFree(pool, ptr);
+    }
+    const char *get_name() noexcept { return "provider_from_pool"; }
+
+    virtual ~provider_from_pool() {
+        if (pool) {
+            umfPoolDestroy(pool);
+            pool = nullptr;
+        }
+    }
+};
+
+umf_memory_provider_ops_t PROVIDER_FROM_POOL_OPS =
+    umf::providerMakeCOps<provider_from_pool, umf_memory_pool_t>();
+
+static void *providerFromPoolParamsCreate(void) {
+    umf_file_memory_provider_params_handle_t paramsFile = NULL;
+    umf_result_t umf_result =
+        umfFileMemoryProviderParamsCreate(&paramsFile, FILE_PATH);
+    EXPECT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    EXPECT_NE(paramsFile, nullptr);
+
+    umf_memory_provider_handle_t providerFile = nullptr;
+    umf_result = umfMemoryProviderCreate(umfFileMemoryProviderOps(), paramsFile,
+                                         &providerFile);
+    EXPECT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    EXPECT_NE(providerFile, nullptr);
+
+    umf_memory_pool_handle_t poolProxyFile = nullptr;
+    umf_result =
+        umfPoolCreate(umfProxyPoolOps(), providerFile, nullptr,
+                      UMF_POOL_CREATE_FLAG_OWN_PROVIDER, &poolProxyFile);
+    EXPECT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    EXPECT_NE(poolProxyFile, nullptr);
+
+    umf_result = umfFileMemoryProviderParamsDestroy(paramsFile);
+    EXPECT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    paramsFile = nullptr;
+
+    return poolProxyFile;
+}
+
+// TESTS
+
+INSTANTIATE_TEST_SUITE_P(TrackingProviderPoolTest, umfPoolTest,
+                         ::testing::Values(poolCreateExtParams{
+                             umfProxyPoolOps(), nullptr, nullptr,
+                             &PROVIDER_FROM_POOL_OPS,
+                             providerFromPoolParamsCreate, nullptr}));
+
+INSTANTIATE_TEST_SUITE_P(TrackingProviderMultiPoolTest, umfMultiPoolTest,
+                         ::testing::Values(poolCreateExtParams{
+                             umfProxyPoolOps(), nullptr, nullptr,
+                             &PROVIDER_FROM_POOL_OPS,
+                             providerFromPoolParamsCreate, nullptr}));


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

Use eight level of critnibs in the tracker.
Multilevel maps are needed to support the case
when one memory pool acts as a memory provider
for another memory pool (nested memory pooling).

Depends on:
- [x] https://github.com/oneapi-src/unified-memory-framework/pull/1151

Requires:
- [x] https://github.com/oneapi-src/unified-memory-framework/pull/1176

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
