### PR TITLE
update benchmark scripts

### DIFF
--- a/.github/workflows/reusable_benchmarks.yml
+++ b/.github/workflows/reusable_benchmarks.yml
@@ -103,7 +103,9 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         repository: intel/llvm
-        ref: nightly-2025-02-19
+        # add preloaded UMF benchmarks
+        # https://github.com/intel/llvm/pull/17278
+        ref: b2f9dab5266d227cc9eb19af1b54c5bdc50221d1
         path: sycl-repo
         fetch-depth: 1
 


### PR DESCRIPTION
rrudnick_update_bench_scripts to:

https://github.com/intel/llvm/pull/17278
Add Unified Memory Framework benchmarks which use preloaded libraries.