### PR TITLE
remove pool benchmarks with fixed provider.

### DIFF
--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -143,73 +143,18 @@ UMF_BENCHMARK_TEMPLATE_DEFINE(multiple_malloc_free_benchmark,
 UMF_BENCHMARK_REGISTER_F(multiple_malloc_free_benchmark,
                          proxy_pool_fixedprovider)
     ->Apply(&default_multiple_alloc_fix_size)
-    ->Apply(&singlethreaded);
+    ->Apply(&singlethreaded)
+    // reduce iterations, to match os_provider benchmark
+    ->Iterations(50000);
 
 UMF_BENCHMARK_TEMPLATE_DEFINE(multiple_malloc_free_benchmark, fixed_provider,
                               fixed_alloc_size,
                               provider_allocator<fixed_provider>);
 UMF_BENCHMARK_REGISTER_F(multiple_malloc_free_benchmark, fixed_provider)
     ->Apply(&default_multiple_alloc_fix_size)
-    ->Apply(&singlethreaded);
-
-UMF_BENCHMARK_TEMPLATE_DEFINE(multiple_malloc_free_benchmark,
-                              disjoint_pool_fix_fixedprovider, fixed_alloc_size,
-                              pool_allocator<disjoint_pool<fixed_provider>>);
-UMF_BENCHMARK_REGISTER_F(multiple_malloc_free_benchmark,
-                         disjoint_pool_fix_fixedprovider)
-    ->Apply(&default_multiple_alloc_fix_size)
-    ->Apply(&multithreaded);
-
-UMF_BENCHMARK_TEMPLATE_DEFINE(multiple_malloc_free_benchmark,
-                              disjoint_pool_uniform_fixedprovider,
-                              uniform_alloc_size,
-                              pool_allocator<disjoint_pool<fixed_provider>>);
-UMF_BENCHMARK_REGISTER_F(multiple_malloc_free_benchmark,
-                         disjoint_pool_uniform_fixedprovider)
-    ->Apply(&default_multiple_alloc_uniform_size)
-    ->Apply(&multithreaded);
-
-#ifdef UMF_POOL_JEMALLOC_ENABLED
-UMF_BENCHMARK_TEMPLATE_DEFINE(multiple_malloc_free_benchmark,
-                              jemalloc_pool_fixedprovider, fixed_alloc_size,
-                              pool_allocator<jemalloc_pool<fixed_provider>>);
-UMF_BENCHMARK_REGISTER_F(multiple_malloc_free_benchmark,
-                         jemalloc_pool_fixedprovider)
-    ->Apply(&default_multiple_alloc_fix_size)
-    ->Apply(&multithreaded);
-
-UMF_BENCHMARK_TEMPLATE_DEFINE(multiple_malloc_free_benchmark,
-                              jemalloc_pool_uniform_fixedprovider,
-                              uniform_alloc_size,
-                              pool_allocator<jemalloc_pool<fixed_provider>>);
-UMF_BENCHMARK_REGISTER_F(multiple_malloc_free_benchmark,
-                         jemalloc_pool_uniform_fixedprovider)
-    ->Apply(&default_multiple_alloc_uniform_size)
-    ->Apply(&multithreaded);
-
-#endif
-
-#ifdef UMF_POOL_SCALABLE_ENABLED
-UMF_BENCHMARK_TEMPLATE_DEFINE(multiple_malloc_free_benchmark,
-                              scalable_pool_fix_fixedprovider, fixed_alloc_size,
-                              pool_allocator<scalable_pool<fixed_provider>>);
-
-UMF_BENCHMARK_REGISTER_F(multiple_malloc_free_benchmark,
-                         scalable_pool_fix_fixedprovider)
-    ->Apply(&default_multiple_alloc_fix_size)
-    ->Apply(&multithreaded);
-
-UMF_BENCHMARK_TEMPLATE_DEFINE(multiple_malloc_free_benchmark,
-                              scalable_pool_uniform_fixedprovider,
-                              uniform_alloc_size,
-                              pool_allocator<scalable_pool<fixed_provider>>);
-
-UMF_BENCHMARK_REGISTER_F(multiple_malloc_free_benchmark,
-                         scalable_pool_uniform_fixedprovider)
-    ->Apply(&default_multiple_alloc_uniform_size)
-    ->Apply(&multithreaded);
-
-#endif
+    ->Apply(&singlethreaded)
+    // reduce iterations, to match os_provider benchmark
+    ->Iterations(50000);
 
 //BENCHMARK_MAIN();
 int main(int argc, char **argv) {


### PR DESCRIPTION
Simplify benchmark tests by removing redundant pool benchmarks for fixed provider, as results are nearly identical to os provider. Also reduce iteration count for 'fix' provider benchmarks to match with 'os' provider.

<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
- [ ] All API changes are reflected in docs and def/map files, and are tested
