### PR TITLE
do not use FetchContent_Populate in CMake >= 3.28

### DIFF
--- a/.github/workflows/reusable_basic.yml
+++ b/.github/workflows/reusable_basic.yml
@@ -26,7 +26,7 @@ jobs:
         install_tbb: ['ON']
         disable_hwloc: ['OFF']
         link_hwloc_statically: ['OFF']
-        cmake_ver: ['latest']
+        cmake_ver: ['default']
         include:
           - os: 'ubuntu-22.04'
             build_type: Release
@@ -48,7 +48,7 @@ jobs:
             install_tbb: 'ON'
             disable_hwloc: 'OFF'
             link_hwloc_statically: 'OFF'
-            cmake_ver: 'latest'
+            cmake_ver: '3.28.0'
           - os: 'ubuntu-24.04'
             build_type: Debug
             compiler: {c: gcc, cxx: g++}
@@ -58,7 +58,7 @@ jobs:
             install_tbb: 'ON'
             disable_hwloc: 'OFF'
             link_hwloc_statically: 'OFF'
-            cmake_ver: 'latest'
+            cmake_ver: 'default'
           # test level_zero_provider='OFF' and cuda_provider='OFF'
           - os: 'ubuntu-22.04'
             build_type: Release
@@ -69,7 +69,7 @@ jobs:
             install_tbb: 'ON'
             disable_hwloc: 'OFF'
             link_hwloc_statically: 'OFF'
-            cmake_ver: 'latest'
+            cmake_ver: 'default'
           # test icx compiler
           - os: 'ubuntu-22.04'
             build_type: Release
@@ -80,7 +80,7 @@ jobs:
             install_tbb: 'ON'
             disable_hwloc: 'OFF'
             link_hwloc_statically: 'OFF'
-            cmake_ver: 'latest'
+            cmake_ver: 'default'
           # test lld linker
           - os: 'ubuntu-24.04'
             build_type: Release
@@ -92,7 +92,7 @@ jobs:
             disable_hwloc: 'OFF'
             link_hwloc_statically: 'OFF'
             llvm_linker: '-DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" -DCMAKE_MODULE_LINKER_FLAGS="-fuse-ld=lld" -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld"'
-            cmake_ver: 'latest'
+            cmake_ver: 'default'
             # test without installing TBB
           - os: 'ubuntu-22.04'
             build_type: Release
@@ -103,7 +103,7 @@ jobs:
             install_tbb: 'OFF'
             disable_hwloc: 'OFF'
             link_hwloc_statically: 'OFF'
-            cmake_ver: 'latest'
+            cmake_ver: 'default'
           - os: 'ubuntu-22.04'
             build_type: Debug
             compiler: {c: gcc, cxx: g++}
@@ -113,7 +113,7 @@ jobs:
             install_tbb: 'ON'
             disable_hwloc: 'ON'
             link_hwloc_statically: 'OFF'
-            cmake_ver: 'latest'
+            cmake_ver: 'default'
           - os: 'ubuntu-22.04'
             build_type: Release
             compiler: {c: gcc, cxx: g++}
@@ -123,7 +123,7 @@ jobs:
             install_tbb: 'ON'
             disable_hwloc: 'OFF'
             link_hwloc_statically: 'ON'
-            cmake_ver: 'latest'
+            cmake_ver: 'default'
     runs-on: ${{matrix.os}}
 
     steps:
@@ -137,8 +137,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y clang libnuma-dev lcov
 
-    - name: Install cmake (minimum supported version)
-      if: matrix.cmake_ver != 'latest'
+    - name: Install cmake (non-default version)
+      if: matrix.cmake_ver != 'default'
       run: |
         sudo apt-get remove --purge -y cmake
         wget https://github.com/Kitware/CMake/releases/download/v${{matrix.cmake_ver}}/cmake-${{matrix.cmake_ver}}-Linux-x86_64.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,13 +412,24 @@ if(UMF_BUILD_LEVEL_ZERO_PROVIDER)
 
         message(STATUS "Fetching Level Zero loader (${LEVEL_ZERO_LOADER_TAG}) "
                        "from ${LEVEL_ZERO_LOADER_REPO} ...")
