### PR TITLE
Check valgrind log files

### DIFF
--- a/test/test_valgrind.sh
+++ b/test/test_valgrind.sh
@@ -188,11 +188,33 @@ echo
 echo "======================================================================"
 echo
 
-for log in $(ls -1 ${PATH_TESTS}.log ${PATH_EXAMPLES}.log); do
+LOG_FILES=""
+NT=$(ls -1 ${PATH_TESTS}.log 2>/dev/null | wc -l)
+if [ $NT -gt 0 ]; then
+	LOG_FILES="$LOG_FILES $(ls -1 ${PATH_TESTS}.log | xargs)"
+fi
+NE=$(ls -1 ${PATH_EXAMPLES}.log 2>/dev/null | wc -l)
+if [ $NE -gt 0 ]; then
+	LOG_FILES="$LOG_FILES $(ls -1 ${PATH_EXAMPLES}.log | xargs)"
+fi
+if [ $(($NT + $NE)) -eq 0 ]; then
+	echo
+	echo "FATAL ERROR: no log files found, but number of failed tests equals $ANY_TEST_FAILED!"
+	echo
+	exit 1
+fi
+
+for log in $LOG_FILES; do
 	echo ">>>>>>> LOG $log"
 	cat $log
 	echo
 	echo
 done
+
+if [ $(($NT + $NE)) -ne $ANY_TEST_FAILED ]; then
+	echo
+	echo "ERROR: incorrect number of log files: ANY_TEST_FAILED=$ANY_TEST_FAILED != ($NT + $NE)"
+	echo
+fi
 
 exit 1


### PR DESCRIPTION

<!-- Provide a short summary of your changes in the Title above -->

### Description

Check valgrind log files. Do not print an error message like:
```
ls: cannot access './examples/umf_example_*.log': No such file or directory
```
when only the tests log files are present for example.

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
