### PR TITLE
Bump legacy sycl

### DIFF
--- a/.github/workflows/reusable_sycl.yml
+++ b/.github/workflows/reusable_sycl.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        llvm_tag: ["latest", "nightly-2025-02-08"] # "latest" or llvm with UMF v0.11.0-dev2
+        llvm_tag: ["latest", "nightly-2025-03-15"] # "latest" or llvm with UMF v0.11.0-dev4
 
     steps:
     # Install sycl
@@ -77,6 +77,8 @@ jobs:
 
     # Test sycl-ls
     - name: Run sycl-ls
+      env:
+        SYCL_UR_TRACE: 1
       run: |
         ./llvm/bin/sycl-ls | tee sycl-ls-output.log
         grep -q "level_zero:gpu" sycl-ls-output.log


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description
Sycl compatibility tests are failing after the recent removal of the `umfMemoryTrackerGetAllocInfo` symbol (#1235) form the `.map` file:
```
<LOADER>[INFO]: failed to load adapter 'libur_adapter_level_zero.so.0' with error: llvm/lib/libur_adapter_level_zero.so.0: undefined symbol: umfMemoryTrackerGetAllocInfo, version UMF_0.10
```
Update legacy sycl version used in CI to one that is built with UMF with Disjoint Pool being a part of libumf library.
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [x] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
https://github.com/oneapi-src/unified-memory-framework/actions/runs/14328678325/job/40159432929?pr=1243
