### PR TITLE
Fix vcpkg tbb installation

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -123,12 +123,12 @@ jobs:
       env: 
         VCPKG_PATH: ${{env.VCPKG_PATH}}
       with:
-        vcpkgGitCommitId: 3dd44b931481d7a8e9ba412621fa810232b66289
+        vcpkgGitCommitId: ea2a964f9303270322cf3f2d51c265ba146c422d # 1.04.2025
         vcpkgDirectory: ${{env.BUILD_DIR}}/vcpkg
         vcpkgJsonGlob: '**/vcpkg.json'
 
     - name: Install dependencies
-      run: vcpkg install
+      run: vcpkg install --triplet x64-windows
 
     - name: Install Ninja
       if: matrix.generator == 'Ninja'
@@ -190,12 +190,12 @@ jobs:
    - name: Initialize vcpkg
      uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5
      with:
-       vcpkgGitCommitId: 3dd44b931481d7a8e9ba412621fa810232b66289
+       vcpkgGitCommitId: ea2a964f9303270322cf3f2d51c265ba146c422d # 1.04.2025
        vcpkgDirectory: ${{env.BUILD_DIR}}/vcpkg
        vcpkgJsonGlob: '**/vcpkg.json'
   
    - name: Install dependencies
-     run: vcpkg install
+     run: vcpkg install --triplet x64-windows
   
    - name: Install Ninja
      uses: seanmiddleditch/gha-setup-ninja@96bed6edff20d1dd61ecff9b75cc519d516e6401 # v5

--- a/.github/workflows/reusable_basic.yml
+++ b/.github/workflows/reusable_basic.yml
@@ -260,12 +260,12 @@ jobs:
     - name: Initialize vcpkg
       uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5
       with:
-        vcpkgGitCommitId: 3dd44b931481d7a8e9ba412621fa810232b66289
+        vcpkgGitCommitId: ea2a964f9303270322cf3f2d51c265ba146c422d # 1.04.2025
         vcpkgDirectory: ${{env.BUILD_DIR}}/vcpkg
         vcpkgJsonGlob: '**/vcpkg.json'
 
     - name: Install dependencies
-      run: vcpkg install
+      run: vcpkg install --triplet x64-windows
       shell: pwsh # Specifies PowerShell as the shell for running the script.
 
     - name: Get UMF version

--- a/.github/workflows/reusable_codeql.yml
+++ b/.github/workflows/reusable_codeql.yml
@@ -48,14 +48,14 @@ jobs:
       if: matrix.os == 'windows-latest'
       uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5
       with:
-        vcpkgGitCommitId: 3dd44b931481d7a8e9ba412621fa810232b66289
+        vcpkgGitCommitId: ea2a964f9303270322cf3f2d51c265ba146c422d # 1.04.2025
         vcpkgDirectory: ${{env.BUILD_DIR}}/vcpkg
         vcpkgJsonGlob: '**/vcpkg.json'
 
     - name: "[Win] Install dependencies"
       if: matrix.os == 'windows-latest'
       run: |
-        vcpkg install
+        vcpkg install --triplet x64-windows
         python3 -m pip install -r third_party/requirements.txt
 
     - name: "[Lin] Install apt packages"

--- a/.github/workflows/reusable_compatibility.yml
+++ b/.github/workflows/reusable_compatibility.yml
@@ -120,14 +120,14 @@ jobs:
     - name: Initialize vcpkg
       uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5
       with:
-        vcpkgGitCommitId: 3dd44b931481d7a8e9ba412621fa810232b66289
+        vcpkgGitCommitId: ea2a964f9303270322cf3f2d51c265ba146c422d # 1.04.2025
         vcpkgDirectory: ${{github.workspace}}/vcpkg
         vcpkgJsonGlob: '**/vcpkg.json'
 
     # NOTE we use vcpkg setup from "tag" version
     - name: Install dependencies
       working-directory: ${{github.workspace}}/tag_version
-      run: vcpkg install
+      run: vcpkg install --triplet x64-windows
       shell: pwsh # Specifies PowerShell as the shell for running the script.
 
     - name: Configure "tag" UMF build

--- a/.github/workflows/reusable_fast.yml
+++ b/.github/workflows/reusable_fast.yml
@@ -60,13 +60,13 @@ jobs:
       if: matrix.os == 'windows-latest'
       uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5
       with:
-        vcpkgGitCommitId: 3dd44b931481d7a8e9ba412621fa810232b66289
+        vcpkgGitCommitId: ea2a964f9303270322cf3f2d51c265ba146c422d # 1.04.2025
         vcpkgDirectory: ${{env.BUILD_DIR}}/vcpkg
         vcpkgJsonGlob: '**/vcpkg.json'
 
     - name: Install dependencies (windows-latest)
       if: matrix.os == 'windows-latest'
