### PR TITLE
retrieve numanode object by os index instead of logical index.

### DIFF
--- a/src/memtargets/memtarget_numa.c
+++ b/src/memtargets/memtarget_numa.c
@@ -263,17 +263,15 @@ static umf_result_t query_attribute_value(void *srcMemoryTarget,
         return UMF_RESULT_ERROR_NOT_SUPPORTED;
     }
 
-    hwloc_obj_t srcNumaNode = hwloc_get_obj_by_type(
-        topology, HWLOC_OBJ_NUMANODE,
-        ((struct numa_memtarget_t *)srcMemoryTarget)->physical_id);
+    hwloc_obj_t srcNumaNode = hwloc_get_numanode_obj_by_os_index(
+        topology, ((struct numa_memtarget_t *)srcMemoryTarget)->physical_id);
     if (!srcNumaNode) {
         LOG_PERR("Getting HWLOC object by type failed");
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;
     }
 
-    hwloc_obj_t dstNumaNode = hwloc_get_obj_by_type(
-        topology, HWLOC_OBJ_NUMANODE,
-        ((struct numa_memtarget_t *)dstMemoryTarget)->physical_id);
+    hwloc_obj_t dstNumaNode = hwloc_get_numanode_obj_by_os_index(
+        topology, ((struct numa_memtarget_t *)dstMemoryTarget)->physical_id);
     if (!dstNumaNode) {
         LOG_PERR("Getting HWLOC object by type failed");
         return UMF_RESULT_ERROR_INVALID_ARGUMENT;


### PR DESCRIPTION
physical_id field stores os index, so we should use correct function to get hwloc numanode object.

fixes: #1289

<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
- [ ] All API changes are reflected in docs and def/map files, and are tested
