### PR TITLE
Remove `umfMemoryTrackerGetAllocInfo()` from def and map files

### DIFF
--- a/src/libumf.def
+++ b/src/libumf.def
@@ -60,7 +60,6 @@ EXPORTS
     umfMemoryProviderPurgeForce
     umfMemoryProviderPurgeLazy
     umfMemoryProviderPutIPCHandle
-    umfMemoryTrackerGetAllocInfo
     umfMempolicyCreate
     umfMempolicyDestroy
     umfMempolicySetCustomSplitPartitions

--- a/src/libumf.map
+++ b/src/libumf.map
@@ -54,7 +54,6 @@ UMF_0.10 {
         umfMemoryProviderPurgeForce;
         umfMemoryProviderPurgeLazy;
         umfMemoryProviderPutIPCHandle;
-        umfMemoryTrackerGetAllocInfo;
         umfMempolicyCreate;
         umfMempolicyDestroy;
         umfMempolicySetCustomSplitPartitions;


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

Remove `umfMemoryTrackerGetAllocInfo()` from def and map files.

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
