### PR TITLE
[CMake] Bump L0 version to latest - v1.21.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,7 +391,7 @@ endif()
 # headers are not provided by the user (via setting UMF_LEVEL_ZERO_INCLUDE_DIR).
 if(UMF_BUILD_LEVEL_ZERO_PROVIDER AND (NOT UMF_LEVEL_ZERO_INCLUDE_DIR))
     set(LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
-    set(LEVEL_ZERO_LOADER_TAG v1.20.2)
+    set(LEVEL_ZERO_LOADER_TAG v1.21.9)
 
     message(
         STATUS

--- a/examples/ipc_level_zero/CMakeLists.txt
+++ b/examples/ipc_level_zero/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 include(FetchContent)
 
 set(LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
-set(LEVEL_ZERO_LOADER_TAG v1.20.2)
+set(LEVEL_ZERO_LOADER_TAG v1.21.9)
 
 message(
     STATUS

--- a/examples/level_zero_shared_memory/CMakeLists.txt
+++ b/examples/level_zero_shared_memory/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 include(FetchContent)
 
 set(LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
-set(LEVEL_ZERO_LOADER_TAG v1.20.2)
+set(LEVEL_ZERO_LOADER_TAG v1.21.9)
 
 message(
     STATUS


### PR DESCRIPTION
- [x] wait for nightly test: https://github.com/oneapi-src/unified-memory-framework/pull/1283

Bump to the latest L0 release. SYCL repo is already using it, with success 😉 