### PR TITLE
link with Clang static fuzzer lib if UMF_BUILD_FUZZTESTS is set

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,6 +57,14 @@ jobs:
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}} --verbose -j$(nproc)
 
+      - name: Run regular tests
+        working-directory: ${{github.workspace}}/build
+        run: ctest -C ${{matrix.build_type}} --output-on-failure -E "fuzz|test_init_teardown"
+
+      - name: Run regular tests with proxy library
+        working-directory: ${{env.BUILD_DIR}}
+        run: LD_PRELOAD=./lib/libumf_proxy.so ctest -C ${{matrix.build_type}} --output-on-failure -E "fuzz|test_init_teardown"
+
       - name: Fuzz long test
         working-directory: ${{github.workspace}}/build
         run: ctest -C ${{matrix.build_type}} --output-on-failure --verbose -L "fuzz-long"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,13 +36,20 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake hwloc libhwloc-dev libnuma-dev libtbb-dev
 
+      - name: Find Clang fuzzer lib
+        run: |
+          CLANG_LIBS_DIR=$(find /usr/lib -name "libclang_rt.fuzzer_no_main-x86_64.a" -exec dirname {} \; | head -n 1)
+          echo "CLANG_LIBS_DIR=${CLANG_LIBS_DIR}" >> $GITHUB_ENV
+
       - name: Configure CMake
         run: >
           cmake
           -B ${{github.workspace}}/build
+          -DCMAKE_PREFIX_PATH=${{env.CLANG_LIBS_DIR}}
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
           -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
           -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
+          -DUMF_BUILD_SHARED_LIBRARY=ON
           -DUMF_TESTS_FAIL_ON_SKIP=ON
           -DUMF_DEVELOPER_MODE=ON
           -DUMF_BUILD_FUZZTESTS=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -586,6 +586,20 @@ if(UMF_BUILD_FUZZTESTS)
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND LINUX)
         add_compile_options("-fsanitize=fuzzer-no-link")
         add_link_options("-fsanitize=fuzzer-no-link")
+
+        # We need to find the fuzzer lib in the LLVM installation dir and link
+        # it statically as UMF does not define the main function used by fuzzer
+        # as well as __sancov_* functions
+        find_library(FUZZER_NO_MAIN_LIB
+                     NAMES libclang_rt.fuzzer_no_main-x86_64.a)
+
+        if(FUZZER_NO_MAIN_LIB)
+            message(STATUS "Found fuzzer lib: ${FUZZER_NO_MAIN_LIB}")
+            # Fuzzer lib requires libstdc++
+            link_libraries(${FUZZER_NO_MAIN_LIB} "stdc++")
+        else()
+            message(FATAL_ERROR "libclang_rt.fuzzer_no_main-x86_64 not found!")
+        endif()
     else()
         message(
             FATAL_ERROR

--- a/README.md
+++ b/README.md
@@ -97,6 +97,20 @@ List of sanitizers available on Windows:
 
 Listed sanitizers can be enabled with appropriate [CMake options](#cmake-standard-options).
 
+### Fuzz testing
+
+To enable fuzz testing, the `UMF_BUILD_FUZZTESTS` CMake configuration flag must
+be set to `ON`. Note, that this feature is supported only on Linux and requires
+Clang. Additionally, ensure that the `CMAKE_PREFIX_PATH` includes the directory
+containing the libraries necessary for fuzzing (e.g., Clang's
+libclang_rt.fuzzer_no_main-x86_64.a).
+
+Example:
+
+```bash
+cmake -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Debug -DUMF_BUILD_FUZZTESTS=ON -DCMAKE_PREFIX_PATH=/path/to/fuzzer/libs
+```
+
 ### CMake standard options
 
 List of options provided by CMake:


### PR DESCRIPTION
Link with the Clang static fuzzer library, libclang_rt.fuzzer_no_main-x86_64, if UMF_BUILD_FUZZTESTS is set. 
Additionally, run extra tests in the nightly workflow that would fail without this change.

Successful run: https://github.com/oneapi-src/unified-memory-framework/actions/runs/14704118968/job/41260044056?pr=1284
```
-- Found fuzzer lib: /usr/lib/llvm-17/lib/clang/17/lib/linux/libclang_rt.fuzzer_no_main-x86_64.a
...
-- Fuzzing tests enabled.
```

Fixes: https://github.com/oneapi-src/unified-memory-framework/issues/590