### PR TITLE
[CI] Add pip's venv into PATH in benchmarks' workflow

### DIFF
--- a/.github/workflows/reusable_benchmarks.yml
+++ b/.github/workflows/reusable_benchmarks.yml
@@ -130,6 +130,7 @@ jobs:
       run: |
         python -m venv .venv
         source .venv/bin/activate
+        echo "$PATH" >> $GITHUB_PATH
         pip install -r ${{github.workspace}}/sc/devops/scripts/benchmarks/requirements.txt
 
     - name: Set core range and GPU mask
@@ -153,7 +154,6 @@ jobs:
     - name: Run UMF benchmarks
       id: benchmarks
       run: >
-        source .venv/bin/activate &&
         taskset -c ${{ env.CORES }} ./sc/devops/scripts/benchmarks/main.py
         ~/bench_workdir_umf
         --umf ${{env.BUILD_DIR}}


### PR DESCRIPTION
All steps should be able to use the packages installed via venv.

// Fixing e.g. https://github.com/oneapi-src/unified-memory-framework/actions/runs/14616987712/job/41010729651?pr=1284
// `ModuleNotFoundError: No module named 'dataclasses_json'` found in "Commit data.json and results directory" step.



Preview: [link](https://github.com/oneapi-src/unified-memory-framework/actions/runs/14756725275/job/41426780573?pr=1293)
// while the run is still red, it's not because of missing package (on PR, the bot's token is not capable of writing stuff)