### PR TITLE
Do not free a pointer from another pool

### DIFF
--- a/include/umf/base.h
+++ b/include/umf/base.h
@@ -47,6 +47,9 @@ typedef enum umf_result_t {
         6, ///< Failure in user provider code (i.e in user provided callback)
     UMF_RESULT_ERROR_DEPENDENCY_UNAVAILABLE =
         7, ///< External required dependency is unavailable or missing
+    UMF_RESULT_ERROR_INVALID_FREE_OP =
+        8, /*!< Invalid free operation - trying to free a pointer used by another
+                pool or a pointer belonging to another pool */
     UMF_RESULT_ERROR_UNKNOWN = 0x7ffffffe ///< Unknown or internal error
 } umf_result_t;
 

--- a/src/memory_pool.c
+++ b/src/memory_pool.c
@@ -180,6 +180,14 @@ size_t umfPoolMallocUsableSize(umf_memory_pool_handle_t hPool, void *ptr) {
 
 umf_result_t umfPoolFree(umf_memory_pool_handle_t hPool, void *ptr) {
     UMF_CHECK((hPool != NULL), UMF_RESULT_ERROR_INVALID_ARGUMENT);
+    umf_memory_pool_handle_t poolTracker = umfMemoryTrackerGetPool(ptr);
+    if (poolTracker != NULL && poolTracker != hPool) {
+        LOG_ERR("invalid free operation: trying to free a pointer %p used by "
+                "another pool or belonging to another pool %p than the given "
+                "pool %p",
+                ptr, poolTracker, hPool);
+        return UMF_RESULT_ERROR_INVALID_FREE_OP;
+    }
     return hPool->ops.free(hPool->pool_priv, ptr);
 }
 


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

Do not free a pointer from another pool.
Error out when `free()` tries to free a pointer used by another pool
or a pointer belonging to another pool.
Add the `UMF_RESULT_ERROR_INVALID_FREE_OP` error for this case.

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
