### PR TITLE
Cleanup atomics and fix deadlock in DP bucket_can_pool()

### DIFF
--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -96,9 +96,7 @@ UMF_BENCHMARK_TEMPLATE_DEFINE(multiple_malloc_free_benchmark,
                               pool_allocator<disjoint_pool<os_provider>>);
 UMF_BENCHMARK_REGISTER_F(multiple_malloc_free_benchmark, disjoint_pool_uniform)
     ->Apply(&default_multiple_alloc_uniform_size)
-    ->Apply(&singlethreaded);
-// TODO: change to multithreaded
-//->Apply(&multithreaded);
+    ->Apply(&multithreaded);
 
 #ifdef UMF_POOL_JEMALLOC_ENABLED
 UMF_BENCHMARK_TEMPLATE_DEFINE(multiple_malloc_free_benchmark, jemalloc_pool_fix,

--- a/src/critnib/critnib.c
+++ b/src/critnib/critnib.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -132,24 +132,6 @@ struct critnib {
 
     struct utils_mutex_t mutex; /* writes/removes */
 };
-
-/*
- * atomic load
- */
-static void load(void *src, void *dst) {
-    utils_atomic_load_acquire((word *)src, (word *)dst);
-}
-
-static void load64(uint64_t *src, uint64_t *dst) {
-    utils_atomic_load_acquire(src, dst);
-}
-
-/*
- * atomic store
- */
-static void store(void *dst, void *src) {
-    utils_atomic_store_release((word *)dst, (word)src);
-}
 
 /*
  * internal: is_leaf -- check tagged pointer for leafness
@@ -303,7 +285,7 @@ static void free_leaf(struct critnib *__restrict c,
  */
 static struct critnib_leaf *alloc_leaf(struct critnib *__restrict c) {
     if (!c->deleted_leaf) {
-        return umf_ba_global_alloc(sizeof(struct critnib_leaf));
+        return umf_ba_global_aligned_alloc(sizeof(struct critnib_leaf), 8);
     }
 
     struct critnib_leaf *k = c->deleted_leaf;
@@ -343,10 +325,8 @@ int critnib_insert(struct critnib *c, word key, void *value, int update) {
 
     struct critnib_node *n = c->root;
     if (!n) {
-        store(&c->root, kn);
-
+        utils_atomic_store_release_ptr((void **)&c->root, kn);
         utils_mutex_unlock(&c->mutex);
-
         return 0;
     }
 
@@ -361,7 +341,8 @@ int critnib_insert(struct critnib *c, word key, void *value, int update) {
 
     if (!n) {
         n = prev;
-        store(&n->child[slice_index(key, n->shift)], kn);
+        utils_atomic_store_release_ptr(
+            (void **)&n->child[slice_index(key, n->shift)], kn);
 
         utils_mutex_unlock(&c->mutex);
 
@@ -406,7 +387,7 @@ int critnib_insert(struct critnib *c, word key, void *value, int update) {
     m->child[slice_index(path, sh)] = n;
     m->shift = sh;
     m->path = key & path_mask(sh);
-    store(parent, m);
+    utils_atomic_store_release_ptr((void **)parent, m);
 
     utils_mutex_unlock(&c->mutex);
 
@@ -427,7 +408,8 @@ void *critnib_remove(struct critnib *c, word key) {
         goto not_found;
     }
 
-    word del = (utils_atomic_increment(&c->remove_count) - 1) % DELETED_LIFE;
+    word del =
+        (utils_atomic_increment_u64(&c->remove_count) - 1) % DELETED_LIFE;
     free_node(c, c->pending_del_nodes[del]);
     free_leaf(c, c->pending_del_leaves[del]);
     c->pending_del_nodes[del] = NULL;
@@ -436,7 +418,7 @@ void *critnib_remove(struct critnib *c, word key) {
     if (is_leaf(n)) {
         k = to_leaf(n);
         if (k->key == key) {
-            store(&c->root, NULL);
+            utils_atomic_store_release_ptr((void **)&c->root, NULL);
             goto del_leaf;
         }
 
@@ -466,7 +448,8 @@ void *critnib_remove(struct critnib *c, word key) {
         goto not_found;
     }
 
-    store(&n->child[slice_index(key, n->shift)], NULL);
+    utils_atomic_store_release_ptr(
+        (void **)&n->child[slice_index(key, n->shift)], NULL);
 
     /* Remove the node if there's only one remaining child. */
     int ochild = -1;
@@ -482,7 +465,7 @@ void *critnib_remove(struct critnib *c, word key) {
 
     ASSERTne(ochild, -1);
 
-    store(n_parent, n->child[ochild]);
+    utils_atomic_store_release_ptr((void **)n_parent, n->child[ochild]);
     c->pending_del_nodes[del] = n;
 
 del_leaf:
@@ -511,8 +494,8 @@ void *critnib_get(struct critnib *c, word key) {
     do {
         struct critnib_node *n;
 
-        load64(&c->remove_count, &wrs1);
-        load(&c->root, &n);
+        utils_atomic_load_acquire_u64(&c->remove_count, &wrs1);
+        utils_atomic_load_acquire_ptr((void **)&c->root, (void **)&n);
 
         /*
 		 * critbit algorithm: dive into the tree, looking at nothing but
@@ -520,13 +503,14 @@ void *critnib_get(struct critnib *c, word key) {
 		 * going wrong way if our path is missing, but that's ok...
 		 */
         while (n && !is_leaf(n)) {
-            load(&n->child[slice_index(key, n->shift)], &n);
+            utils_atomic_load_acquire_ptr(
+                (void **)&n->child[slice_index(key, n->shift)], (void **)&n);
         }
 
         /* ... as we check it at the end. */
         struct critnib_leaf *k = to_leaf(n);
         res = (n && k->key == key) ? k->value : NULL;
-        load64(&c->remove_count, &wrs2);
+        utils_atomic_load_acquire_u64(&c->remove_count, &wrs2);
     } while (wrs1 + DELETED_LIFE <= wrs2);
 
     return res;
@@ -597,7 +581,7 @@ static struct critnib_leaf *find_le(struct critnib_node *__restrict n,
     /* recursive call: follow the path */
     {
         struct critnib_node *m;
-        load(&n->child[nib], &m);
+        utils_atomic_load_acquire_ptr((void **)&n->child[nib], (void **)&m);
         struct critnib_leaf *k = find_le(m, key);
         if (k) {
             return k;
@@ -611,7 +595,7 @@ static struct critnib_leaf *find_le(struct critnib_node *__restrict n,
 	 */
     for (; nib > 0; nib--) {
         struct critnib_node *m;
-        load(&n->child[nib - 1], &m);
+        utils_atomic_load_acquire_ptr((void **)&n->child[nib - 1], (void **)&m);
         if (m) {
             n = m;
             if (is_leaf(n)) {
@@ -635,12 +619,12 @@ void *critnib_find_le(struct critnib *c, word key) {
     void *res;
 
     do {
-        load64(&c->remove_count, &wrs1);
+        utils_atomic_load_acquire_u64(&c->remove_count, &wrs1);
         struct critnib_node *n; /* avoid a subtle TOCTOU */
-        load(&c->root, &n);
+        utils_atomic_load_acquire_ptr((void **)&c->root, (void **)&n);
         struct critnib_leaf *k = n ? find_le(n, key) : NULL;
         res = k ? k->value : NULL;
-        load64(&c->remove_count, &wrs2);
+        utils_atomic_load_acquire_u64(&c->remove_count, &wrs2);
     } while (wrs1 + DELETED_LIFE <= wrs2);
 
     return res;
@@ -694,7 +678,7 @@ static struct critnib_leaf *find_ge(struct critnib_node *__restrict n,
     unsigned nib = slice_index(key, n->shift);
     {
         struct critnib_node *m;
-        load(&n->child[nib], &m);
+        utils_atomic_load_acquire_ptr((void **)&n->child[nib], (void **)&m);
         struct critnib_leaf *k = find_ge(m, key);
         if (k) {
             return k;
@@ -703,7 +687,7 @@ static struct critnib_leaf *find_ge(struct critnib_node *__restrict n,
 
     for (; nib < NIB; nib++) {
         struct critnib_node *m;
-        load(&n->child[nib + 1], &m);
+        utils_atomic_load_acquire_ptr((void **)&n->child[nib + 1], (void **)&m);
         if (m) {
             n = m;
             if (is_leaf(n)) {
@@ -741,9 +725,9 @@ int critnib_find(struct critnib *c, uintptr_t key, enum find_dir_t dir,
     }
 
     do {
-        load64(&c->remove_count, &wrs1);
+        utils_atomic_load_acquire_u64(&c->remove_count, &wrs1);
         struct critnib_node *n;
-        load(&c->root, &n);
+        utils_atomic_load_acquire_ptr((void **)&c->root, (void **)&n);
 
         if (dir < 0) {
             k = find_le(n, key);
@@ -751,7 +735,9 @@ int critnib_find(struct critnib *c, uintptr_t key, enum find_dir_t dir,
             k = find_ge(n, key);
         } else {
             while (n && !is_leaf(n)) {
-                load(&n->child[slice_index(key, n->shift)], &n);
+                utils_atomic_load_acquire_ptr(
+                    (void **)&n->child[slice_index(key, n->shift)],
+                    (void **)&n);
             }
 
             struct critnib_leaf *kk = to_leaf(n);
@@ -761,7 +747,7 @@ int critnib_find(struct critnib *c, uintptr_t key, enum find_dir_t dir,
             _rkey = k->key;
             _rvalue = k->value;
         }
-        load64(&c->remove_count, &wrs2);
+        utils_atomic_load_acquire_u64(&c->remove_count, &wrs2);
     } while (wrs1 + DELETED_LIFE <= wrs2);
 
     if (k) {

--- a/src/critnib/critnib.c
+++ b/src/critnib/critnib.c
@@ -174,8 +174,8 @@ struct critnib *critnib_new(void) {
         goto err_free_critnib;
     }
 
-    VALGRIND_HG_DRD_DISABLE_CHECKING(&c->root, sizeof(c->root));
-    VALGRIND_HG_DRD_DISABLE_CHECKING(&c->remove_count, sizeof(c->remove_count));
+    utils_annotate_memory_no_check(&c->root, sizeof(c->root));
+    utils_annotate_memory_no_check(&c->remove_count, sizeof(c->remove_count));
 
     return c;
 err_free_critnib:
@@ -260,7 +260,7 @@ static struct critnib_node *alloc_node(struct critnib *__restrict c) {
     struct critnib_node *n = c->deleted_node;
 
     c->deleted_node = n->child[0];
-    VALGRIND_ANNOTATE_NEW_MEMORY(n, sizeof(*n));
+    utils_annotate_memory_new(n, sizeof(*n));
 
     return n;
 }
@@ -291,7 +291,7 @@ static struct critnib_leaf *alloc_leaf(struct critnib *__restrict c) {
     struct critnib_leaf *k = c->deleted_leaf;
 
     c->deleted_leaf = k->value;
-    VALGRIND_ANNOTATE_NEW_MEMORY(k, sizeof(*k));
+    utils_annotate_memory_new(k, sizeof(*k));
 
     return k;
 }
@@ -316,7 +316,7 @@ int critnib_insert(struct critnib *c, word key, void *value, int update) {
         return ENOMEM;
     }
 
-    VALGRIND_HG_DRD_DISABLE_CHECKING(k, sizeof(struct critnib_leaf));
+    utils_annotate_memory_no_check(k, sizeof(struct critnib_leaf));
 
     k->key = key;
     k->value = value;
@@ -377,7 +377,7 @@ int critnib_insert(struct critnib *c, word key, void *value, int update) {
 
         return ENOMEM;
     }
-    VALGRIND_HG_DRD_DISABLE_CHECKING(m, sizeof(struct critnib_node));
+    utils_annotate_memory_no_check(m, sizeof(struct critnib_node));
 
     for (int i = 0; i < SLNODES; i++) {
         m->child[i] = NULL;

--- a/src/ipc_cache.c
+++ b/src/ipc_cache.c
@@ -232,7 +232,7 @@ umf_result_t umfIpcOpenedCacheGet(ipc_opened_cache_handle_t cache,
 
 exit:
     if (ret == UMF_RESULT_SUCCESS) {
-        utils_atomic_increment(&entry->ref_count);
+        utils_atomic_increment_u64(&entry->ref_count);
         *retEntry = &entry->value;
     }
 

--- a/src/libumf.c
+++ b/src/libumf.c
@@ -24,10 +24,10 @@
 
 umf_memory_tracker_handle_t TRACKER = NULL;
 
-static unsigned long long umfRefCount = 0;
+static uint64_t umfRefCount = 0;
 
 int umfInit(void) {
-    if (utils_fetch_and_add64(&umfRefCount, 1) == 0) {
+    if (utils_fetch_and_add_u64(&umfRefCount, 1) == 0) {
         utils_log_init();
         TRACKER = umfMemoryTrackerCreate();
         if (!TRACKER) {
@@ -54,7 +54,7 @@ int umfInit(void) {
 }
 
 void umfTearDown(void) {
-    if (utils_fetch_and_add64(&umfRefCount, -1) == 1) {
+    if (utils_fetch_and_sub_u64(&umfRefCount, 1) == 1) {
 #if !defined(_WIN32) && !defined(UMF_NO_HWLOC)
         umfMemspaceHostAllDestroy();
         umfMemspaceHighestCapacityDestroy();

--- a/src/pool/pool_disjoint.c
+++ b/src/pool/pool_disjoint.c
@@ -8,6 +8,7 @@
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -20,6 +21,7 @@
 #include "provider/provider_tracking.h"
 #include "uthash/utlist.h"
 #include "utils_common.h"
+#include "utils_concurrency.h"
 #include "utils_log.h"
 #include "utils_math.h"
 
@@ -523,7 +525,7 @@ static void disjoint_pool_print_stats(disjoint_pool_t *pool) {
         utils_mutex_unlock(&bucket->bucket_lock);
     }
 
-    LOG_DEBUG("current pool size: %zu",
+    LOG_DEBUG("current pool size: %" PRIu64,
               disjoint_pool_get_limits(pool)->total_size);
     LOG_DEBUG("suggested setting=;%c%s:%zu,%zu,64K", (char)tolower(name[0]),
               (name + 1), high_bucket_size, high_peak_slabs_in_use);
@@ -864,7 +866,8 @@ umf_result_t disjoint_pool_free(void *pool, void *ptr) {
 
     if (disjoint_pool->params.pool_trace > 2) {
         const char *name = disjoint_pool->params.name;
-        LOG_DEBUG("freed %s %p to %s, current total pool size: %zu, current "
+        LOG_DEBUG("freed %s %p to %s, current total pool size: %" PRIu64
+                  ", current "
                   "pool size for %s: %zu",
                   name, ptr, (to_pool ? "pool" : "provider"),
                   disjoint_pool_get_limits(disjoint_pool)->total_size, name,

--- a/src/pool/pool_disjoint.c
+++ b/src/pool/pool_disjoint.c
@@ -36,7 +36,6 @@
 // Forward declarations
 static void bucket_update_stats(bucket_t *bucket, int in_use, int in_pool);
 static bool bucket_can_pool(bucket_t *bucket);
-static void bucket_decrement_pool(bucket_t *bucket);
 static slab_list_item_t *bucket_get_avail_slab(bucket_t *bucket,
                                                bool *from_pool);
 
@@ -318,6 +317,7 @@ static void bucket_free_chunk(bucket_t *bucket, void *ptr, slab_t *slab,
             assert(slab_it->val != NULL);
             pool_unregister_slab(bucket->pool, slab_it->val);
             DL_DELETE(bucket->available_slabs, slab_it);
+            assert(bucket->available_slabs_num > 0);
             bucket->available_slabs_num--;
             destroy_slab(slab_it->val);
         }
@@ -383,10 +383,16 @@ static slab_list_item_t *bucket_get_avail_slab(bucket_t *bucket,
         // Allocation from existing slab is treated as from pool for statistics.
         *from_pool = true;
         if (slab->num_chunks_allocated == 0) {
+            assert(bucket->chunked_slabs_in_pool > 0);
             // If this was an empty slab, it was in the pool.
             // Now it is no longer in the pool, so update count.
             --bucket->chunked_slabs_in_pool;
-            bucket_decrement_pool(bucket);
+            uint64_t size_to_sub = bucket_slab_alloc_size(bucket);
+            uint64_t old_size = utils_fetch_and_sub_u64(
+                &bucket->shared_limits->total_size, size_to_sub);
+            (void)old_size;
+            assert(old_size >= size_to_sub);
+            bucket_update_stats(bucket, 1, -1);
         }
     }
 
@@ -422,12 +428,6 @@ static void bucket_update_stats(bucket_t *bucket, int in_use, int in_pool) {
         in_pool * bucket_slab_alloc_size(bucket);
 }
 
-static void bucket_decrement_pool(bucket_t *bucket) {
-    bucket_update_stats(bucket, 1, -1);
-    utils_fetch_and_add64(&bucket->shared_limits->total_size,
-                          -(long long)bucket_slab_alloc_size(bucket));
-}
-
 static bool bucket_can_pool(bucket_t *bucket) {
     size_t new_free_slabs_in_bucket;
 
@@ -435,23 +435,20 @@ static bool bucket_can_pool(bucket_t *bucket) {
 
     // we keep at most params.capacity slabs in the pool
     if (bucket_max_pooled_slabs(bucket) >= new_free_slabs_in_bucket) {
-        size_t pool_size = 0;
-        utils_atomic_load_acquire(&bucket->shared_limits->total_size,
-                                  &pool_size);
-        while (true) {
-            size_t new_pool_size = pool_size + bucket_slab_alloc_size(bucket);
 
-            if (bucket->shared_limits->max_size < new_pool_size) {
-                break;
-            }
+        uint64_t size_to_add = bucket_slab_alloc_size(bucket);
+        size_t previous_size = utils_fetch_and_add_u64(
+            &bucket->shared_limits->total_size, size_to_add);
 
-            if (utils_compare_exchange(&bucket->shared_limits->total_size,
-                                       &pool_size, &new_pool_size)) {
-                ++bucket->chunked_slabs_in_pool;
-
-                bucket_update_stats(bucket, -1, 1);
-                return true;
-            }
+        if (previous_size + size_to_add <= bucket->shared_limits->max_size) {
+            ++bucket->chunked_slabs_in_pool;
+            bucket_update_stats(bucket, -1, 1);
+            return true;
+        } else {
+            uint64_t old = utils_fetch_and_sub_u64(
+                &bucket->shared_limits->total_size, size_to_add);
+            (void)old;
+            assert(old >= size_to_add);
         }
     }
 

--- a/src/pool/pool_disjoint_internal.h
+++ b/src/pool/pool_disjoint_internal.h
@@ -102,7 +102,7 @@ typedef struct slab_t {
 
 typedef struct umf_disjoint_pool_shared_limits_t {
     size_t max_size;
-    size_t total_size; // requires atomic access
+    uint64_t total_size; // requires atomic access
 } umf_disjoint_pool_shared_limits_t;
 
 typedef struct umf_disjoint_pool_params_t {

--- a/src/provider/provider_os_memory.c
+++ b/src/provider/provider_os_memory.c
@@ -934,7 +934,7 @@ static membind_t membindFirst(os_memory_provider_t *provider, void *addr,
 
     if (provider->mode == UMF_NUMA_MODE_INTERLEAVE) {
         assert(provider->part_size != 0);
-        size_t s = utils_fetch_and_add64(&provider->alloc_sum, size);
+        size_t s = utils_fetch_and_add_u64(&provider->alloc_sum, size);
         membind.node = (s / provider->part_size) % provider->nodeset_len;
         membind.bitmap = provider->nodeset[membind.node];
         membind.bind_size = ALIGN_UP(provider->part_size, membind.page_size);

--- a/src/provider/provider_os_memory_internal.h
+++ b/src/provider/provider_os_memory_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -58,7 +58,7 @@ typedef struct os_memory_provider_t {
     int numa_flags; // combination of hwloc flags
 
     size_t part_size;
-    size_t alloc_sum; // sum of all allocations - used for manual interleaving
+    uint64_t alloc_sum; // sum of all allocations - used for manual interleaving
 
     struct {
         unsigned weight;

--- a/src/utils/utils_common.h
+++ b/src/utils/utils_common.h
@@ -53,9 +53,6 @@ typedef enum umf_purge_advise_t {
 #define ASSERT_IS_ALIGNED(value, align)                                        \
     DO_WHILE_EXPRS(assert(IS_ALIGNED(value, align)))
 
-#define VALGRIND_ANNOTATE_NEW_MEMORY(p, s) DO_WHILE_EMPTY
-#define VALGRIND_HG_DRD_DISABLE_CHECKING(p, s) DO_WHILE_EMPTY
-
 #ifdef _WIN32 /* Windows */
 
 #define __TLS __declspec(thread)

--- a/src/utils/utils_sanitizers.h
+++ b/src/utils/utils_sanitizers.h
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2024 Intel Corporation
+ * Copyright (C) 2024-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -162,6 +162,24 @@ static inline void utils_annotate_memory_inaccessible(void *ptr, size_t size) {
     __asan_poison_memory_region(ptr, size);
 #elif UMF_VG_MEMCHECK_ENABLED
     VALGRIND_MAKE_MEM_NOACCESS(ptr, size);
+#else
+    (void)ptr;
+    (void)size;
+#endif
+}
+
+static inline void utils_annotate_memory_new(void *ptr, size_t size) {
+#ifdef UMF_VG_DRD_ENABLED
+    ANNOTATE_NEW_MEMORY(ptr, size);
+#else
+    (void)ptr;
+    (void)size;
+#endif
+}
+
+static inline void utils_annotate_memory_no_check(void *ptr, size_t size) {
+#ifdef UMF_VG_HELGRIND_ENABLED
+    VALGRIND_HG_DISABLE_CHECKING(ptr, size);
 #else
     (void)ptr;
     (void)size;

--- a/test/supp/drd-umf_test-disjoint_pool.supp
+++ b/test/supp/drd-umf_test-disjoint_pool.supp
@@ -1,7 +1,7 @@
 {
    False-positive ConflictingAccess in critnib_insert
    drd:ConflictingAccess
-   fun:store
+   fun:utils_atomic_store_release_ptr
    fun:critnib_insert
    ...
 }

--- a/test/supp/drd-umf_test-ipc.supp
+++ b/test/supp/drd-umf_test-ipc.supp
@@ -5,3 +5,30 @@
    fun:pthread_cond_destroy@*
    ...
 }
+
+{
+   [false-positive] Double check locking pattern in trackingOpenIpcHandle
+   drd:ConflictingAccess
+   fun:utils_atomic_load_acquire_ptr
+   fun:trackingOpenIpcHandle
+   fun:umfMemoryProviderOpenIPCHandle
+   fun:umfOpenIPCHandle
+   ...
+}
+
+{
+   [false-positive] trackingGetIpcHandle
+   drd:ConflictingAccess
+   fun:trackingGetIpcHandle
+   fun:umfMemoryProviderGetIPCHandle
+   fun:umfGetIPCHandle
+}
+
+{
+   [false-positive] trackingGetIpcHandle
+   drd:ConflictingAccess
+   fun:memmove
+   fun:trackingGetIpcHandle
+   fun:umfMemoryProviderGetIPCHandle
+   fun:umfGetIPCHandle
+}

--- a/test/supp/drd-umf_test-jemalloc_coarse_devdax.supp
+++ b/test/supp/drd-umf_test-jemalloc_coarse_devdax.supp
@@ -9,7 +9,7 @@
 {
    False-positive ConflictingAccess in critnib_insert
    drd:ConflictingAccess
-   fun:store
+   fun:utils_atomic_store_release_ptr
    fun:critnib_insert
    ...
 }

--- a/test/supp/drd-umf_test-jemalloc_coarse_file.supp
+++ b/test/supp/drd-umf_test-jemalloc_coarse_file.supp
@@ -9,7 +9,7 @@
 {
    False-positive ConflictingAccess in critnib_insert
    drd:ConflictingAccess
-   fun:store
+   fun:utils_atomic_store_release_ptr
    fun:critnib_insert
    ...
 }

--- a/test/supp/drd-umf_test-provider_devdax_memory_ipc.supp
+++ b/test/supp/drd-umf_test-provider_devdax_memory_ipc.supp
@@ -1,6 +1,7 @@
 {
    [false-positive] Double check locking pattern in trackingOpenIpcHandle
    drd:ConflictingAccess
+   fun:utils_atomic_store_release_ptr
    fun:trackingOpenIpcHandle
    fun:umfMemoryProviderOpenIPCHandle
    fun:umfOpenIPCHandle

--- a/test/supp/drd-umf_test-provider_file_memory_ipc.supp
+++ b/test/supp/drd-umf_test-provider_file_memory_ipc.supp
@@ -9,10 +9,28 @@
 {
    [false-positive] Double check locking pattern in trackingOpenIpcHandle
    drd:ConflictingAccess
+   fun:utils_atomic_store_release_ptr
    fun:trackingOpenIpcHandle
    fun:umfMemoryProviderOpenIPCHandle
    fun:umfOpenIPCHandle
    ...
+}
+
+{
+   [false-positive] trackingGetIpcHandle
+   drd:ConflictingAccess
+   fun:trackingGetIpcHandle
+   fun:umfMemoryProviderGetIPCHandle
+   fun:umfGetIPCHandle
+}
+
+{
+   [false-positive] trackingGetIpcHandle
+   drd:ConflictingAccess
+   fun:memmove
+   fun:trackingGetIpcHandle
+   fun:umfMemoryProviderGetIPCHandle
+   fun:umfGetIPCHandle
 }
 
 {

--- a/test/supp/drd-umf_test-provider_os_memory.supp
+++ b/test/supp/drd-umf_test-provider_os_memory.supp
@@ -1,6 +1,7 @@
 {
    [false-positive] Double check locking pattern in trackingOpenIpcHandle
    drd:ConflictingAccess
+   fun:utils_atomic_store_release_ptr
    fun:trackingOpenIpcHandle
    fun:umfMemoryProviderOpenIPCHandle
    fun:umfOpenIPCHandle

--- a/test/supp/helgrind-umf_test-disjoint_pool.supp
+++ b/test/supp/helgrind-umf_test-disjoint_pool.supp
@@ -31,7 +31,7 @@
 {
    False-positive Race in critnib_insert
    Helgrind:Race
-   fun:store
+   fun:utils_atomic_store_release_ptr
    fun:critnib_insert
    ...
 }

--- a/test/supp/helgrind-umf_test-ipc.supp
+++ b/test/supp/helgrind-umf_test-ipc.supp
@@ -1,7 +1,7 @@
 {
    False-positive race in critnib_insert (lack of instrumentation)
    Helgrind:Race
-   fun:store
+   fun:utils_atomic_store_release_ptr
    fun:critnib_insert
    ...
 }
@@ -13,4 +13,41 @@
    fun:find_le
    fun:critnib_find
    ...
+}
+
+{
+   [false-positive] Double check locking pattern in trackingOpenIpcHandle
+   Helgrind:Race
+   fun:utils_atomic_store_release_ptr
+   fun:trackingOpenIpcHandle
+   fun:umfMemoryProviderOpenIPCHandle
+   fun:umfOpenIPCHandle
+   ...
+}
+
+{
+   [false-positive] Double check locking pattern in trackingOpenIpcHandle
+   Helgrind:Race
+   fun:utils_atomic_load_acquire_ptr
+   fun:trackingOpenIpcHandle
+   fun:umfMemoryProviderOpenIPCHandle
+   fun:umfOpenIPCHandle
+   ...
+}
+
+{
+   [false-positive] umfMemoryProviderGetIPCHandle
+   Helgrind:Race
+   fun:trackingGetIpcHandle
+   fun:umfMemoryProviderGetIPCHandle
+   fun:umfGetIPCHandle
+}
+
+{
+   [false-positive] umfMemoryProviderGetIPCHandle
+   Helgrind:Race
+   fun:memmove
+   fun:trackingGetIpcHandle
+   fun:umfMemoryProviderGetIPCHandle
+   fun:umfGetIPCHandle
 }

--- a/test/supp/helgrind-umf_test-jemalloc_coarse_devdax.supp
+++ b/test/supp/helgrind-umf_test-jemalloc_coarse_devdax.supp
@@ -9,7 +9,7 @@
 {
    False-positive Race in critnib_insert
    Helgrind:Race
-   fun:store
+   fun:utils_atomic_store_release_ptr
    fun:critnib_insert
    ...
 }

--- a/test/supp/helgrind-umf_test-jemalloc_coarse_file.supp
+++ b/test/supp/helgrind-umf_test-jemalloc_coarse_file.supp
@@ -9,7 +9,7 @@
 {
    False-positive Race in critnib_insert
    Helgrind:Race
-   fun:store
+   fun:utils_atomic_store_release_ptr
    fun:critnib_insert
    ...
 }

--- a/test/supp/helgrind-umf_test-provider_devdax_memory_ipc.supp
+++ b/test/supp/helgrind-umf_test-provider_devdax_memory_ipc.supp
@@ -1,6 +1,7 @@
 {
    [false-positive] Double check locking pattern in trackingOpenIpcHandle
    Helgrind:Race
+   fun:utils_atomic_store_release_ptr
    fun:trackingOpenIpcHandle
    fun:umfMemoryProviderOpenIPCHandle
    fun:umfOpenIPCHandle

--- a/test/supp/helgrind-umf_test-provider_file_memory_ipc.supp
+++ b/test/supp/helgrind-umf_test-provider_file_memory_ipc.supp
@@ -1,6 +1,17 @@
 {
    [false-positive] Double check locking pattern in trackingOpenIpcHandle
    Helgrind:Race
+   fun:utils_atomic_store_release_ptr
+   fun:trackingOpenIpcHandle
+   fun:umfMemoryProviderOpenIPCHandle
+   fun:umfOpenIPCHandle
+   ...
+}
+
+{
+   [false-positive] Double check locking pattern in trackingOpenIpcHandle
+   Helgrind:Race
+   fun:utils_atomic_load_acquire_ptr
    fun:trackingOpenIpcHandle
    fun:umfMemoryProviderOpenIPCHandle
    fun:umfOpenIPCHandle
@@ -10,7 +21,7 @@
 {
    False-positive race in critnib_insert (lack of instrumentation)
    Helgrind:Race
-   fun:store
+   fun:utils_atomic_store_release_ptr
    fun:critnib_insert
    ...
 }
@@ -39,4 +50,21 @@
    ...
    fun:tbb_pool_finalize
    ...
+}
+
+{
+   [false-positive] trackingGetIpcHandle
+   Helgrind:Race
+   fun:trackingGetIpcHandle
+   fun:umfMemoryProviderGetIPCHandle
+   fun:umfGetIPCHandle
+}
+
+{
+   [false-positive] trackingGetIpcHandle
+   Helgrind:Race
+   fun:memmove
+   fun:trackingGetIpcHandle
+   fun:umfMemoryProviderGetIPCHandle
+   fun:umfGetIPCHandle
 }

--- a/test/supp/helgrind-umf_test-provider_os_memory.supp
+++ b/test/supp/helgrind-umf_test-provider_os_memory.supp
@@ -1,6 +1,7 @@
 {
    [false-positive] Double check locking pattern in trackingOpenIpcHandle
    Helgrind:Race
+   fun:utils_atomic_store_release_ptr
    fun:trackingOpenIpcHandle
    fun:umfMemoryProviderOpenIPCHandle
    fun:umfOpenIPCHandle


### PR DESCRIPTION
Cleanup atomics and replace while(true) loop in Disjoint Pool bucket_can_pool() with a pair of atomic add/sub.

fix for https://github.com/oneapi-src/unified-memory-framework/issues/1125 and https://github.com/oneapi-src/unified-memory-framework/issues/1115

This PR is required by https://github.com/oneapi-src/unified-memory-framework/pull/1143