### PR TITLE
Install libnuma-dev in the proxy lib workflow

### DIFF
--- a/.github/workflows/reusable_proxy_lib.yml
+++ b/.github/workflows/reusable_proxy_lib.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install apt packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake libhwloc-dev libtbb-dev lcov
+          sudo apt-get install -y cmake libhwloc-dev libnuma-dev libtbb-dev lcov
 
       - name: Configure build
         run: >


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

Install libnuma-dev in the proxy lib workflow,
because it is required.

It has worked correctly so far most probably,
because libnuma-dev has been installed
as a dependency of libhwloc-dev.
It failed when libhwloc-dev was not installed:
https://github.com/oneapi-src/unified-memory-framework/actions/runs/13895067500/job/38875043512


<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
