### PR TITLE
Use atomics in `trackingAlloc()`

### DIFF
--- a/src/provider/provider_tracking.c
+++ b/src/provider/provider_tracking.c
@@ -471,7 +471,7 @@ static umf_result_t trackingAlloc(void *hProvider, size_t size,
 
     assert(p->hUpstream);
 
-    *_ptr = NULL;
+    utils_atomic_store_release_ptr(_ptr, NULL);
 
     ret = umfMemoryProviderAlloc(p->hUpstream, size, alignment, &ptr);
     if (ret != UMF_RESULT_SUCCESS || !ptr) {
@@ -492,7 +492,7 @@ static umf_result_t trackingAlloc(void *hProvider, size_t size,
         return ret;
     }
 
-    *_ptr = ptr;
+    utils_atomic_store_release_ptr(_ptr, ptr);
 
     return UMF_RESULT_SUCCESS;
 }


### PR DESCRIPTION
Use `utils_atomic_store_release_ptr()` atomics in `trackingAlloc()`.

It fixes a data race detected by TSAN:
https://github.com/ldorau/unified-memory-framework/actions/runs/14440708601/job/40490018118
```
WARNING: ThreadSanitizer: data race (pid=85235)
  Write of size 8 at 0x7f5ae5e5c6e8 by thread T18 (mutexes: write M0):
    #0 trackingAlloc /home/runner/work/unified-memory-framework/unified-memory-framework/src/provider/provider_tracking.c:474 (test_memoryPool+0xb1b53)
    #1 umfMemoryProviderAlloc /home/runner/work/unified-memory-framework/unified-memory-framework/src/memory_provider.c:245 (test_memoryPool+0xada4d)
    #2 create_slab /home/runner/work/unified-memory-framework/unified-memory-framework/src/pool/pool_disjoint.c:116 (test_memoryPool+0xb7010)
    #3 bucket_create_slab /home/runner/work/unified-memory-framework/unified-memory-framework/src/pool/pool_disjoint.c:345 (test_memoryPool+0xb8a5d)
    #4 bucket_get_avail_slab /home/runner/work/unified-memory-framework/unified-memory-framework/src/pool/pool_disjoint.c:368 (test_memoryPool+0xb8ca6)
    #5 bucket_get_free_chunk /home/runner/work/unified-memory-framework/unified-memory-framework/src/pool/pool_disjoint.c:321 (test_memoryPool+0xb85bf)
    #6 disjoint_pool_aligned_malloc /home/runner/work/unified-memory-framework/unified-memory-framework/src/pool/pool_disjoint.c:763 (test_memoryPool+0xba644)
    #7 umfPoolAlignedMalloc /home/runner/work/unified-memory-framework/unified-memory-framework/src/memory_pool.c:195 (test_memoryPool+0xac901)
    #8 pow2AlignedAllocHelper(umf_memory_pool_t*) /home/runner/work/unified-memory-framework/unified-memory-framework/test/poolFixtures.hpp:216 (test_memoryPool+0x1abf0)
    #9 operator() /home/runner/work/unified-memory-framework/unified-memory-framework/test/poolFixtures.hpp:299 (test_memoryPool+0x1b916)
    #10 __invoke_impl<void, umfPoolTest_multiThreadedpow2AlignedAlloc_Test::TestBody()::<lambda(umf_memory_pool_handle_t)>, umf_memory_pool_t*> /usr/include/c++/11/bits/invoke.h:61 (test_memoryPool+0x35b82)
    #11 __invoke<umfPoolTest_multiThreadedpow2AlignedAlloc_Test::TestBody()::<lambda(umf_memory_pool_handle_t)>, umf_memory_pool_t*> /usr/include/c++/11/bits/invoke.h:96 (test_memoryPool+0x35555)
    #12 _M_invoke<0, 1> /usr/include/c++/11/bits/std_thread.h:259 (test_memoryPool+0x34e38)
    #13 operator() /usr/include/c++/11/bits/std_thread.h:266 (test_memoryPool+0x34ade)
    #14 _M_run /usr/include/c++/11/bits/std_thread.h:211 (test_memoryPool+0x348c8)
    #15 <null> <null> (libstdc++.so.6+0xdc252)

  Previous read of size 8 at 0x7f5ae5e5c6e8 by thread T16:
    #0 slab_get_end /home/runner/work/unified-memory-framework/unified-memory-framework/src/pool/pool_disjoint.c:179 (test_memoryPool+0xb744f)
    #1 disjoint_pool_free /home/runner/work/unified-memory-framework/unified-memory-framework/src/pool/pool_disjoint.c:843 (test_memoryPool+0xbac10)
    #2 umfPoolFree /home/runner/work/unified-memory-framework/unified-memory-framework/src/memory_pool.c:215 (test_memoryPool+0xacba9)
    #3 pow2AlignedAllocHelper(umf_memory_pool_t*) /home/runner/work/unified-memory-framework/unified-memory-framework/test/poolFixtures.hpp:224 (test_memoryPool+0x1aef2)
    #4 operator() /home/runner/work/unified-memory-framework/unified-memory-framework/test/poolFixtures.hpp:299 (test_memoryPool+0x1b916)
    #5 __invoke_impl<void, umfPoolTest_multiThreadedpow2AlignedAlloc_Test::TestBody()::<lambda(umf_memory_pool_handle_t)>, umf_memory_pool_t*> /usr/include/c++/11/bits/invoke.h:61 (test_memoryPool+0x35b82)
    #6 __invoke<umfPoolTest_multiThreadedpow2AlignedAlloc_Test::TestBody()::<lambda(umf_memory_pool_handle_t)>, umf_memory_pool_t*> /usr/include/c++/11/bits/invoke.h:96 (test_memoryPool+0x35555)
    #7 _M_invoke<0, 1> /usr/include/c++/11/bits/std_thread.h:259 (test_memoryPool+0x34e38)
    #8 operator() /usr/include/c++/11/bits/std_thread.h:266 (test_memoryPool+0x34ade)
    #9 _M_run /usr/include/c++/11/bits/std_thread.h:211 (test_memoryPool+0x348c8)
    #10 <null> <null> (libstdc++.so.6+0xdc252)
```


<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
