### PR TITLE
coarse: error out on double free instead of assert

### DIFF
--- a/src/coarse/coarse.c
+++ b/src/coarse/coarse.c
@@ -1170,10 +1170,13 @@ umf_result_t coarse_free(coarse_t *coarse, void *ptr, size_t bytes) {
     }
 
     block_t *block = get_node_block(node);
-    assert(block->used);
+    if (!block->used) {
+        LOG_ERR("double free");
+        utils_mutex_unlock(&coarse->lock);
+        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+    }
 
     if (bytes > 0 && bytes != block->size) {
-        // wrong size of allocation
         LOG_ERR("wrong size of allocation");
         utils_mutex_unlock(&coarse->lock);
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;

--- a/test/coarse_lib.cpp
+++ b/test/coarse_lib.cpp
@@ -160,6 +160,13 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_basic_provider) {
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
     ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
 
+    // test double free
+    umf_result = coarse_free(ch, ptr, 2 * MB);
+    ASSERT_EQ(umf_result, UMF_RESULT_ERROR_INVALID_ARGUMENT);
+    ASSERT_EQ(coarse_get_stats(ch).used_size, 0);
+    ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+
     coarse_delete(ch);
     umfMemoryProviderDestroy(malloc_memory_provider);
 }
@@ -198,6 +205,13 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_basic_fixed_memory) {
 
     umf_result = coarse_free(ch, ptr, 2 * MB);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
+    ASSERT_EQ(coarse_get_stats(ch).used_size, 0);
+    ASSERT_EQ(coarse_get_stats(ch).alloc_size, buff_size);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+
+    // test double free
+    umf_result = coarse_free(ch, ptr, 2 * MB);
+    ASSERT_EQ(umf_result, UMF_RESULT_ERROR_INVALID_ARGUMENT);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, buff_size);
     ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);


### PR DESCRIPTION

<!-- Provide a short summary of your changes in the Title above -->

### Description

Error out in case of double free() instead of assert in coarse library.

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
