### PR TITLE
[CI] Use install dir path within workspace

### DIFF
--- a/.github/workflows/reusable_basic.yml
+++ b/.github/workflows/reusable_basic.yml
@@ -8,7 +8,7 @@ permissions:
 
 env:
   BUILD_DIR : "${{github.workspace}}/build"
-  INSTL_DIR : "${{github.workspace}}/../install-dir"
+  INSTL_DIR : "${{github.workspace}}/install-dir"
   COVERAGE_DIR : "${{github.workspace}}/coverage"
   COVERAGE_NAME : "exports-coverage-basic"
 

--- a/.github/workflows/reusable_codeql.yml
+++ b/.github/workflows/reusable_codeql.yml
@@ -8,7 +8,7 @@ permissions:
 
 env:
   BUILD_DIR : "${{github.workspace}}/build"
-  INSTL_DIR : "${{github.workspace}}/../install-dir"
+  INSTL_DIR : "${{github.workspace}}/install-dir"
 
 jobs:
   analyze:

--- a/.github/workflows/reusable_dax.yml
+++ b/.github/workflows/reusable_dax.yml
@@ -28,7 +28,7 @@ env:
   UMF_TESTS_FSDAX_PATH: "/mnt/pmem1/file"
   UMF_TESTS_FSDAX_PATH_2: "/mnt/pmem1/file_2"
   BUILD_DIR : "${{github.workspace}}/build"
-  INSTL_DIR : "${{github.workspace}}/../install-dir"
+  INSTL_DIR : "${{github.workspace}}/install-dir"
   COVERAGE_DIR : "${{github.workspace}}/coverage"
   COVERAGE_NAME : "exports-coverage-dax"
   DAX_TESTS: "./test/test_provider_file_memory ./test/test_provider_devdax_memory"

--- a/.github/workflows/reusable_fast.yml
+++ b/.github/workflows/reusable_fast.yml
@@ -8,7 +8,7 @@ permissions:
 
 env:
   BUILD_DIR : "${{github.workspace}}/build"
-  INSTL_DIR : "${{github.workspace}}/../install-dir"
+  INSTL_DIR : "${{github.workspace}}/install-dir"
 
 jobs:
   FastBuild:

--- a/.github/workflows/reusable_gpu.yml
+++ b/.github/workflows/reusable_gpu.yml
@@ -31,7 +31,7 @@ permissions:
 
 env:
   BUILD_DIR : "${{github.workspace}}/build"
-  INSTL_DIR : "${{github.workspace}}/../install-dir"
+  INSTL_DIR : "${{github.workspace}}/install-dir"
   COVERAGE_DIR : "${{github.workspace}}/coverage"
 
 jobs:

--- a/.github/workflows/reusable_proxy_lib.yml
+++ b/.github/workflows/reusable_proxy_lib.yml
@@ -8,7 +8,7 @@ permissions:
 
 env:
   BUILD_DIR : "${{github.workspace}}/build"
-  INSTL_DIR : "${{github.workspace}}/../install-dir"
+  INSTL_DIR : "${{github.workspace}}/install-dir"
   COVERAGE_DIR : "${{github.workspace}}/coverage"
   COVERAGE_NAME : "exports-coverage-proxy"
 

--- a/.github/workflows/reusable_sanitizers.yml
+++ b/.github/workflows/reusable_sanitizers.yml
@@ -5,7 +5,7 @@ on: workflow_call
 
 env:
   BUILD_DIR : "${{github.workspace}}/build"
-  INSTL_DIR : "${{github.workspace}}/../install-dir"
+  INSTL_DIR : "${{github.workspace}}/install-dir"
 
 permissions:
   contents: read


### PR DESCRIPTION
Dir outside of the workspace can't be cleaned in cases of non-stateless runners.

// example of failing job: https://github.com/luszczewskakasia1/unified-memory-framework/actions/runs/14466409232/job/40570259829
// that happened on a machine, when user can't access the `..`