### PR TITLE
fix "discard ‘const’ qualifier" warning in disjoint pool

### DIFF
--- a/src/pool/pool_disjoint.c
+++ b/src/pool/pool_disjoint.c
@@ -965,7 +965,7 @@ void umfDisjointPoolSharedLimitsDestroy(
 
 umf_result_t
 umfDisjointPoolParamsCreate(umf_disjoint_pool_params_handle_t *hParams) {
-    static char *DEFAULT_NAME = "disjoint_pool";
+    static const char *DEFAULT_NAME = "disjoint_pool";
 
     if (!hParams) {
         LOG_ERR("disjoint pool params handle is NULL");


### PR DESCRIPTION
fix warning when building UMF in sycl:

/home/rrudnick/llvm/build/_deps/unified-memory-framework-src/src/pool/pool_disjoint.c:968:33: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  968 |     static char *DEFAULT_NAME = "disjoint_pool";
      |                                 ^~~~~~~~~~~~~~~

