### PR TITLE
Check for autoreconf prerequisite in case hwloc is fetched from sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,37 +245,45 @@ else()
     )
 endif()
 
+if(NOT UMF_DISABLE_HWLOC AND (NOT UMF_LINK_HWLOC_STATICALLY))
+    pkg_check_modules(LIBHWLOC hwloc>=2.3.0)
+    if(NOT LIBHWLOC_FOUND)
+        find_package(LIBHWLOC 2.3.0 COMPONENTS hwloc)
+        if(LIBHWLOC_LIBRARIES)
+            set(LIBHWLOC_AVAILABLE TRUE)
+        endif()
+    endif()
+
+    if(LIBHWLOC_AVAILABLE OR LIBHWLOC_FOUND)
+        # add PATH to DLL on Windows
+        set(DLL_PATH_LIST
+            "${DLL_PATH_LIST};PATH=path_list_append:${LIBHWLOC_DLL_DIRS}")
+    else()
+        set(UMF_LINK_HWLOC_STATICALLY ON)
+    endif()
+endif()
+
+if(UMF_LINK_HWLOC_STATICALLY AND LINUX)
+    find_program(AUTORECONF_EXECUTABLE autoreconf)
+    if(NOT AUTORECONF_EXECUTABLE)
+        message(WARNING "autoreconf is not installed. Disabling hwloc.")
+        set(UMF_DISABLE_HWLOC ON)
+        set(UMF_LINK_HWLOC_STATICALLY OFF)
+    endif()
+endif()
+
 if(UMF_DISABLE_HWLOC)
     message(STATUS "hwloc is disabled, hence OS provider, memtargets, "
                    "topology discovery, examples won't be available!")
 else()
-    if(NOT DEFINED UMF_HWLOC_REPO)
-        set(UMF_HWLOC_REPO "https://github.com/open-mpi/hwloc.git")
-    endif()
-
-    if(NOT DEFINED UMF_HWLOC_TAG)
-        set(UMF_HWLOC_TAG hwloc-2.10.0)
-    endif()
-
-    if(NOT UMF_LINK_HWLOC_STATICALLY)
-        pkg_check_modules(LIBHWLOC hwloc>=2.3.0)
-        if(NOT LIBHWLOC_FOUND)
-            find_package(LIBHWLOC 2.3.0 COMPONENTS hwloc)
-            if(LIBHWLOC_LIBRARIES)
-                set(LIBHWLOC_AVAILABLE TRUE)
-            endif()
-        endif()
-
-        if(LIBHWLOC_AVAILABLE OR LIBHWLOC_FOUND)
-            # add PATH to DLL on Windows
-            set(DLL_PATH_LIST
-                "${DLL_PATH_LIST};PATH=path_list_append:${LIBHWLOC_DLL_DIRS}")
-        else()
-            set(UMF_LINK_HWLOC_STATICALLY ON)
-        endif()
-    endif()
-
     if(UMF_LINK_HWLOC_STATICALLY)
+        if(NOT DEFINED UMF_HWLOC_REPO)
+            set(UMF_HWLOC_REPO "https://github.com/open-mpi/hwloc.git")
+        endif()
+
+        if(NOT DEFINED UMF_HWLOC_TAG)
+            set(UMF_HWLOC_TAG hwloc-2.10.0)
+        endif()
         message(
             STATUS
                 "Will fetch hwloc from ${UMF_HWLOC_REPO} (tag: ${UMF_HWLOC_TAG})"


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description
Check for `autoreconf` prerequisite in case hwloc is fetched from sources.
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [x] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->

