### PR TITLE
do not install libze_loader

### DIFF
--- a/.github/workflows/reusable_basic.yml
+++ b/.github/workflows/reusable_basic.yml
@@ -26,6 +26,7 @@ jobs:
         install_tbb: ['ON']
         disable_hwloc: ['OFF']
         link_hwloc_statically: ['OFF']
+        cmake_ver: ['latest']
         include:
           - os: 'ubuntu-22.04'
             build_type: Release
@@ -36,6 +37,8 @@ jobs:
             install_tbb: 'ON'
             disable_hwloc: 'OFF'
             link_hwloc_statically: 'OFF'
+            # check minimum supported cmake version
+            cmake_ver: '3.14.0'
           - os: 'ubuntu-22.04'
             build_type: Release
             compiler: {c: gcc, cxx: g++}
@@ -45,6 +48,7 @@ jobs:
             install_tbb: 'ON'
             disable_hwloc: 'OFF'
             link_hwloc_statically: 'OFF'
+            cmake_ver: 'latest'
           - os: 'ubuntu-24.04'
             build_type: Debug
             compiler: {c: gcc, cxx: g++}
@@ -54,6 +58,7 @@ jobs:
             install_tbb: 'ON'
             disable_hwloc: 'OFF'
             link_hwloc_statically: 'OFF'
+            cmake_ver: 'latest'
           # test level_zero_provider='OFF' and cuda_provider='OFF'
           - os: 'ubuntu-22.04'
             build_type: Release
@@ -64,6 +69,7 @@ jobs:
             install_tbb: 'ON'
             disable_hwloc: 'OFF'
             link_hwloc_statically: 'OFF'
+            cmake_ver: 'latest'
           # test icx compiler
           - os: 'ubuntu-22.04'
             build_type: Release
@@ -74,6 +80,7 @@ jobs:
             install_tbb: 'ON'
             disable_hwloc: 'OFF'
             link_hwloc_statically: 'OFF'
+            cmake_ver: 'latest'
           # test lld linker
           - os: 'ubuntu-24.04'
             build_type: Release
@@ -85,7 +92,8 @@ jobs:
             disable_hwloc: 'OFF'
             link_hwloc_statically: 'OFF'
             llvm_linker: '-DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" -DCMAKE_MODULE_LINKER_FLAGS="-fuse-ld=lld" -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld"'
-          # test without installing TBB
+            cmake_ver: 'latest'
+            # test without installing TBB
           - os: 'ubuntu-22.04'
             build_type: Release
             compiler: {c: gcc, cxx: g++}
@@ -95,6 +103,7 @@ jobs:
             install_tbb: 'OFF'
             disable_hwloc: 'OFF'
             link_hwloc_statically: 'OFF'
+            cmake_ver: 'latest'
           - os: 'ubuntu-22.04'
             build_type: Debug
             compiler: {c: gcc, cxx: g++}
@@ -104,6 +113,7 @@ jobs:
             install_tbb: 'ON'
             disable_hwloc: 'ON'
             link_hwloc_statically: 'OFF'
+            cmake_ver: 'latest'
           - os: 'ubuntu-22.04'
             build_type: Release
             compiler: {c: gcc, cxx: g++}
@@ -113,6 +123,7 @@ jobs:
             install_tbb: 'ON'
             disable_hwloc: 'OFF'
             link_hwloc_statically: 'ON'
+            cmake_ver: 'latest'
     runs-on: ${{matrix.os}}
 
     steps:
@@ -124,7 +135,15 @@ jobs:
     - name: Install apt packages
       run: |
         sudo apt-get update
-        sudo apt-get install -y clang cmake libnuma-dev lcov
+        sudo apt-get install -y clang libnuma-dev lcov
+
+    - name: Install cmake (minimum supported version)
+      if: matrix.cmake_ver != 'latest'
+      run: |
+        sudo apt-get remove --purge -y cmake
+        wget https://github.com/Kitware/CMake/releases/download/v${{matrix.cmake_ver}}/cmake-${{matrix.cmake_ver}}-Linux-x86_64.sh
+        chmod +x cmake-${{matrix.cmake_ver}}-Linux-x86_64.sh
+        sudo ./cmake-${{matrix.cmake_ver}}-Linux-x86_64.sh --skip-license --prefix=/usr/local
 
     - name: Install hwloc
       if: matrix.disable_hwloc == 'OFF'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,16 +406,17 @@ if(UMF_BUILD_LEVEL_ZERO_PROVIDER AND (NOT UMF_LEVEL_ZERO_INCLUDE_DIR))
         GIT_REPOSITORY ${LEVEL_ZERO_LOADER_REPO}
         GIT_TAG ${LEVEL_ZERO_LOADER_TAG}
         EXCLUDE_FROM_ALL)
-    FetchContent_MakeAvailable(level-zero-loader)
+    # Only populate the repo - we don't need to build it
+    FetchContent_Populate(level-zero-loader)
 
     set(LEVEL_ZERO_INCLUDE_DIRS
         ${level-zero-loader_SOURCE_DIR}/include
-        CACHE PATH "Path to Level Zero Headers")
-    message(STATUS "Level Zero include directory: ${LEVEL_ZERO_INCLUDE_DIRS}")
+        CACHE PATH "Path to Level Zero headers")
+    message(STATUS "LEVEL_ZERO_INCLUDE_DIRS = ${LEVEL_ZERO_INCLUDE_DIRS}")
 elseif(UMF_BUILD_LEVEL_ZERO_PROVIDER)
     # Only header is needed to build UMF
     set(LEVEL_ZERO_INCLUDE_DIRS ${UMF_LEVEL_ZERO_INCLUDE_DIR})
-    message(STATUS "Level Zero include directory: ${LEVEL_ZERO_INCLUDE_DIRS}")
+    message(STATUS "LEVEL_ZERO_INCLUDE_DIRS = ${LEVEL_ZERO_INCLUDE_DIRS}")
 endif()
 
 # Fetch CUDA only if needed i.e.: if building CUDA provider is ON and CUDA
@@ -425,14 +426,15 @@ if(UMF_BUILD_CUDA_PROVIDER AND (NOT UMF_CUDA_INCLUDE_DIR))
         "https://gitlab.com/nvidia/headers/cuda-individual/cudart.git")
     set(CUDA_TAG cuda-12.5.1)
 
