### PR TITLE
fix for potential out-of-bounds read in tracker

### DIFF
--- a/src/provider/provider_tracking.c
+++ b/src/provider/provider_tracking.c
@@ -1236,9 +1236,9 @@ umf_memory_tracker_handle_t umfMemoryTrackerCreate(void) {
 err_destroy_ipc_info_allocator:
     umf_ba_destroy(handle->ipc_info_allocator);
 err_destroy_alloc_segments_map:
-    for (int j = i; j >= 0; j--) {
-        if (handle->alloc_segments_map[j]) {
-            critnib_delete(handle->alloc_segments_map[j]);
+    for (i = 0; i < MAX_LEVELS_OF_ALLOC_SEGMENT_MAP; i++) {
+        if (handle->alloc_segments_map[i]) {
+            critnib_delete(handle->alloc_segments_map[i]);
         }
     }
     utils_mutex_destroy_not_free(&handle->splitMergeMutex);


### PR DESCRIPTION
this is a fix for Coverity issue:
https://scan3.scan.coverity.com/#/project-view/65229/15141?selectedIssue=477771