### PR TITLE
[CI] Install hwloc from apt instead of building from sources

### DIFF
--- a/.github/workflows/reusable_basic.yml
+++ b/.github/workflows/reusable_basic.yml
@@ -126,6 +126,11 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y clang cmake libnuma-dev lcov
 
+    - name: Install hwloc
+      if: matrix.disable_hwloc == 'OFF'
+      run: |
+        sudo apt-get install -y libhwloc-dev
+
     - name: Install TBB apt package
       if: matrix.install_tbb == 'ON'
       run: |
@@ -143,9 +148,6 @@ jobs:
     - name: Install g++-7
       if: matrix.compiler.cxx == 'g++-7'
       run: sudo apt-get install -y ${{matrix.compiler.cxx}}
-
-    - name: Install libhwloc
-      run: .github/scripts/install_hwloc.sh
 
     - name: Get UMF version
       run: |

--- a/.github/workflows/reusable_compatibility.yml
+++ b/.github/workflows/reusable_compatibility.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install apt packages
       run: |
         sudo apt-get update
-        sudo apt-get install -y clang cmake hwloc libnuma-dev libtbb-dev
+        sudo apt-get install -y clang cmake hwloc libhwloc-dev libnuma-dev libtbb-dev
 
     - name: Checkout "tag" UMF version
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -31,10 +31,6 @@ jobs:
         fetch-depth: 0
         ref: refs/tags/${{inputs.tag}}
         path: ${{github.workspace}}/tag_version
-
-    - name: Install libhwloc
-      working-directory: ${{github.workspace}}/tag_version
-      run: .github/scripts/install_hwloc.sh
 
     - name: Checkout latest UMF version
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Get rid of the hwloc installation script runs in CI. Save ca. 25s in each of 14 jobs using this script.

<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
- [ ] All API changes are reflected in docs and def/map files, and are tested
