### PR TITLE
Use atomics in critnib find_*

### DIFF
--- a/src/critnib/critnib.c
+++ b/src/critnib/critnib.c
@@ -525,7 +525,9 @@ find_predecessor(struct critnib_node *__restrict n) {
     while (1) {
         int nib;
         for (nib = NIB; nib >= 0; nib--) {
-            if (n->child[nib]) {
+            struct critnib_node *m;
+            utils_atomic_load_acquire_ptr((void **)&n->child[nib], (void **)&m);
+            if (m) {
                 break;
             }
         }
@@ -534,7 +536,7 @@ find_predecessor(struct critnib_node *__restrict n) {
             return NULL;
         }
 
-        n = n->child[nib];
+        utils_atomic_load_acquire_ptr((void **)&n->child[nib], (void **)&n);
         if (is_leaf(n)) {
             return to_leaf(n);
         }


### PR DESCRIPTION

<!-- Provide a short summary of your changes in the Title above -->

### Description

It fixes ThreadSanitizer data race in find_predecessor() vs critnib_insert() and critnib_remove().
See:
https://github.com/oneapi-src/unified-memory-framework/actions/runs/13724176734/job/38387107349?pr=998
https://github.com/oneapi-src/unified-memory-framework/actions/runs/13724176734/job/38475443684?pr=998

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