-      run: vcpkg install
+      run: vcpkg install --triplet x64-windows
       shell: pwsh # Specifies PowerShell as the shell for running the script.
 
     - name: Install dependencies

--- a/.github/workflows/reusable_gpu.yml
+++ b/.github/workflows/reusable_gpu.yml
@@ -80,13 +80,13 @@ jobs:
         if: matrix.os == 'Windows'
         uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5
         with:
-          vcpkgGitCommitId: 3dd44b931481d7a8e9ba412621fa810232b66289
+          vcpkgGitCommitId: ea2a964f9303270322cf3f2d51c265ba146c422d # 1.04.2025
           vcpkgDirectory: ${{env.BUILD_DIR}}/vcpkg
           vcpkgJsonGlob: '**/vcpkg.json'
 
       - name: "[Win] Install dependencies"
         if: matrix.os == 'Windows'
-        run: vcpkg install
+        run: vcpkg install --triplet x64-windows
 
       # note: disable all providers except the one being tested
       # '-DCMAKE_SUPPRESS_REGENERATION=ON' is the WA for the error: "CUSTOMBUILD : CMake error : Cannot restore timestamp"

--- a/.github/workflows/reusable_sanitizers.yml
+++ b/.github/workflows/reusable_sanitizers.yml
@@ -106,12 +106,12 @@ jobs:
     - name: Initialize vcpkg
       uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5
       with:
-        vcpkgGitCommitId: 3dd44b931481d7a8e9ba412621fa810232b66289
+        vcpkgGitCommitId: ea2a964f9303270322cf3f2d51c265ba146c422d # 1.04.2025
         vcpkgDirectory: ${{env.BUILD_DIR}}/vcpkg
         vcpkgJsonGlob: '**/vcpkg.json'
 
     - name: Install dependencies
-      run: vcpkg install
+      run: vcpkg install --triplet x64-windows
       shell: pwsh # Specifies PowerShell as the shell for running the script.
 
     # TODO enable level zero provider


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description
Fixes vcpkg tbb installation error on the latest Windows runners with CMake 2.31 installed:
```
Building tbb[core,hwloc]:x64-windows@2021.11.0...
-- Downloading https://github.com/oneapi-src/oneTBB/archive/v2021.11.0.tar.gz -> oneapi-src-oneTBB-v2021.11.0.tar.gz...
-- Extracting source D:/a/unified-memory-framework/unified-memory-framework/build/vcpkg/downloads/oneapi-src-oneTBB-v2021.11.0.tar.gz
-- Using source at D:/a/unified-memory-framework/unified-memory-framework/build/vcpkg/buildtrees/tbb/src/v2021.11.0-0163f51d5f.clean
CMake Warning (dev) at scripts/cmake/vcpkg_find_acquire_program.cmake:70 (cmake_parse_arguments):
  The INTERPRETER keyword was followed by an empty string or no value at all.
  Policy CMP0174 is not set, so cmake_parse_arguments() will unset the
  arg_INTERPRETER variable rather than setting it to an empty string.
Call Stack (most recent call first):
  scripts/cmake/vcpkg_find_acquire_program.cmake:143 (z_vcpkg_find_acquire_program_find_internal)
  D:/a/unified-memory-framework/unified-memory-framework/vcpkg_installed/x64-windows/share/vcpkg-cmake/vcpkg_cmake_configure.cmake:104 (vcpkg_find_acquire_program)
  ports/tbb/portfile.cmake:17 (vcpkg_cmake_configure)
  scripts/ports.cmake:170 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at scripts/cmake/vcpkg_find_acquire_program.cmake:30 (cmake_parse_arguments):
  The INTERPRETER keyword was followed by an empty string or no value at all.
  Policy CMP0174 is not set, so cmake_parse_arguments() will unset the
  arg_INTERPRETER variable rather than setting it to an empty string.
Call Stack (most recent call first):
  scripts/cmake/vcpkg_find_acquire_program.cmake:149 (z_vcpkg_find_acquire_program_find_external)
  D:/a/unified-memory-framework/unified-memory-framework/vcpkg_installed/x64-windows/share/vcpkg-cmake/vcpkg_cmake_configure.cmake:104 (vcpkg_find_acquire_program)
  ports/tbb/portfile.cmake:17 (vcpkg_cmake_configure)
  scripts/ports.cmake:170 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Found external ninja('1.12.1').
-- Configuring x64-windows
CMake Error at scripts/cmake/vcpkg_execute_required_process.cmake:112 (message):
Error:     Command failed: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/Common7/IDE/CommonExtensions/Microsoft/CMake/Ninja/ninja.exe" -v
    Working Directory: D:/a/unified-memory-framework/unified-memory-framework/build/vcpkg/buildtrees/tbb/x64-windows-rel/vcpkg-parallel-configure
    Error code: 1
```
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [x] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
