### PR TITLE
Remove redundant asserts in umfMemspace*Init

### DIFF
--- a/src/memspaces/memspace_highest_bandwidth.c
+++ b/src/memspaces/memspace_highest_bandwidth.c
@@ -105,7 +105,11 @@ static void umfMemspaceHighestBandwidthInit(void) {
         LOG_DEBUG(
             "Creating the highest bandwidth memspace failed with the error: %u",
             ret);
-        assert(ret == UMF_RESULT_ERROR_NOT_SUPPORTED);
+        if (ret != UMF_RESULT_ERROR_NOT_SUPPORTED) {
+            LOG_FATAL("Unknown error, expected "
+                      "'UMF_RESULT_ERROR_NOT_SUPPORTED', got: %u",
+                      ret);
+        }
     }
 }
 

--- a/src/memspaces/memspace_lowest_latency.c
+++ b/src/memspaces/memspace_lowest_latency.c
@@ -101,7 +101,11 @@ static void umfMemspaceLowestLatencyInit(void) {
         LOG_DEBUG(
             "Creating the lowest latency memspace failed with the error: %u",
             ret);
-        assert(ret == UMF_RESULT_ERROR_NOT_SUPPORTED);
+        if (ret != UMF_RESULT_ERROR_NOT_SUPPORTED) {
+            LOG_FATAL("Unknown error, expected "
+                      "'UMF_RESULT_ERROR_NOT_SUPPORTED', got: %u",
+                      ret);
+        }
     }
 
 #if defined(_WIN32) && !defined(UMF_SHARED_LIBRARY)


### PR DESCRIPTION
// found in https://github.com/oneapi-src/unified-memory-framework/pull/1287