### PR TITLE
L0 provider: fix initialization

### DIFF
--- a/src/provider/provider_level_zero.c
+++ b/src/provider/provider_level_zero.c
@@ -629,7 +629,7 @@ static umf_result_t ze_memory_provider_initialize(void *params,
     umf_result_t result =
         query_min_page_size(ze_provider, &ze_provider->min_page_size);
     if (result != UMF_RESULT_SUCCESS) {
-        ze_memory_provider_finalize(provider);
+        ze_memory_provider_finalize(ze_provider);
         return result;
     }
 


### PR DESCRIPTION
In case of error in the init function, cleanup was being called on 'provider' which was being initialized at the very end of init function, instead of 'ze_provider'.
