### PR TITLE
[CI] Use venv for pip installation in benchmarks

### DIFF
--- a/.github/workflows/reusable_benchmarks.yml
+++ b/.github/workflows/reusable_benchmarks.yml
@@ -111,7 +111,9 @@ jobs:
 
     - name: Install benchmarking scripts deps
       run: |
-        pip install --force-reinstall -r ${{github.workspace}}/sycl-repo/unified-runtime/third_party/benchmark_requirements.txt
+        python -m venv .venv
+        source .venv/bin/activate
+        pip install -r ${{github.workspace}}/sycl-repo/unified-runtime/third_party/benchmark_requirements.txt
 
     - name: Set core range and GPU mask
       run: |
@@ -135,6 +137,7 @@ jobs:
       id: benchmarks
       working-directory: ${{env.BUILD_DIR}}
       run: >
+        source ${{github.workspace}}/.venv/bin/activate &&
         taskset -c ${{ env.CORES }} ${{ github.workspace }}/sycl-repo/unified-runtime/scripts/benchmarks/main.py
         ~/bench_workdir_umf
         --umf ${{env.BUILD_DIR}}


### PR DESCRIPTION
We moved on to new Ubuntu and it does not allow global pip installation - just use venv.

### Checklist
- [x] CI workflows execute properly
- [x] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
// https://github.com/oneapi-src/unified-memory-framework/actions/runs/13788400307/job/38561764479?pr=1178