### PR TITLE
[CI] Minor update in get_system_info.sh

### DIFF
--- a/.github/scripts/get_system_info.sh
+++ b/.github/scripts/get_system_info.sh
@@ -7,7 +7,7 @@
 
 function check_L0_version {
     if command -v dpkg &> /dev/null; then
-        dpkg -l | grep level-zero && return
+        dpkg -l | grep -iE "level-zero|libze|Compute Runtime|Level Zero" && return
     fi
 
     if command -v rpm &> /dev/null; then
@@ -34,7 +34,7 @@ function system_info {
 	numactl -H
 
 	echo "**********VGA info**********"
-	lspci | grep -i VGA
+	lspci | grep -iE "vga|display|gpu"
 
 	echo "**********CUDA Version**********"
 	if command -v nvidia-smi &> /dev/null; then


### PR DESCRIPTION
on new Ubuntu `level-zero` packages are renamed to `libze`. Extend this part and finding gpu.