### PR TITLE
[CI] Disable legacy GHA Image - Ubuntu 20.04

### DIFF
--- a/.github/workflows/reusable_basic.yml
+++ b/.github/workflows/reusable_basic.yml
@@ -17,7 +17,7 @@ jobs:
     name: Ubuntu
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'ubuntu-22.04']
+        os: ['ubuntu-22.04', 'ubuntu-24.04']
         build_type: [Debug, Release]
         compiler: [{c: gcc, cxx: g++}]
         shared_library: ['OFF']
@@ -27,15 +27,6 @@ jobs:
         disable_hwloc: ['OFF']
         link_hwloc_statically: ['OFF']
         include:
-          - os: 'ubuntu-20.04'
-            build_type: Release
-            compiler: {c: gcc-7, cxx: g++-7}
-            shared_library: 'OFF'
-            level_zero_provider: 'ON'
-            cuda_provider: 'ON'
-            install_tbb: 'ON'
-            disable_hwloc: 'OFF'
-            link_hwloc_statically: 'OFF'
           - os: 'ubuntu-22.04'
             build_type: Release
             compiler: {c: clang, cxx: clang++}

--- a/.github/workflows/reusable_fast.yml
+++ b/.github/workflows/reusable_fast.yml
@@ -43,8 +43,8 @@ jobs:
             build_tests: 'ON'
             extra_build_options: '-DCMAKE_BUILD_TYPE=Release'
             simple_cmake: 'ON'
-          # simplest CMake ubuntu-20.04
-          - os: ubuntu-20.04
+          # simplest CMake ubuntu-22.04
+          - os: ubuntu-22.04
             build_tests: 'ON'
             extra_build_options: '-DCMAKE_BUILD_TYPE=Release'
             simple_cmake: 'ON'
@@ -69,18 +69,11 @@ jobs:
       run: vcpkg install
       shell: pwsh # Specifies PowerShell as the shell for running the script.
 
-    - name: Install dependencies (ubuntu-latest)
-      if: matrix.os == 'ubuntu-latest'
+    - name: Install dependencies
+      if: matrix.os != 'windows-latest'
       run: |
         sudo apt-get update
         sudo apt-get install -y cmake libhwloc-dev libnuma-dev libtbb-dev
-
-    - name: Install dependencies (ubuntu-20.04)
-      if: matrix.os == 'ubuntu-20.04'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y cmake libnuma-dev libtbb-dev
-        .github/scripts/install_hwloc.sh # install hwloc-2.3.0 instead of hwloc-2.1.0 present in the OS package
 
     - name: Configure CMake
       if: matrix.simple_cmake == 'OFF'


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->
There are some jobs cancelled due to legacy Ubuntu 20.04, so it should be disabled immediately.
Source: https://github.com/oneapi-src/unified-memory-framework/actions/runs/13655322578
### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
