### PR TITLE
[CI] Bump L0 version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,7 +376,7 @@ endif()
 # headers are not provided by the user (via setting UMF_LEVEL_ZERO_INCLUDE_DIR).
 if(UMF_BUILD_LEVEL_ZERO_PROVIDER AND (NOT UMF_LEVEL_ZERO_INCLUDE_DIR))
     set(LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
-    set(LEVEL_ZERO_LOADER_TAG v1.20.2)
+    set(LEVEL_ZERO_LOADER_TAG v1.21.3)
 
     message(
         STATUS

--- a/examples/ipc_level_zero/CMakeLists.txt
+++ b/examples/ipc_level_zero/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 include(FetchContent)
 
 set(LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
-set(LEVEL_ZERO_LOADER_TAG v1.20.2)
+set(LEVEL_ZERO_LOADER_TAG v1.21.3)
 
 message(
     STATUS

--- a/examples/level_zero_shared_memory/CMakeLists.txt
+++ b/examples/level_zero_shared_memory/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 include(FetchContent)
 
 set(LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
-set(LEVEL_ZERO_LOADER_TAG v1.20.2)
+set(LEVEL_ZERO_LOADER_TAG v1.21.3)
 
 message(
     STATUS


### PR DESCRIPTION
It contains static loader now. It should work with any loader installed in the system (e.g. via apt) as long as it's >= v1.15.17

// ref. https://github.com/intel/llvm/pull/17523