### PR TITLE
[v0.11.x] Check global state destruction in destructors

### DIFF
--- a/src/memory_pool.c
+++ b/src/memory_pool.c
@@ -85,6 +85,10 @@ err_provider_create:
 }
 
 void umfPoolDestroy(umf_memory_pool_handle_t hPool) {
+    if (umf_ba_global_is_destroyed()) {
+        return;
+    }
+
     hPool->ops.finalize(hPool->pool_priv);
 
     umf_memory_provider_handle_t hUpstreamProvider = NULL;

--- a/src/memory_provider.c
+++ b/src/memory_provider.c
@@ -194,7 +194,7 @@ umf_result_t umfMemoryProviderCreate(const umf_memory_provider_ops_t *ops,
 }
 
 void umfMemoryProviderDestroy(umf_memory_provider_handle_t hProvider) {
-    if (hProvider) {
+    if (hProvider && !umf_ba_global_is_destroyed()) {
         hProvider->ops.finalize(hProvider->provider_priv);
         umf_ba_global_free(hProvider);
     }


### PR DESCRIPTION
cherry-pick https://github.com/oneapi-src/unified-memory-framework/pull/1296 to stable v0.11.x