-        FetchContent_Declare(
-            level-zero-loader
-            GIT_REPOSITORY ${LEVEL_ZERO_LOADER_REPO}
-            GIT_TAG ${LEVEL_ZERO_LOADER_TAG}
-            EXCLUDE_FROM_ALL)
-        # Only populate the repo - we don't need to build it
-        FetchContent_Populate(level-zero-loader)
+
+        # We don't want to build and include Level Zero binaries to our install
+        # target. For CMake >= 3.28 we use EXCLUDE_FROM_ALL flag to do that, but
+        # for older versions we need to use FetchContent_Populate.
+        if(CMAKE_VERSION VERSION_LESS 3.28)
+            FetchContent_Declare(
+                level-zero-loader
+                GIT_REPOSITORY ${LEVEL_ZERO_LOADER_REPO}
+                GIT_TAG ${LEVEL_ZERO_LOADER_TAG})
+            FetchContent_Populate(level-zero-loader)
+        else()
+            FetchContent_Declare(
+                level-zero-loader
+                GIT_REPOSITORY ${LEVEL_ZERO_LOADER_REPO}
+                GIT_TAG ${LEVEL_ZERO_LOADER_TAG}
+                EXCLUDE_FROM_ALL)
+            FetchContent_MakeAvailable(level-zero-loader)
+        endif()
 
         set(LEVEL_ZERO_INCLUDE_DIRS
             ${level-zero-loader_SOURCE_DIR}/include
@@ -457,13 +468,24 @@ if(UMF_BUILD_CUDA_PROVIDER)
 
         message(
             STATUS "Fetching CUDA (${CUDA_TAG}) headers from ${CUDA_REPO} ...")
-        FetchContent_Declare(
-            cuda-headers
-            GIT_REPOSITORY ${CUDA_REPO}
-            GIT_TAG ${CUDA_TAG}
-            EXCLUDE_FROM_ALL)
-        # Only populate the repo - we don't need to build it
-        FetchContent_Populate(cuda-headers)
+
+        # We don't want to build and include CUDA binaries to our install
+        # target. For CMake >= 3.28 we could use EXCLUDE_FROM_ALL flag to do
+        # that, but for older versions we need to use FetchContent_Populate.
+        if(CMAKE_VERSION VERSION_LESS 3.28)
+            FetchContent_Declare(
+                cuda-headers
+                GIT_REPOSITORY ${CUDA_REPO}
+                GIT_TAG ${CUDA_TAG})
+            FetchContent_Populate(cuda-headers)
+        else()
+            FetchContent_Declare(
+                cuda-headers
+                GIT_REPOSITORY ${CUDA_REPO}
+                GIT_TAG ${CUDA_TAG}
+                EXCLUDE_FROM_ALL)
+            FetchContent_MakeAvailable(cuda-headers)
+        endif()
 
         set(CUDA_INCLUDE_DIRS
             ${cuda-headers_SOURCE_DIR}

--- a/examples/cuda_shared_memory/CMakeLists.txt
+++ b/examples/cuda_shared_memory/CMakeLists.txt
@@ -28,12 +28,23 @@ set(CUDA_REPO "https://gitlab.com/nvidia/headers/cuda-individual/cudart.git")
 set(CUDA_TAG cuda-12.5.1)
 message(STATUS "Fetching CUDA ${CUDA_TAG} from ${CUDA_REPO} ...")
 
-FetchContent_Declare(
-    cuda-headers
-    GIT_REPOSITORY ${CUDA_REPO}
-    GIT_TAG ${CUDA_TAG}
-    EXCLUDE_FROM_ALL)
-FetchContent_Populate(cuda-headers)
+# We don't want to build and include CUDA binaries to our install target. For
+# CMake >= 3.28 we use EXCLUDE_FROM_ALL flag to do that, but for older versions
+# we need to use FetchContent_Populate.
+if(CMAKE_VERSION VERSION_LESS 3.28)
+    FetchContent_Declare(
+        cuda-headers
+        GIT_REPOSITORY ${CUDA_REPO}
+        GIT_TAG ${CUDA_TAG})
+    FetchContent_Populate(cuda-headers)
+else()
+    FetchContent_Declare(
+        cuda-headers
+        GIT_REPOSITORY ${CUDA_REPO}
+        GIT_TAG ${CUDA_TAG}
+        EXCLUDE_FROM_ALL)
+    FetchContent_MakeAvailable(cuda-headers)
+endif()
 
 set(CUDA_INCLUDE_DIRS
     ${cuda-headers_SOURCE_DIR}


### PR DESCRIPTION
Starting with CMake 3.30, FetchContent_Populate is deprecated. It can be replaced by FetchContent_Declare(... EXCLUDE_FROM_ALL) + FetchContent_MakeAvailable(). However, the EXCLUDE_FROM_ALL flag is available only from CMake 3.28 

This pull request checks the CMake version, and for versions <= 3.28, we use FetchContent_Populate, and for later versions, we use EXCLUDE_FROM_ALL + FetchContent_MakeAvailable.

example logs with different CMake versions:

CMake 3.14.0
https://github.com/oneapi-src/unified-memory-framework/actions/runs/14906699261/job/41871908648?pr=1300

CMake 3.29.0
https://github.com/oneapi-src/unified-memory-framework/actions/runs/14906699261/job/41871908635?pr=1300

CMake latest (3.31.6)
https://github.com/oneapi-src/unified-memory-framework/actions/runs/14906699261/job/41871908632?pr=1300

fixes https://github.com/oneapi-src/unified-memory-framework/issues/971