### PR TITLE
[CI][Bench] Add compare option to manual bench runs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -13,6 +13,13 @@ on:
         type: string
         required: false
         default: ''
+      bench_script_compare:
+        description: Compare label, passed to script executing benchmark as '--compare <label>'
+        type: choice
+        required: false
+        default: 'Baseline_PVC'
+        options:
+          - 'Baseline_PVC'
       runner:
         description: Runner
         type: choice
@@ -32,4 +39,5 @@ jobs:
     with:
       pr_no: ${{ inputs.pr_no }}
       bench_script_params: ${{ inputs.bench_script_params }}
+      bench_script_compare: ${{ inputs.bench_script_compare }}
       runner: ${{ inputs.runner }}

--- a/.github/workflows/reusable_benchmarks.yml
+++ b/.github/workflows/reusable_benchmarks.yml
@@ -14,6 +14,10 @@ on:
         required: false
         type: string
         default: ''
+      bench_script_compare:
+        required: false
+        type: string
+        default: ''
       runner:
         required: false
         type: string
@@ -35,6 +39,16 @@ jobs:
     runs-on: ${{ inputs.runner }}
 
     steps:
+    - name: Establish bench params
+      run: |
+        params="${{ inputs.bench_script_params }}"
+        if [ -n "${{ inputs.bench_script_compare }}" ]; then
+          params="$params --compare '${{ inputs.bench_script_compare }}'"
+        fi
+
+        echo "params=$params"
+        echo "bench_params=$params" >> $GITHUB_ENV
+
     - name: Add comment to PR
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       if: ${{ always() && inputs.pr_no != 0 }}
@@ -42,7 +56,7 @@ jobs:
         script: |
           const pr_no = '${{ inputs.pr_no }}';
           const url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
-          const params = '${{ inputs.bench_script_params }}';
+          const params = '${{ env.bench_params }}';
           const body = `Compute Benchmarks run (with params: ${params}):\n${url}`;
 
           github.rest.issues.createComment({
@@ -145,7 +159,7 @@ jobs:
         --output-html remote
         --results-dir ${{ github.workspace }}/results-repo
         --output-markdown
-        ${{ inputs.bench_script_params }}
+        ${{ env.bench_params }}
 
     # In case it failed to add a comment, we can still print the results.
     - name: Print benchmark results
@@ -168,7 +182,7 @@ jobs:
           const url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
           const test_status = '${{ steps.benchmarks.outcome }}';
           const job_status = '${{ job.status }}';
-          const params = '${{ inputs.bench_script_params }}';
+          const params = '${{ env.bench_params }}';
           const body = `Compute Benchmarks run (${params}):\n${url}\nJob status: ${job_status}. Test status: ${test_status}.\n ${markdown}`;
 
           github.rest.issues.createComment({


### PR DESCRIPTION
It will enable to compare PRs against selected baseline - for now only PVC baseline is available.

// preview run on my fork: https://github.com/lukaszstolarczuk/unified-memory-framework/actions/runs/14063489283/job/39379963638#step:3:9

It will look like this:
![image](https://github.com/user-attachments/assets/05276106-9b0a-4c59-8367-374047ba9909)
