### PR TITLE
Run Compatibility GPU CI jobs only on upstream

### DIFF
--- a/.github/workflows/reusable_compatibility.yml
+++ b/.github/workflows/reusable_compatibility.yml
@@ -186,6 +186,8 @@ jobs:
 
   gpu:
     name: GPU Ubuntu
+    # run only on upstream; forks will not have the HW
+    if: github.repository == 'oneapi-src/unified-memory-framework'
     strategy:
       matrix:
         provider: ['LEVEL_ZERO', 'CUDA']


### PR DESCRIPTION

<!-- Provide a short summary of your changes in the Title above -->

### Description

Run Compatibility GPU CI jobs only on upstream,
since forks do not have the required HW.


<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
