### PR TITLE
Fix disjoint_pool_free() and proxy_free()

### DIFF
--- a/src/memory_pool.c
+++ b/src/memory_pool.c
@@ -208,3 +208,10 @@ umf_result_t umfPoolGetTag(umf_memory_pool_handle_t hPool, void **tag) {
     utils_mutex_unlock(&hPool->lock);
     return UMF_RESULT_SUCCESS;
 }
+
+void *umfPoolGetPoolPriv(umf_memory_pool_handle_t hPool) {
+    if (hPool == NULL) {
+        return NULL;
+    }
+    return hPool->pool_priv;
+}

--- a/src/memory_pool_internal.h
+++ b/src/memory_pool_internal.h
@@ -36,6 +36,8 @@ typedef struct umf_memory_pool_t {
     void *tag;
 } umf_memory_pool_t;
 
+void *umfPoolGetPoolPriv(umf_memory_pool_handle_t hPool);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/pool/pool_disjoint.c
+++ b/src/pool/pool_disjoint.c
@@ -17,6 +17,7 @@
 #include <umf/memory_provider.h>
 
 #include "base_alloc_global.h"
+#include "memory_pool_internal.h"
 #include "pool_disjoint_internal.h"
 #include "provider/provider_tracking.h"
 #include "uthash/utlist.h"
@@ -817,6 +818,11 @@ umf_result_t disjoint_pool_free(void *pool, void *ptr) {
             TLS_last_allocation_error = ret;
             LOG_ERR("failed to get allocation info from the memory tracker");
             return ret;
+        }
+
+        if (pool != umfPoolGetPoolPriv(allocInfo.pool)) {
+            LOG_ERR("pool mismatch");
+            return UMF_RESULT_ERROR_INVALID_ARGUMENT;
         }
 
         size_t size = allocInfo.baseSize;

--- a/src/pool/pool_proxy.c
+++ b/src/pool/pool_proxy.c
@@ -13,8 +13,10 @@
 #include <assert.h>
 
 #include "base_alloc_global.h"
+#include "memory_pool_internal.h"
 #include "provider/provider_tracking.h"
 #include "utils_common.h"
+#include "utils_log.h"
 
 static __TLS umf_result_t TLS_last_allocation_error;
 
@@ -100,6 +102,11 @@ static umf_result_t proxy_free(void *pool, void *ptr) {
         umf_alloc_info_t allocInfo = {NULL, 0, NULL};
         umf_result_t umf_result = umfMemoryTrackerGetAllocInfo(ptr, &allocInfo);
         if (umf_result == UMF_RESULT_SUCCESS) {
+            if (pool != umfPoolGetPoolPriv(allocInfo.pool)) {
+                LOG_ERR("pool mismatch");
+                return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+            }
+
             size = allocInfo.baseSize;
         }
     }


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

Fix disjoint_pool_free() and proxy_free() - error out on pool mismatch, when we try to free the pointer
belonging to a different pool.

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
