### PR TITLE
Print time of tests run under valgrind

### DIFF
--- a/test/test_valgrind.sh
+++ b/test/test_valgrind.sh
@@ -154,7 +154,7 @@ for test in $TESTS; do
 
 	LAST_TEST_FAILED=0
 	set +e
-	HWLOC_CPUID_PATH=./cpuid valgrind $OPTION $OPT_SUP --gen-suppressions=all $test $FILTER >$LOG 2>&1
+	HWLOC_CPUID_PATH=./cpuid time valgrind $OPTION $OPT_SUP --gen-suppressions=all $test $FILTER >$LOG 2>&1
 	RET=$?
 	set -e
 	# 125 is the return code when the test is skipped
@@ -172,9 +172,11 @@ for test in $TESTS; do
 	grep -e "ERROR SUMMARY:" $LOG | grep -v -e "ERROR SUMMARY: 0 errors from 0 contexts" > $ERR || true
 	if [ $LAST_TEST_FAILED -eq 0 -a $(cat $ERR | wc -l) -eq 0 ]; then
 		[ $RET -eq 0 ] && echo "- OK" || echo "- SKIPPED"
+		tail -n2 $LOG || true # print out the output of the "time" command
 		rm -f $LOG $ERR
 	else
 		echo "- FAILED!"
+		tail -n2 $LOG || true # print out the output of the "time" command
 		cat $ERR | cut -d' ' -f2-
 		ANY_TEST_FAILED=1
 	fi || true


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

Print time of tests run under valgrind.

An example of output:
https://github.com/ldorau/unified-memory-framework/actions/runs/14906349518/job/41869531562
```
./test/test_ipc - starting ...
./test/test_ipc (drd-test_ipc.supp) - OK
352.32user 0.20system 5:52.62elapsed 99%CPU (0avgtext+0avgdata 370696maxresident)k
0inputs+96outputs (0major+50817minor)pagefaults 0swaps
```

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
