### PR TITLE
Downgrade error logs to debug in memspaces and memtargets

### DIFF
--- a/src/memspaces/memspace_highest_bandwidth.c
+++ b/src/memspaces/memspace_highest_bandwidth.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2024 Intel Corporation
+ * Copyright (C) 2024-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -102,7 +102,7 @@ static void umfMemspaceHighestBandwidthInit(void) {
     umf_result_t ret =
         umfMemspaceHighestBandwidthCreate(&UMF_MEMSPACE_HIGHEST_BANDWIDTH);
     if (ret != UMF_RESULT_SUCCESS) {
-        LOG_ERR(
+        LOG_DEBUG(
             "Creating the highest bandwidth memspace failed with the error: %u",
             ret);
         assert(ret == UMF_RESULT_ERROR_NOT_SUPPORTED);

--- a/src/memspaces/memspace_lowest_latency.c
+++ b/src/memspaces/memspace_lowest_latency.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2024 Intel Corporation
+ * Copyright (C) 2024-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -98,7 +98,7 @@ static void umfMemspaceLowestLatencyInit(void) {
     umf_result_t ret =
         umfMemspaceLowestLatencyCreate(&UMF_MEMSPACE_LOWEST_LATENCY);
     if (ret != UMF_RESULT_SUCCESS) {
-        LOG_ERR(
+        LOG_DEBUG(
             "Creating the lowest latency memspace failed with the error: %u",
             ret);
         assert(ret == UMF_RESULT_ERROR_NOT_SUPPORTED);

--- a/src/memtargets/memtarget_numa.c
+++ b/src/memtargets/memtarget_numa.c
@@ -309,8 +309,8 @@ static umf_result_t query_attribute_value(void *srcMemoryTarget,
     int ret = hwloc_memattr_get_value(topology, hwlocMemAttrType, dstNumaNode,
                                       &initiator, 0, &memAttrValue);
     if (ret) {
-        LOG_PERR("Getting an attribute value for a specific target NUMA node "
-                 "failed");
+        LOG_PDEBUG("Getting an attribute value for a specific target NUMA node "
+                   "failed");
         return (errno == EINVAL) ? UMF_RESULT_ERROR_NOT_SUPPORTED
                                  : UMF_RESULT_ERROR_UNKNOWN;
     }
@@ -330,9 +330,10 @@ static umf_result_t numa_get_bandwidth(void *srcMemoryTarget,
     umf_result_t ret = query_attribute_value(srcMemoryTarget, dstMemoryTarget,
                                              bandwidth, MEMATTR_TYPE_BANDWIDTH);
     if (ret) {
-        LOG_ERR("Retrieving bandwidth for initiator node %u to node %u failed.",
-                ((struct numa_memtarget_t *)srcMemoryTarget)->physical_id,
-                ((struct numa_memtarget_t *)dstMemoryTarget)->physical_id);
+        LOG_DEBUG(
+            "Retrieving bandwidth for initiator node %u to node %u failed.",
+            ((struct numa_memtarget_t *)srcMemoryTarget)->physical_id,
+            ((struct numa_memtarget_t *)dstMemoryTarget)->physical_id);
         return ret;
     }
 
@@ -348,9 +349,9 @@ static umf_result_t numa_get_latency(void *srcMemoryTarget,
     umf_result_t ret = query_attribute_value(srcMemoryTarget, dstMemoryTarget,
                                              latency, MEMATTR_TYPE_LATENCY);
     if (ret) {
-        LOG_ERR("Retrieving latency for initiator node %u to node %u failed.",
-                ((struct numa_memtarget_t *)srcMemoryTarget)->physical_id,
-                ((struct numa_memtarget_t *)dstMemoryTarget)->physical_id);
+        LOG_DEBUG("Retrieving latency for initiator node %u to node %u failed.",
+                  ((struct numa_memtarget_t *)srcMemoryTarget)->physical_id,
+                  ((struct numa_memtarget_t *)dstMemoryTarget)->physical_id);
         return ret;
     }
 


### PR DESCRIPTION
They are misleadingly read as errors, while they are simply debug information that these targets aren't accessible on a machine.