### PR TITLE
[CI] Run DocsBuild only when needed

### DIFF
--- a/.github/workflows/docs_pr_push.yml
+++ b/.github/workflows/docs_pr_push.yml
@@ -1,0 +1,36 @@
+# This workflow is strictly for documentation updates. It triggers only when files related
+# to documentation or specific workflows are edited, ensuring that the job runs only for
+# relevant changes.
+
+name: Documentation PR/push
+
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+      - 'main'  # Ignore main branch as it's handled by docs.yml
+    paths:
+      - 'docs/**'
+      - 'include/**'
+      - .github/workflows/reusable_docs_build.yml
+      - .github/workflows/docs_pr_push.yml
+      - 'third_party/requirements.txt'
+
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'include/**'
+      - .github/workflows/reusable_docs_build.yml
+      - .github/workflows/docs_pr_push.yml
+      - 'third_party/requirements.txt'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  DocsBuild:
+    uses: ./.github/workflows/reusable_docs_build.yml

--- a/.github/workflows/pr_push.yml
+++ b/.github/workflows/pr_push.yml
@@ -18,11 +18,9 @@ permissions:
 jobs:
   CodeChecks:
     uses: ./.github/workflows/reusable_checks.yml
-  DocsBuild:
-    uses: ./.github/workflows/reusable_docs_build.yml
   FastBuild:
     name: Fast builds
-    needs: [CodeChecks, DocsBuild]
+    needs: [CodeChecks]
     uses: ./.github/workflows/reusable_fast.yml
   Build:
     name: Basic builds


### PR DESCRIPTION
Oftentimes pushes to branches and PRs doesn't change anything in docs/ or include/ directories which influence the documentation build. This job takes ca. 1 minute to run with each push, so it's optimal to run it only when relevant changes were made.

Also, there is no need for other pr_push jobs to wait for docs to build. Developer can work on the docs and project build/tests in any order.

<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
- [ ] All API changes are reflected in docs and def/map files, and are tested
