### PR TITLE
update doc and fail if fuzz tests reqs are not met

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,8 @@ umf_option(UMF_BUILD_BENCHMARKS "Build UMF benchmarks" OFF)
 umf_option(UMF_BUILD_BENCHMARKS_MT "Build UMF multithreaded benchmarks" OFF)
 umf_option(UMF_BUILD_EXAMPLES "Build UMF examples" ON)
 umf_option(UMF_BUILD_GPU_EXAMPLES "Build UMF GPU examples" OFF)
-umf_option(UMF_BUILD_FUZZTESTS "Build UMF fuzz tests" OFF)
+umf_option(UMF_BUILD_FUZZTESTS
+           "Build UMF fuzz tests (supported only on Linux with Clang)" OFF)
 umf_option(
     UMF_DISABLE_HWLOC
     "Disable hwloc and UMF features requiring it (OS provider, memtargets, topology discovery)"
@@ -579,12 +580,19 @@ if(UMF_USE_MSAN)
                     "prevent reporting false-positives")
     add_sanitizer_flag(memory)
 endif()
+
 # Fuzzer instrumentation for the whole library
-if(UMF_BUILD_FUZZTESTS
-   AND CMAKE_CXX_COMPILER_ID MATCHES "Clang"
-   AND LINUX)
-    add_compile_options("-fsanitize=fuzzer-no-link")
-    add_link_options("-fsanitize=fuzzer-no-link")
+if(UMF_BUILD_FUZZTESTS)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND LINUX)
+        add_compile_options("-fsanitize=fuzzer-no-link")
+        add_link_options("-fsanitize=fuzzer-no-link")
+    else()
+        message(
+            FATAL_ERROR
+                "UMF_BUILD_FUZZTESTS option is set, but fuzz tests are supported only on Linux with Clang"
+        )
+        set(UMF_BUILD_FUZZTESTS OFF)
+    endif()
 endif()
 
 # A header-only lib to specify include directories in transitive dependencies

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ List of options provided by CMake:
 | UMF_BUILD_GPU_TESTS | Build UMF GPU tests | ON/OFF | OFF |
 | UMF_BUILD_BENCHMARKS | Build UMF benchmarks | ON/OFF | OFF |
 | UMF_BUILD_EXAMPLES | Build UMF examples | ON/OFF | ON |
-| UMF_BUILD_FUZZTESTS | Build UMF fuzz tests | ON/OFF | OFF |
+| UMF_BUILD_FUZZTESTS | Build UMF fuzz tests (supported only on Linux with Clang) | ON/OFF | OFF |
 | UMF_BUILD_GPU_EXAMPLES | Build UMF GPU examples | ON/OFF | OFF |
 | UMF_DEVELOPER_MODE | Enable additional developer checks | ON/OFF | OFF |
 | UMF_FORMAT_CODE_STYLE | Add clang, cmake, and black -format-check and -format-apply targets to make | ON/OFF | OFF |

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -391,7 +391,7 @@ if(LINUX AND (NOT UMF_DISABLE_HWLOC)) # OS-specific functions are implemented
             LIBS ${UMF_UTILS_FOR_TEST})
     endif()
 
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND UMF_BUILD_FUZZTESTS)
+    if(UMF_BUILD_FUZZTESTS)
         add_subdirectory(fuzz)
     endif()
 else()


### PR DESCRIPTION
update the documentation and fail CMake if the fuzz tests are enabled but their requirements (Clang and Linux) are not met.

fixes https://github.com/oneapi-src/unified-memory-framework/issues/1267