-    message(STATUS "Fetching CUDA ${CUDA_TAG} from ${CUDA_REPO} ...")
+    message(STATUS "Fetching CUDA (${CUDA_TAG}) from ${CUDA_REPO} ...")
 
     FetchContent_Declare(
         cuda-headers
         GIT_REPOSITORY ${CUDA_REPO}
         GIT_TAG ${CUDA_TAG}
         EXCLUDE_FROM_ALL)
-    FetchContent_MakeAvailable(cuda-headers)
+    # Only populate the repo - we don't need to build it
+    FetchContent_Populate(cuda-headers)
 
     set(CUDA_INCLUDE_DIRS
         ${cuda-headers_SOURCE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,60 +390,94 @@ if(hwloc_targ_SOURCE_DIR)
     endif()
 endif()
 
-# Fetch L0 loader only if needed i.e.: if building L0 provider is ON and L0
-# headers are not provided by the user (via setting UMF_LEVEL_ZERO_INCLUDE_DIR).
-if(UMF_BUILD_LEVEL_ZERO_PROVIDER AND (NOT UMF_LEVEL_ZERO_INCLUDE_DIR))
-    set(LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
-    set(LEVEL_ZERO_LOADER_TAG v1.21.9)
+if(UMF_BUILD_LEVEL_ZERO_PROVIDER)
+    if(UMF_BUILD_GPU_TESTS OR UMF_BUILD_GPU_EXAMPLES)
+        # Level Zero loader library is required to build Level Zero GPU tests
+        # and examples
+        find_package(ZE_LOADER REQUIRED ze_loader)
+    else()
+        find_package(ZE_LOADER COMPONENTS ze_loader)
+    endif()
 
-    message(
-        STATUS
-            "Fetching L0 loader (${LEVEL_ZERO_LOADER_TAG}) from ${LEVEL_ZERO_LOADER_REPO} ..."
-    )
+    # If the Level Zero headers are not provided by the user and not found in
+    # the system, we will fetch them from the repo
+    if(UMF_LEVEL_ZERO_INCLUDE_DIR)
+        set(LEVEL_ZERO_INCLUDE_DIRS ${UMF_LEVEL_ZERO_INCLUDE_DIR})
+    elseif(ZE_LOADER_INCLUDE_DIR)
+        set(LEVEL_ZERO_INCLUDE_DIRS ${ZE_LOADER_INCLUDE_DIR})
+    else()
+        set(LEVEL_ZERO_LOADER_REPO
+            "https://github.com/oneapi-src/level-zero.git")
+        set(LEVEL_ZERO_LOADER_TAG v1.21.9)
 
-    FetchContent_Declare(
-        level-zero-loader
-        GIT_REPOSITORY ${LEVEL_ZERO_LOADER_REPO}
-        GIT_TAG ${LEVEL_ZERO_LOADER_TAG}
-        EXCLUDE_FROM_ALL)
-    # Only populate the repo - we don't need to build it
-    FetchContent_Populate(level-zero-loader)
+        message(STATUS "Fetching Level Zero loader (${LEVEL_ZERO_LOADER_TAG}) "
+                       "from ${LEVEL_ZERO_LOADER_REPO} ...")
+        FetchContent_Declare(
+            level-zero-loader
+            GIT_REPOSITORY ${LEVEL_ZERO_LOADER_REPO}
+            GIT_TAG ${LEVEL_ZERO_LOADER_TAG}
+            EXCLUDE_FROM_ALL)
+        # Only populate the repo - we don't need to build it
+        FetchContent_Populate(level-zero-loader)
 
-    set(LEVEL_ZERO_INCLUDE_DIRS
-        ${level-zero-loader_SOURCE_DIR}/include
-        CACHE PATH "Path to Level Zero headers")
+        set(LEVEL_ZERO_INCLUDE_DIRS
+            ${level-zero-loader_SOURCE_DIR}/include
+            CACHE PATH "Path to Level Zero headers")
+    endif()
     message(STATUS "LEVEL_ZERO_INCLUDE_DIRS = ${LEVEL_ZERO_INCLUDE_DIRS}")
-elseif(UMF_BUILD_LEVEL_ZERO_PROVIDER)
-    # Only header is needed to build UMF
-    set(LEVEL_ZERO_INCLUDE_DIRS ${UMF_LEVEL_ZERO_INCLUDE_DIR})
-    message(STATUS "LEVEL_ZERO_INCLUDE_DIRS = ${LEVEL_ZERO_INCLUDE_DIRS}")
+
+    if(ZE_LOADER_LIBRARIES)
+        set(UMF_LEVEL_ZERO_ENABLED TRUE)
+    else()
+        message(
+            STATUS
+                "Disabling tests and examples that use the Level Zero Provider "
+                "because the Level Zero libraries they require were not found.")
+    endif()
 endif()
 
-# Fetch CUDA only if needed i.e.: if building CUDA provider is ON and CUDA
-# headers are not provided by the user (via setting UMF_CUDA_INCLUDE_DIR).
-if(UMF_BUILD_CUDA_PROVIDER AND (NOT UMF_CUDA_INCLUDE_DIR))
-    set(CUDA_REPO
-        "https://gitlab.com/nvidia/headers/cuda-individual/cudart.git")
-    set(CUDA_TAG cuda-12.5.1)
+if(UMF_BUILD_CUDA_PROVIDER)
+    if(UMF_BUILD_GPU_TESTS OR UMF_BUILD_GPU_EXAMPLES)
+        # CUDA library is required to build CUDA GPU tests and examples
+        find_package(CUDA REQUIRED cuda)
+    else()
+        find_package(CUDA COMPONENTS cuda)
+    endif()
 
-    message(STATUS "Fetching CUDA (${CUDA_TAG}) from ${CUDA_REPO} ...")
+    # If the CUDA headers are not provided by the user and not found in the
+    # system, we will fetch them from the repo
+    if(UMF_CUDA_INCLUDE_DIR)
+        set(CUDA_INCLUDE_DIRS ${UMF_CUDA_INCLUDE_DIR})
+    elseif(CUDA_INCLUDE_DIR)
+        set(CUDA_INCLUDE_DIRS ${CUDA_INCLUDE_DIR})
+    else()
+        set(CUDA_REPO
+            "https://gitlab.com/nvidia/headers/cuda-individual/cudart.git")
+        set(CUDA_TAG cuda-12.5.1)
 
-    FetchContent_Declare(
-        cuda-headers
-        GIT_REPOSITORY ${CUDA_REPO}
-        GIT_TAG ${CUDA_TAG}
-        EXCLUDE_FROM_ALL)
-    # Only populate the repo - we don't need to build it
-    FetchContent_Populate(cuda-headers)
+        message(
+            STATUS "Fetching CUDA (${CUDA_TAG}) headers from ${CUDA_REPO} ...")
+        FetchContent_Declare(
+            cuda-headers
+            GIT_REPOSITORY ${CUDA_REPO}
+            GIT_TAG ${CUDA_TAG}
+            EXCLUDE_FROM_ALL)
+        # Only populate the repo - we don't need to build it
+        FetchContent_Populate(cuda-headers)
 
-    set(CUDA_INCLUDE_DIRS
-        ${cuda-headers_SOURCE_DIR}
-        CACHE PATH "Path to CUDA headers")
+        set(CUDA_INCLUDE_DIRS
+            ${cuda-headers_SOURCE_DIR}
+            CACHE PATH "Path to CUDA headers")
+    endif()
     message(STATUS "CUDA_INCLUDE_DIRS = ${CUDA_INCLUDE_DIRS}")
-elseif(UMF_BUILD_CUDA_PROVIDER)
-    # Only header is needed to build UMF
-    set(CUDA_INCLUDE_DIRS ${UMF_CUDA_INCLUDE_DIR})
-    message(STATUS "CUDA_INCLUDE_DIRS = ${CUDA_INCLUDE_DIRS}")
+
+    if(CUDA_LIBRARIES)
+        set(UMF_CUDA_ENABLED TRUE)
+    else()
+        message(
+            STATUS "Disabling tests and examples that use the CUDA Provider "
+                   "because the CUDA libraries they require were not found.")
+    endif()
 endif()
 
 # Build the umfd target in a separate directory with Debug configuration
@@ -709,18 +743,6 @@ else()
         FATAL_ERROR
             "Proxy library: pool manager not chosen or set to a non-supported one (see UMF_PROXY_LIB_BASED_ON_POOL)"
     )
-endif()
-
-if((UMF_BUILD_GPU_TESTS OR UMF_BUILD_GPU_EXAMPLES) AND UMF_BUILD_CUDA_PROVIDER)
-    find_package(CUDA REQUIRED cuda)
-    if(CUDA_LIBRARIES)
-        set(UMF_CUDA_ENABLED TRUE)
-    else()
-        message(
-            STATUS "Disabling tests and examples that use the CUDA provider "
-                   "because the CUDA libraries they require were not found.")
-    endif()
-    # TODO do the same for ze_loader
 endif()
 
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,9 @@
 # Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+message(STATUS "CMake version: ${CMAKE_VERSION}")
 cmake_minimum_required(VERSION 3.14.0 FATAL_ERROR)
+
 # needed when UMF is used as an external project
 set(UMF_CMAKE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -60,8 +60,10 @@ function(add_umf_benchmark)
         LIBS ${BENCH_LIBS})
 
     target_include_directories(
-        ${BENCH_NAME} PRIVATE ${UMF_CMAKE_SOURCE_DIR}/include
-                              ${UMF_CMAKE_SOURCE_DIR}/src/utils)
+        ${BENCH_NAME}
+        PRIVATE ${UMF_CMAKE_SOURCE_DIR}/include
+                ${UMF_CMAKE_SOURCE_DIR}/src/utils
+                ${UMF_CMAKE_SOURCE_DIR}/test/common)
 
     target_link_directories(${BENCH_NAME} PRIVATE ${ARG_LIBDIRS})
 
@@ -87,16 +89,6 @@ function(add_umf_benchmark)
         set_property(TEST ${BENCH_NAME} PROPERTY ENVIRONMENT_MODIFICATION
                                                  "${DLL_PATH_LIST}")
     endif()
-    if(LINUX)
-        # prepend LD_LIBRARY_PATH with ${CMAKE_BINARY_DIR}/lib it is required
-        # because ${CMAKE_BINARY_DIR}/lib contains libze_loader.so and tests
-        # should use it instead of system one.
-        set_property(
-            TEST ${BENCH_NAME}
-            PROPERTY ENVIRONMENT_MODIFICATION
-                     "LD_LIBRARY_PATH=path_list_prepend:${CMAKE_BINARY_DIR}/lib"
-        )
-    endif()
 
     if(UMF_POOL_JEMALLOC_ENABLED)
         target_compile_definitions(${BENCH_NAME}
@@ -106,19 +98,16 @@ function(add_umf_benchmark)
         target_compile_definitions(${BENCH_NAME}
                                    PRIVATE UMF_POOL_SCALABLE_ENABLED=1)
     endif()
-    if(UMF_BUILD_LEVEL_ZERO_PROVIDER)
+    if(UMF_LEVEL_ZERO_ENABLED)
         target_compile_definitions(${BENCH_NAME}
                                    PRIVATE UMF_PROVIDER_LEVEL_ZERO_ENABLED=1)
-        target_include_directories(
-            ${BENCH_NAME} PRIVATE ${UMF_CMAKE_SOURCE_DIR}/test/common
-                                  ${LEVEL_ZERO_INCLUDE_DIRS})
+        target_include_directories(${BENCH_NAME}
+                                   PRIVATE ${LEVEL_ZERO_INCLUDE_DIRS})
     endif()
-    if(UMF_BUILD_CUDA_PROVIDER)
+    if(UMF_CUDA_ENABLED)
         target_compile_definitions(${BENCH_NAME}
                                    PRIVATE UMF_BUILD_CUDA_PROVIDER=1)
-        target_include_directories(
-            ${BENCH_NAME} PRIVATE ${UMF_CMAKE_SOURCE_DIR}/test/common
-                                  ${CUDA_INCLUDE_DIRS})
+        target_include_directories(${BENCH_NAME} PRIVATE ${CUDA_INCLUDE_DIRS})
     endif()
     if(UMF_BUILD_GPU_TESTS)
         target_compile_definitions(${BENCH_NAME} PRIVATE UMF_BUILD_GPU_TESTS=1)
@@ -131,8 +120,9 @@ set(LIB_DIRS ${LIBHWLOC_LIBRARY_DIRS})
 if(LINUX)
     set(LIBS_OPTIONAL ${LIBS_OPTIONAL} m)
 endif()
-if(UMF_BUILD_GPU_TESTS AND UMF_BUILD_LEVEL_ZERO_PROVIDER)
+if(UMF_BUILD_GPU_TESTS AND UMF_LEVEL_ZERO_ENABLED)
     set(SRCS_OPTIONAL ${SRCS_OPTIONAL} ../src/utils/utils_level_zero.cpp)
+    set(LIB_DIRS ${LIB_DIRS} ${ZE_LOADER_LIBRARY_DIRS})
     set(LIBS_OPTIONAL ${LIBS_OPTIONAL} ze_loader)
     # TODO add CUDA
 endif()

--- a/cmake/FindCUDA.cmake
+++ b/cmake/FindCUDA.cmake
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2024-2025 Intel Corporation
 # Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -6,6 +6,10 @@ message(STATUS "Checking for module 'cuda' using find_library()")
 
 find_library(CUDA_LIBRARY NAMES libcuda cuda)
 set(CUDA_LIBRARIES ${CUDA_LIBRARY})
+
+find_file(CUDA_HEADER NAMES "cuda.h")
+get_filename_component(CUDA_INCLUDE_DIR ${CUDA_HEADER} DIRECTORY)
+set(CUDA_INCLUDE_DIRS ${CUDA_INCLUDE_DIR})
 
 get_filename_component(CUDA_LIB_DIR ${CUDA_LIBRARIES} DIRECTORY)
 set(CUDA_LIBRARY_DIRS ${CUDA_LIB_DIR})

--- a/cmake/FindZE_LOADER.cmake
+++ b/cmake/FindZE_LOADER.cmake
@@ -1,0 +1,39 @@
+# Copyright (C) 2025 Intel Corporation
+# Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+message(STATUS "Checking for module 'ze_loader' using find_library()")
+
+find_library(ZE_LOADER_LIBRARY NAMES libze_loader ze_loader)
+set(ZE_LOADER_LIBRARIES ${ZE_LOADER_LIBRARY})
+
+find_file(ZE_LOADER_HEADER NAMES "ze_api.h" "level_zero/ze_api.h")
+get_filename_component(ZE_LOADER_INCLUDE_DIR ${ZE_LOADER_HEADER} DIRECTORY)
+set(ZE_LOADER_INCLUDE_DIRS ${ZE_LOADER_INCLUDE_DIR})
+
+get_filename_component(ZE_LOADER_LIB_DIR ${ZE_LOADER_LIBRARIES} DIRECTORY)
+set(ZE_LOADER_LIBRARY_DIRS ${ZE_LOADER_LIB_DIR})
+
+if(WINDOWS)
+    find_file(ZE_LOADER_DLL NAMES "ze_loader.dll")
+    get_filename_component(ZE_LOADER_DLL_DIR ${ZE_LOADER_DLL} DIRECTORY)
+    set(ZE_LOADER_DLL_DIRS ${ZE_LOADER_DLL_DIR})
+endif()
+
+if(ZE_LOADER_LIBRARY)
+    message(STATUS "  Found ZE_LOADER using find_library()")
+    message(STATUS "    ZE_LOADER_LIBRARIES = ${ZE_LOADER_LIBRARIES}")
+    message(STATUS "    ZE_LOADER_INCLUDE_DIRS = ${ZE_LOADER_INCLUDE_DIRS}")
+    message(STATUS "    ZE_LOADER_LIBRARY_DIRS = ${ZE_LOADER_LIBRARY_DIRS}")
+    if(WINDOWS)
+        message(STATUS "    ZE_LOADER_DLL_DIRS = ${ZE_LOADER_DLL_DIRS}")
+    endif()
+else()
+    set(MSG_NOT_FOUND "ZE_LOADER NOT found (set CMAKE_PREFIX_PATH to point the "
+                      "location)")
+    if(ZE_LOADER_FIND_REQUIRED)
+        message(FATAL_ERROR ${MSG_NOT_FOUND})
+    else()
+        message(WARNING ${MSG_NOT_FOUND})
+    endif()
+endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -41,7 +41,7 @@ if(UMF_POOL_SCALABLE_ENABLED)
     endif()
 endif()
 
-if(UMF_BUILD_GPU_EXAMPLES AND UMF_BUILD_LEVEL_ZERO_PROVIDER)
+if(UMF_BUILD_GPU_EXAMPLES AND UMF_LEVEL_ZERO_ENABLED)
     set(EXAMPLE_NAME umf_example_level_zero_shared_memory)
 
     add_umf_executable(
@@ -56,7 +56,8 @@ if(UMF_BUILD_GPU_EXAMPLES AND UMF_BUILD_LEVEL_ZERO_PROVIDER)
                 ${UMF_CMAKE_SOURCE_DIR}/include
                 ${UMF_CMAKE_SOURCE_DIR}/examples/common)
 
-    target_link_directories(${EXAMPLE_NAME} PRIVATE ${LIBHWLOC_LIBRARY_DIRS})
+    target_link_directories(${EXAMPLE_NAME} PRIVATE ${LIBHWLOC_LIBRARY_DIRS}
+                            ${ZE_LOADER_LIBRARY_DIRS})
 
     add_test(
         NAME ${EXAMPLE_NAME}
@@ -70,25 +71,13 @@ if(UMF_BUILD_GPU_EXAMPLES AND UMF_BUILD_LEVEL_ZERO_PROVIDER)
         set_property(TEST ${EXAMPLE_NAME} PROPERTY ENVIRONMENT_MODIFICATION
                                                    "${DLL_PATH_LIST}")
     endif()
-    if(LINUX)
-        # prepend LD_LIBRARY_PATH with ${CMAKE_BINARY_DIR}/lib it is required
-        # because ${CMAKE_BINARY_DIR}/lib contains libze_loader.so and tests
-        # should use it instead of system one.
-        set_property(
-            TEST ${EXAMPLE_NAME}
-            PROPERTY ENVIRONMENT_MODIFICATION
-                     "LD_LIBRARY_PATH=path_list_prepend:${CMAKE_BINARY_DIR}/lib"
-        )
-    endif()
 else()
     message(STATUS "GPU Level Zero shared memory example requires "
                    "UMF_BUILD_GPU_EXAMPLES and UMF_BUILD_LEVEL_ZERO_PROVIDER "
                    "to be turned ON - skipping")
 endif()
 
-if(UMF_BUILD_GPU_EXAMPLES
-   AND UMF_BUILD_CUDA_PROVIDER
-   AND UMF_CUDA_ENABLED)
+if(UMF_BUILD_GPU_EXAMPLES AND UMF_CUDA_ENABLED)
     set(EXAMPLE_NAME umf_example_cuda_shared_memory)
 
     add_umf_executable(
@@ -127,7 +116,7 @@ endif()
 # TODO: it looks like there is some problem with IPC implementation in Level
 # Zero on windows
 if(UMF_BUILD_GPU_EXAMPLES
-   AND UMF_BUILD_LEVEL_ZERO_PROVIDER
+   AND UMF_LEVEL_ZERO_ENABLED
    AND LINUX)
     set(EXAMPLE_NAME umf_example_ipc_level_zero)
 
@@ -143,7 +132,8 @@ if(UMF_BUILD_GPU_EXAMPLES
                 ${UMF_CMAKE_SOURCE_DIR}/include
                 ${UMF_CMAKE_SOURCE_DIR}/examples/common)
 
-    target_link_directories(${EXAMPLE_NAME} PRIVATE ${LIBHWLOC_LIBRARY_DIRS})
+    target_link_directories(${EXAMPLE_NAME} PRIVATE ${LIBHWLOC_LIBRARY_DIRS}
+                            ${ZE_LOADER_LIBRARY_DIRS})
 
     add_test(
         NAME ${EXAMPLE_NAME}
@@ -156,16 +146,6 @@ if(UMF_BUILD_GPU_EXAMPLES
         # append PATH to DLLs
         set_property(TEST ${EXAMPLE_NAME} PROPERTY ENVIRONMENT_MODIFICATION
                                                    "${DLL_PATH_LIST}")
-    endif()
-    if(LINUX)
-        # prepend LD_LIBRARY_PATH with ${CMAKE_BINARY_DIR}/lib it is required
-        # because ${CMAKE_BINARY_DIR}/lib contains libze_loader.so and tests
-        # should use it instead of system one.
-        set_property(
-            TEST ${EXAMPLE_NAME}
-            PROPERTY ENVIRONMENT_MODIFICATION
-                     "LD_LIBRARY_PATH=path_list_prepend:${CMAKE_BINARY_DIR}/lib"
-        )
     endif()
 else()
     message(

--- a/examples/cmake/FindZE_LOADER.cmake
+++ b/examples/cmake/FindZE_LOADER.cmake
@@ -1,0 +1,39 @@
+# Copyright (C) 2025 Intel Corporation
+# Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+message(STATUS "Checking for module 'ze_loader' using find_library()")
+
+find_library(ZE_LOADER_LIBRARY NAMES libze_loader ze_loader)
+set(ZE_LOADER_LIBRARIES ${ZE_LOADER_LIBRARY})
+
+find_file(ZE_LOADER_HEADER NAMES "ze_api.h" "level_zero/ze_api.h")
+get_filename_component(ZE_LOADER_INCLUDE_DIR ${ZE_LOADER_HEADER} DIRECTORY)
+set(ZE_LOADER_INCLUDE_DIRS ${ZE_LOADER_INCLUDE_DIR})
+
+get_filename_component(ZE_LOADER_LIB_DIR ${ZE_LOADER_LIBRARIES} DIRECTORY)
+set(ZE_LOADER_LIBRARY_DIRS ${ZE_LOADER_LIB_DIR})
+
+if(WINDOWS)
+    find_file(ZE_LOADER_DLL NAMES "ze_loader.dll")
+    get_filename_component(ZE_LOADER_DLL_DIR ${ZE_LOADER_DLL} DIRECTORY)
+    set(ZE_LOADER_DLL_DIRS ${ZE_LOADER_DLL_DIR})
+endif()
+
+if(ZE_LOADER_LIBRARY)
+    message(STATUS "  Found ZE_LOADER using find_library()")
+    message(STATUS "    ZE_LOADER_LIBRARIES = ${ZE_LOADER_LIBRARIES}")
+    message(STATUS "    ZE_LOADER_INCLUDE_DIRS = ${ZE_LOADER_INCLUDE_DIRS}")
+    message(STATUS "    ZE_LOADER_LIBRARY_DIRS = ${ZE_LOADER_LIBRARY_DIRS}")
+    if(WINDOWS)
+        message(STATUS "    ZE_LOADER_DLL_DIRS = ${ZE_LOADER_DLL_DIRS}")
+    endif()
+else()
+    set(MSG_NOT_FOUND "ZE_LOADER NOT found (set CMAKE_PREFIX_PATH to point the "
+                      "location)")
+    if(ZE_LOADER_FIND_REQUIRED)
+        message(FATAL_ERROR ${MSG_NOT_FOUND})
+    else()
+        message(WARNING ${MSG_NOT_FOUND})
+    endif()
+endif()

--- a/examples/cuda_shared_memory/CMakeLists.txt
+++ b/examples/cuda_shared_memory/CMakeLists.txt
@@ -21,13 +21,11 @@ if(NOT LIBHWLOC_FOUND)
     find_package(LIBHWLOC 2.3.0 REQUIRED hwloc)
 endif()
 
-find_package(CUDA REQUIRED cuda)
-
+# the CUDA headers are fetched from the NVIDIA repository
 include(FetchContent)
 
 set(CUDA_REPO "https://gitlab.com/nvidia/headers/cuda-individual/cudart.git")
 set(CUDA_TAG cuda-12.5.1)
-
 message(STATUS "Fetching CUDA ${CUDA_TAG} from ${CUDA_REPO} ...")
 
 FetchContent_Declare(
@@ -35,28 +33,28 @@ FetchContent_Declare(
     GIT_REPOSITORY ${CUDA_REPO}
     GIT_TAG ${CUDA_TAG}
     EXCLUDE_FROM_ALL)
-FetchContent_MakeAvailable(cuda-headers)
+FetchContent_Populate(cuda-headers)
 
 set(CUDA_INCLUDE_DIRS
     ${cuda-headers_SOURCE_DIR}
     CACHE PATH "Path to CUDA headers")
-message(STATUS "CUDA include directory: ${CUDA_INCLUDE_DIRS}")
+
+find_package(CUDA REQUIRED cuda)
+
+set(CUDA_SM_LIBRARY_DIRS ${LIBUMF_LIBRARY_DIRS} ${LIBHWLOC_LIBRARY_DIRS}
+                         ${CUDA_LIBRARY_DIRS})
+set(CUDA_SM_INCLUDE_DIRS ${CUDA_INCLUDE_DIRS} ${LIBUMF_INCLUDE_DIRS}
+                         ${UMF_EXAMPLE_DIR}/common)
+set(CUDA_SM_LIBS stdc++ ${CUDA_LIBRARIES} ${LIBUMF_LIBRARIES})
 
 # build the example
 set(EXAMPLE_NAME umf_example_cuda_shared_memory)
 add_executable(${EXAMPLE_NAME} cuda_shared_memory.c)
-target_include_directories(
-    ${EXAMPLE_NAME} PRIVATE ${CUDA_INCLUDE_DIRS} ${LIBUMF_INCLUDE_DIRS}
-                            ${UMF_EXAMPLE_DIR}/common)
-target_link_directories(
-    ${EXAMPLE_NAME}
-    PRIVATE
-    ${LIBUMF_LIBRARY_DIRS}
-    ${LIBHWLOC_LIBRARY_DIRS}
-    ${CUDA_LIBRARY_DIRS})
+target_include_directories(${EXAMPLE_NAME} PRIVATE ${CUDA_SM_INCLUDE_DIRS})
+target_link_directories(${EXAMPLE_NAME} PRIVATE ${CUDA_SM_LIBRARY_DIRS})
 target_link_options(${EXAMPLE_NAME} PRIVATE "-Wl,--start-group")
-target_link_libraries(${EXAMPLE_NAME} PRIVATE stdc++ ${CUDA_LIBRARIES}
-                                              ${LIBUMF_LIBRARIES})
+target_link_libraries(${EXAMPLE_NAME} PRIVATE ${CUDA_SM_LIBS})
+target_link_options(${EXAMPLE_NAME} PRIVATE "-Wl,--end-group")
 
 # an optional part - adds a test of this example
 add_test(
@@ -68,10 +66,10 @@ set_tests_properties(${EXAMPLE_NAME} PROPERTIES LABELS "example-standalone")
 
 if(LINUX)
     # set LD_LIBRARY_PATH
+    string(JOIN ":" CUDA_SM_LIBRARY_DIRS_JOINED ${CUDA_SM_LIBRARY_DIRS})
     set_property(
         TEST ${EXAMPLE_NAME}
         PROPERTY
             ENVIRONMENT_MODIFICATION
-            "LD_LIBRARY_PATH=path_list_append:${LIBUMF_LIBRARY_DIRS};LD_LIBRARY_PATH=path_list_append:${LIBHWLOC_LIBRARY_DIRS}"
-    )
+            "LD_LIBRARY_PATH=path_list_append:${CUDA_SM_LIBRARY_DIRS_JOINED}")
 endif()

--- a/examples/ipc_level_zero/CMakeLists.txt
+++ b/examples/ipc_level_zero/CMakeLists.txt
@@ -21,40 +21,29 @@ if(NOT LIBHWLOC_FOUND)
     find_package(LIBHWLOC 2.3.0 REQUIRED hwloc)
 endif()
 
-include(FetchContent)
+pkg_check_modules(ZE_LOADER ze_loader)
+if(NOT ZE_LOADER_FOUND)
+    find_package(ZE_LOADER REQUIRED ze_loader)
+endif()
 
-set(LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
-set(LEVEL_ZERO_LOADER_TAG v1.21.9)
-
-message(
-    STATUS
-        "Fetching L0 loader (${LEVEL_ZERO_LOADER_TAG}) from ${LEVEL_ZERO_LOADER_REPO} ..."
-)
-
-FetchContent_Declare(
-    level-zero-loader
-    GIT_REPOSITORY ${LEVEL_ZERO_LOADER_REPO}
-    GIT_TAG ${LEVEL_ZERO_LOADER_TAG}
-    EXCLUDE_FROM_ALL)
-FetchContent_MakeAvailable(level-zero-loader)
-
-set(LEVEL_ZERO_INCLUDE_DIRS
-    ${level-zero-loader_SOURCE_DIR}/include
-    CACHE PATH "Path to Level Zero Headers")
-message(STATUS "Level Zero include directory: ${LEVEL_ZERO_INCLUDE_DIRS}")
+set(EXAMPLE_NAME umf_example_ipc_level_zero)
+set(IPC_LEVEL_ZERO_SM_LIBRARY_DIRS
+    ${LIBUMF_LIBRARY_DIRS} ${LIBHWLOC_LIBRARY_DIRS} ${ZE_LOADER_LIBRARY_DIRS})
+set(IPC_LEVEL_ZERO_SM_INCLUDE_DIRS
+    ${LIBUMF_INCLUDE_DIRS} ${ZE_LOADER_INCLUDE_DIRS} ${UMF_EXAMPLE_DIR}/common)
 
 # build the example
-set(EXAMPLE_NAME umf_example_ipc_level_zero)
 add_executable(
     ${EXAMPLE_NAME} ipc_level_zero.c
                     ${UMF_EXAMPLE_DIR}/common/examples_level_zero_helpers.c)
-target_include_directories(${EXAMPLE_NAME} PRIVATE ${LIBUMF_INCLUDE_DIRS}
-                                                   ${UMF_EXAMPLE_DIR}/common)
-target_link_directories(${EXAMPLE_NAME} PRIVATE ${LIBUMF_LIBRARY_DIRS}
-                        ${LIBHWLOC_LIBRARY_DIRS})
+target_include_directories(${EXAMPLE_NAME}
+                           PRIVATE ${IPC_LEVEL_ZERO_SM_INCLUDE_DIRS})
+target_link_directories(${EXAMPLE_NAME} PRIVATE
+                        ${IPC_LEVEL_ZERO_SM_LIBRARY_DIRS})
 target_link_options(${EXAMPLE_NAME} PRIVATE "-Wl,--start-group")
 target_link_libraries(${EXAMPLE_NAME} PRIVATE stdc++ ze_loader
                                               ${LIBUMF_LIBRARIES})
+target_link_options(${EXAMPLE_NAME} PRIVATE "-Wl,--end-group")
 
 # an optional part - adds a test of this example
 add_test(
@@ -65,10 +54,13 @@ add_test(
 set_tests_properties(${EXAMPLE_NAME} PROPERTIES LABELS "example-standalone")
 
 if(LINUX)
+    # set LD_LIBRARY_PATH
+    string(JOIN ":" IPC_LEVEL_ZERO_SM_LIBRARY_DIRS_JOINED
+           ${IPC_LEVEL_ZERO_SM_LIBRARY_DIRS})
     set_property(
         TEST ${EXAMPLE_NAME}
         PROPERTY
             ENVIRONMENT_MODIFICATION
-            "LD_LIBRARY_PATH=path_list_prepend:${LIBUMF_LIBRARY_DIRS};LD_LIBRARY_PATH=path_list_append:${LIBHWLOC_LIBRARY_DIRS}"
+            "LD_LIBRARY_PATH=path_list_prepend:${IPC_LEVEL_ZERO_SM_LIBRARY_DIRS_JOINED}"
     )
 endif()

--- a/examples/level_zero_shared_memory/CMakeLists.txt
+++ b/examples/level_zero_shared_memory/CMakeLists.txt
@@ -21,40 +21,28 @@ if(NOT LIBHWLOC_FOUND)
     find_package(LIBHWLOC 2.3.0 REQUIRED hwloc)
 endif()
 
-include(FetchContent)
+pkg_check_modules(ZE_LOADER ze_loader)
+if(NOT ZE_LOADER_FOUND)
+    find_package(ZE_LOADER REQUIRED ze_loader)
+endif()
 
-set(LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
-set(LEVEL_ZERO_LOADER_TAG v1.21.9)
-
-message(
-    STATUS
-        "Fetching L0 loader (${LEVEL_ZERO_LOADER_TAG}) from ${LEVEL_ZERO_LOADER_REPO} ..."
-)
-
-FetchContent_Declare(
-    level-zero-loader
-    GIT_REPOSITORY ${LEVEL_ZERO_LOADER_REPO}
-    GIT_TAG ${LEVEL_ZERO_LOADER_TAG}
-    EXCLUDE_FROM_ALL)
-FetchContent_MakeAvailable(level-zero-loader)
-
-set(LEVEL_ZERO_INCLUDE_DIRS
-    ${level-zero-loader_SOURCE_DIR}/include
-    CACHE PATH "Path to Level Zero Headers")
-message(STATUS "Level Zero include directory: ${LEVEL_ZERO_INCLUDE_DIRS}")
+set(EXAMPLE_NAME umf_example_level_zero_shared_memory)
+set(LEVEL_ZERO_SM_LIBRARY_DIRS ${LIBUMF_LIBRARY_DIRS} ${LIBHWLOC_LIBRARY_DIRS}
+                               ${ZE_LOADER_LIBRARY_DIRS})
 
 # build the example
-set(EXAMPLE_NAME umf_example_level_zero_shared_memory)
 add_executable(
     ${EXAMPLE_NAME} level_zero_shared_memory.c
                     ${UMF_EXAMPLE_DIR}/common/examples_level_zero_helpers.c)
-target_include_directories(${EXAMPLE_NAME} PRIVATE ${LIBUMF_INCLUDE_DIRS}
-                                                   ${UMF_EXAMPLE_DIR}/common)
-target_link_directories(${EXAMPLE_NAME} PRIVATE ${LIBUMF_LIBRARY_DIRS}
-                        ${LIBHWLOC_LIBRARY_DIRS})
+
+target_include_directories(
+    ${EXAMPLE_NAME} PRIVATE ${LIBUMF_INCLUDE_DIRS} ${ZE_LOADER_INCLUDE_DIRS}
+                            ${UMF_EXAMPLE_DIR}/common)
+target_link_directories(${EXAMPLE_NAME} PRIVATE ${LEVEL_ZERO_SM_LIBRARY_DIRS})
 target_link_options(${EXAMPLE_NAME} PRIVATE "-Wl,--start-group")
 target_link_libraries(${EXAMPLE_NAME} PRIVATE stdc++ ze_loader
                                               ${LIBUMF_LIBRARIES})
+target_link_options(${EXAMPLE_NAME} PRIVATE "-Wl,--end-group")
 
 # an optional part - adds a test of this example
 add_test(
@@ -66,10 +54,12 @@ set_tests_properties(${EXAMPLE_NAME} PROPERTIES LABELS "example-standalone")
 
 if(LINUX)
     # set LD_LIBRARY_PATH
+    string(JOIN ":" LEVEL_ZERO_SM_LIBRARY_DIRS_JOINED
+           ${LEVEL_ZERO_SM_LIBRARY_DIRS})
     set_property(
         TEST ${EXAMPLE_NAME}
         PROPERTY
             ENVIRONMENT_MODIFICATION
-            "LD_LIBRARY_PATH=path_list_prepend:${LIBUMF_LIBRARY_DIRS};LD_LIBRARY_PATH=path_list_append:${LIBHWLOC_LIBRARY_DIRS}"
+            "LD_LIBRARY_PATH=path_list_append:${LEVEL_ZERO_SM_LIBRARY_DIRS_JOINED}"
     )
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,13 +50,14 @@ function(build_umf_test)
 
     set(LIB_DIRS ${LIB_DIRS} ${LIBHWLOC_LIBRARY_DIRS})
 
-    if(UMF_BUILD_CUDA_PROVIDER)
+    if(UMF_CUDA_ENABLED)
         set(INC_DIRS ${INC_DIRS} ${CUDA_INCLUDE_DIRS})
         set(LIB_DIRS ${LIB_DIRS} ${CUDA_LIBRARY_DIRS})
     endif()
 
-    if(UMF_BUILD_LEVEL_ZERO_PROVIDER)
+    if(UMF_LEVEL_ZERO_ENABLED)
         set(INC_DIRS ${INC_DIRS} ${LEVEL_ZERO_INCLUDE_DIRS})
+        set(LIB_DIRS ${LIB_DIRS} ${ZE_LOADER_LIBRARY_DIRS})
     endif()
 
     if(NOT UMF_DISABLE_HWLOC)
@@ -153,16 +154,6 @@ function(add_umf_test)
         # append PATH to DLLs
         set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT_MODIFICATION
                                                 "${DLL_PATH_LIST}")
-    endif()
-    if(LINUX)
-        # prepend LD_LIBRARY_PATH with ${CMAKE_BINARY_DIR}/lib it is required
-        # because ${CMAKE_BINARY_DIR}/lib contains libze_loader.so and tests
-        # should use it instead of system one.
-        set_property(
-            TEST ${TEST_NAME}
-            PROPERTY ENVIRONMENT_MODIFICATION
-                     "LD_LIBRARY_PATH=path_list_prepend:${CMAKE_BINARY_DIR}/lib"
-        )
     endif()
 endfunction()
 
@@ -412,7 +403,7 @@ if(UMF_DISABLE_HWLOC)
         LIBS ${UMF_UTILS_FOR_TEST})
 endif()
 
-if(UMF_BUILD_GPU_TESTS AND UMF_BUILD_LEVEL_ZERO_PROVIDER)
+if(UMF_BUILD_GPU_TESTS AND UMF_LEVEL_ZERO_ENABLED)
     # we have two test binaries here that use the same sources, but differ in
     # the way they are linked to the Level Zero (statically or at runtime using
     # dlopen)
@@ -575,16 +566,6 @@ function(add_umf_ipc_test)
     if(NOT UMF_TESTS_FAIL_ON_SKIP)
         set_tests_properties(${TEST_NAME} PROPERTIES SKIP_RETURN_CODE 125)
     endif()
-    if(LINUX)
-        # prepend LD_LIBRARY_PATH with ${CMAKE_BINARY_DIR}/lib it is required
-        # because ${CMAKE_BINARY_DIR}/lib contains libze_loader.so and tests
-        # should use it instead of system one.
-        set_property(
-            TEST ${TEST_NAME}
-            PROPERTY ENVIRONMENT_MODIFICATION
-                     "LD_LIBRARY_PATH=path_list_prepend:${CMAKE_BINARY_DIR}/lib"
-        )
-    endif()
 endfunction()
 
 if(LINUX)
@@ -632,7 +613,7 @@ if(LINUX)
 
     # TODO add IPC tests for CUDA
 
-    if(UMF_BUILD_GPU_TESTS AND UMF_BUILD_LEVEL_ZERO_PROVIDER)
+    if(UMF_BUILD_GPU_TESTS AND UMF_LEVEL_ZERO_ENABLED)
         build_umf_test(
             NAME ipc_level_zero_prov_consumer
             SRCS providers/ipc_level_zero_prov_consumer.c common/ipc_common.c
@@ -712,7 +693,7 @@ if(LINUX
         )
     endif()
 
-    if(UMF_BUILD_GPU_EXAMPLES AND UMF_BUILD_LEVEL_ZERO_PROVIDER)
+    if(UMF_BUILD_GPU_EXAMPLES AND UMF_LEVEL_ZERO_ENABLED)
         set(EXAMPLES ${EXAMPLES} level_zero_shared_memory)
     else()
         message(
@@ -721,9 +702,7 @@ if(LINUX
                 "UMF_BUILD_LEVEL_ZERO_PROVIDER to be turned ON - skipping")
     endif()
 
-    if(UMF_BUILD_GPU_EXAMPLES
-       AND UMF_BUILD_CUDA_PROVIDER
-       AND UMF_CUDA_ENABLED)
+    if(UMF_BUILD_GPU_EXAMPLES AND UMF_CUDA_ENABLED)
         set(EXAMPLES ${EXAMPLES} cuda_shared_memory)
     else()
         message(
@@ -734,7 +713,7 @@ if(LINUX
     endif()
 
     # TODO add IPC examples for CUDA
-    if(UMF_BUILD_GPU_EXAMPLES AND UMF_BUILD_LEVEL_ZERO_PROVIDER)
+    if(UMF_BUILD_GPU_EXAMPLES AND UMF_LEVEL_ZERO_ENABLED)
         set(EXAMPLES ${EXAMPLES} ipc_level_zero)
     else()
         message(
@@ -780,15 +759,5 @@ if(LINUX
                 "${CMAKE_INSTALL_PREFIX}" "${STANDALONE_CMAKE_OPTIONS}"
                 ${EXAMPLES}
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-        if(LINUX)
-            # prepend LD_LIBRARY_PATH with ${CMAKE_BINARY_DIR}/lib it is
-            # required because ${CMAKE_BINARY_DIR}/lib contains libze_loader.so
-            # and tests should use it instead of system one.
-            set_property(
-                TEST umf-standalone_examples
-                PROPERTY
-                    ENVIRONMENT_MODIFICATION
-                    "LD_LIBRARY_PATH=path_list_prepend:${CMAKE_BINARY_DIR}/lib")
-        endif()
     endif()
 endif()

--- a/test/test_installation.py
+++ b/test/test_installation.py
@@ -181,8 +181,10 @@ class UmfInstaller:
                     f"Error: Installation directory '{self.install_dir}' is not empty"
                 )
 
-        install_cmd = f"cmake --install {self.build_dir} --config {self.build_type.title()} --prefix {self.install_dir}"
+        install_cmd = f"cmake --build {self.build_dir} --config {self.build_type.title()} --target install"
+
         try:
+            print(f"Running command: {install_cmd}", flush=True)
             subprocess.run(install_cmd.split()).check_returncode()  # nosec B603
         except subprocess.CalledProcessError:
             sys.exit(f"Error: UMF installation command '{install_cmd}' failed")


### PR DESCRIPTION
Never build and install ze_loader by using FetchContent_Populate instead of MakeAvailable. After this change, we have to find ze_loader installed on the system instead of using the one built by us. 
Additionally, add testing cmake 3.14, which is the oldest supported version by UMF.

Example of failed installation/deinstallation test (requires using CMake 3.14.0):
https://github.com/oneapi-src/unified-memory-framework/actions/runs/14692346477/job/41229764121?pr=1285

fixes: https://github.com/oneapi-src/unified-memory-framework/issues/1110