### PR TITLE
use --install in installation tests on Windows

### DIFF
--- a/.github/workflows/reusable_basic.yml
+++ b/.github/workflows/reusable_basic.yml
@@ -239,6 +239,7 @@ jobs:
     name: Windows
     env:
       VCPKG_PATH: "${{github.workspace}}/build/vcpkg/packages/hwloc_x64-windows;${{github.workspace}}/build/vcpkg/packages/tbb_x64-windows;${{github.workspace}}/build/vcpkg/packages/jemalloc_x64-windows"
+      VCPKG_PATH_BIN: "${{github.workspace}}/build/vcpkg/packages/hwloc_x64-windows/bin;${{github.workspace}}/build/vcpkg/packages/tbb_x64-windows/bin;${{github.workspace}}/build/vcpkg/packages/jemalloc_x64-windows/bin"
     strategy:
       matrix:
         os: ['windows-2019', 'windows-2022']
@@ -247,6 +248,7 @@ jobs:
         shared_library: ['ON', 'OFF']
         level_zero_provider: ['ON']
         cuda_provider: ['ON']
+        cmake_ver: ['default']
         include:
           - os: 'windows-2019'
             # clang build fails on Windows 2022
@@ -256,6 +258,7 @@ jobs:
             level_zero_provider: 'ON'
             cuda_provider: 'ON'
             toolset: "-T ClangCL"
+            cmake_ver: '3.14.0-win64-x64'
           - os: 'windows-2022'
             build_type: Release
             compiler: {c: cl, cxx: cl}
@@ -263,12 +266,14 @@ jobs:
             level_zero_provider: 'ON'
             cuda_provider: 'ON'
             umfd_lib: 'ON'
+            cmake_ver: '3.28.0-windows-x86_64'
           - os: 'windows-2022'
             build_type: Release
             compiler: {c: cl, cxx: cl}
             shared_library: 'ON'
             level_zero_provider: 'OFF'
             cuda_provider: 'OFF'
+            cmake_ver: 'default'
 
     runs-on: ${{matrix.os}}
 
@@ -278,6 +283,25 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Install cmake (non-default version)
+      if: matrix.cmake_ver != 'default'
+      run: |
+        $ErrorActionPreference = "Stop"
+        $cmakePath = "C:\Program Files\CMake"
+        if (Test-Path -Path $cmakePath) {
+          Write-Host "Removing existing CMake installation..."
+          Remove-Item -Recurse -Force -Path $cmakePath
+        }
+        $cmakeInstaller = "cmake-${{matrix.cmake_ver}}.msi"
+        $cmakeInstallerParts = $cmakeInstaller -split '-|\.'
+        $cmakeMajorMinorPatch = "$($cmakeInstallerParts[1]).$($cmakeInstallerParts[2]).$($cmakeInstallerParts[3])"
+        $cmakeUrl = "https://github.com/Kitware/CMake/releases/download/v$cmakeMajorMinorPatch/$cmakeInstaller"
+        Write-Host "Downloading CMake version ${{matrix.cmake_ver}}..."
+        Invoke-WebRequest -Uri $cmakeUrl -OutFile $cmakeInstaller -TimeoutSec 360
+        Write-Host "Installing CMake version ${{matrix.cmake_ver}}..."
+        Start-Process msiexec.exe -ArgumentList "/i $cmakeInstaller /quiet /norestart" -Wait
+        cmake --version
+
     - name: Initialize vcpkg
       uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5
       with:
@@ -285,8 +309,13 @@ jobs:
         vcpkgDirectory: ${{env.BUILD_DIR}}/vcpkg
         vcpkgJsonGlob: '**/vcpkg.json'
 
+    # Install the dependencies and add the bin folders to the PATH for older
+    # versions of CMake to correctly locate the libraries
     - name: Install dependencies
-      run: vcpkg install --triplet x64-windows
+      run: |
+        vcpkg install --triplet x64-windows        
+        $env:Path = "${{env.VCPKG_PATH_BIN}};$env:Path"
+        echo "PATH=$env:Path" >> $env:GITHUB_ENV
       shell: pwsh # Specifies PowerShell as the shell for running the script.
 
     - name: Get UMF version
@@ -318,10 +347,23 @@ jobs:
 
     - name: Run tests
       working-directory: ${{env.BUILD_DIR}}
-      run: ctest -C ${{matrix.build_type}} --output-on-failure --test-dir test
+      # For CMake versions < 3.22 we have to add the build directory to the PATH
+      # manually
+      run: |
+        $m = [regex]::Matches((cmake --version), "cmake version (\d+)\.(\d+)\.(\d+)")
+        if ($m) {
+          $major = [int]$m.groups[1].Value
+          $minor = [int]$m.groups[2].Value
+          if ($major -lt 3 -or ($major -eq 3 -and $minor -lt 22)) {
+            $env:Path = "${{env.BUILD_DIR}}/bin/${{matrix.build_type}};${{env.BUILD_DIR}}/src/proxy_lib/${{matrix.build_type}};$env:Path"
+          }
+        }
+        ctest -C ${{matrix.build_type}} --output-on-failure --test-dir test
+      shell: pwsh
 
     - name: Test UMF installation and uninstallation
-      # The '--shared-library' parameter is added to the installation test when the UMF is built as a shared library
+      # The '--shared-library' parameter is added to the installation test when
+      # the UMF is built as a shared library
       run: >
         python3 ${{github.workspace}}/test/test_installation.py
         --build-dir ${{env.BUILD_DIR}}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -151,7 +151,9 @@ function(add_umf_test)
             "${DLL_PATH_LIST};PATH=path_list_append:${CMAKE_BINARY_DIR}/bin/;PATH=path_list_append:${CMAKE_BINARY_DIR}/bin/$<CONFIG>/"
         )
 
-        # append PATH to DLLs
+        # append PATH to DLLs NOTE: this would work only for the CMake ver >= #
+        # 3.22. For the older versions, the PATH variable should be set in the
+        # test script)
         set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT_MODIFICATION
                                                 "${DLL_PATH_LIST}")
     endif()

--- a/test/coarse_lib.cpp
+++ b/test/coarse_lib.cpp
@@ -145,27 +145,27 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_basic_provider) {
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     umf_result = coarse_alloc(ch, 2 * MB, 0, (void **)&ptr);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
     ASSERT_NE(ptr, nullptr);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 2 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 2);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)2);
 
     umf_result = coarse_free(ch, ptr, 2 * MB);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
-    ASSERT_EQ(coarse_get_stats(ch).used_size, 0);
+    ASSERT_EQ(coarse_get_stats(ch).used_size, (size_t)0);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     // test double free
     umf_result = coarse_free(ch, ptr, 2 * MB);
     ASSERT_EQ(umf_result, UMF_RESULT_ERROR_INVALID_ARGUMENT);
-    ASSERT_EQ(coarse_get_stats(ch).used_size, 0);
+    ASSERT_EQ(coarse_get_stats(ch).used_size, (size_t)0);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     coarse_delete(ch);
     umfMemoryProviderDestroy(malloc_memory_provider);
@@ -194,27 +194,27 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_basic_fixed_memory) {
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, buff_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     umf_result = coarse_alloc(ch, 2 * MB, 0, (void **)&ptr);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
     ASSERT_NE(ptr, nullptr);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 2 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, buff_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 2);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)2);
 
     umf_result = coarse_free(ch, ptr, 2 * MB);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
-    ASSERT_EQ(coarse_get_stats(ch).used_size, 0);
+    ASSERT_EQ(coarse_get_stats(ch).used_size, (size_t)0);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, buff_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     // test double free
     umf_result = coarse_free(ch, ptr, 2 * MB);
     ASSERT_EQ(umf_result, UMF_RESULT_ERROR_INVALID_ARGUMENT);
-    ASSERT_EQ(coarse_get_stats(ch).used_size, 0);
+    ASSERT_EQ(coarse_get_stats(ch).used_size, (size_t)0);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, buff_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     coarse_delete(ch);
 }
@@ -242,7 +242,7 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_fixed_memory_various) {
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, buff_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     // free NULL
     umf_result = coarse_free(ch, nullptr, 2 * MB);
@@ -257,9 +257,9 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_fixed_memory_various) {
     umf_result = coarse_alloc(ch, 2 * MB, 3, (void **)&ptr);
     ASSERT_EQ(umf_result, UMF_RESULT_ERROR_INVALID_ALIGNMENT);
     ASSERT_EQ(ptr, nullptr);
-    ASSERT_EQ(coarse_get_stats(ch).used_size, 0);
+    ASSERT_EQ(coarse_get_stats(ch).used_size, (size_t)0);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, buff_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     // not freed allocation
     // coarse_delete() prints LOG_WARN() in Debug mode
@@ -268,7 +268,7 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_fixed_memory_various) {
     ASSERT_NE(ptr, nullptr);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 2 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, buff_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 2);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)2);
 
     coarse_delete(ch);
 }
@@ -295,7 +295,7 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_split_merge) {
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     /* test coarse_split */
     umf_result = coarse_alloc(ch, 2 * MB, 0, (void **)&ptr);
@@ -303,25 +303,25 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_split_merge) {
     ASSERT_NE(ptr, nullptr);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 2 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 2);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)2);
 
     umf_result = coarse_split(ch, ptr, 2 * MB, 1 * MB);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 2 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 3);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)3);
 
     umf_result = coarse_free(ch, (ptr + 1 * MB), 1 * MB);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 1 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 2);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)2);
 
     umf_result = coarse_free(ch, ptr, 1 * MB);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
-    ASSERT_EQ(coarse_get_stats(ch).used_size, 0);
+    ASSERT_EQ(coarse_get_stats(ch).used_size, (size_t)0);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     /* test coarse_merge */
     umf_result = coarse_alloc(ch, 2 * MB, 0, (void **)&ptr);
@@ -329,25 +329,25 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_split_merge) {
     ASSERT_NE(ptr, nullptr);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 2 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 2);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)2);
 
     umf_result = coarse_split(ch, ptr, 2 * MB, 1 * MB);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 2 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 3);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)3);
 
     umf_result = coarse_merge(ch, ptr, (ptr + 1 * MB), 2 * MB);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 2 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 2);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)2);
 
     umf_result = coarse_free(ch, ptr, 2 * MB);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
-    ASSERT_EQ(coarse_get_stats(ch).used_size, 0);
+    ASSERT_EQ(coarse_get_stats(ch).used_size, (size_t)0);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     coarse_delete(coarse_handle);
     umfMemoryProviderDestroy(malloc_memory_provider);
@@ -432,10 +432,10 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_add_memory_fixed_null_0) {
 }
 
 TEST_P(CoarseWithMemoryStrategyTest, coarseTest_null_stats) {
-    ASSERT_EQ(coarse_get_stats(nullptr).alloc_size, 0);
-    ASSERT_EQ(coarse_get_stats(nullptr).used_size, 0);
-    ASSERT_EQ(coarse_get_stats(nullptr).num_all_blocks, 0);
-    ASSERT_EQ(coarse_get_stats(nullptr).num_free_blocks, 0);
+    ASSERT_EQ(coarse_get_stats(nullptr).alloc_size, (size_t)0);
+    ASSERT_EQ(coarse_get_stats(nullptr).used_size, (size_t)0);
+    ASSERT_EQ(coarse_get_stats(nullptr).num_all_blocks, (size_t)0);
+    ASSERT_EQ(coarse_get_stats(nullptr).num_free_blocks, (size_t)0);
 }
 
 TEST_P(CoarseWithMemoryStrategyTest, coarseTest_split_merge_negative) {
@@ -460,7 +460,7 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_split_merge_negative) {
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     /* test coarse_split */
 
@@ -469,7 +469,7 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_split_merge_negative) {
     ASSERT_NE(ptr, nullptr);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 6 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 2);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)2);
 
     // firstSize >= totalSize
     umf_result = coarse_split(ch, ptr, 6 * MB, 6 * MB);
@@ -495,14 +495,14 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_split_merge_negative) {
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     // split freed block
     umf_result = coarse_split(ch, ptr, alloc_size, 1 * MB);
     ASSERT_EQ(umf_result, UMF_RESULT_ERROR_INVALID_ARGUMENT);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     /* test coarse_merge */
 
@@ -511,21 +511,21 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_split_merge_negative) {
     ASSERT_NE(ptr, nullptr);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 6 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 2);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)2);
 
     // split (6 * MB) block into (1 * MB) + (5 * MB)
     umf_result = coarse_split(ch, ptr, 6 * MB, 1 * MB);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 6 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 3);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)3);
 
     // split (5 * MB) block into (2 * MB) + (3 * MB)
     umf_result = coarse_split(ch, (ptr + 1 * MB), 5 * MB, 2 * MB);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 6 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 4);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)4);
 
     // now we have 3 used blocks: (1 * MB) + (2 * MB) + (3 * MB)
 
@@ -558,7 +558,7 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_split_merge_negative) {
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 4 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 4);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)4);
 
     // now we have 3 blocks: (1 * MB) used + (2 * MB) freed + (3 * MB) used
 
@@ -574,13 +574,13 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_split_merge_negative) {
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 3 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 3);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)3);
 
     umf_result = coarse_free(ch, (ptr + 3 * MB), 3 * MB);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
-    ASSERT_EQ(coarse_get_stats(ch).used_size, 0);
+    ASSERT_EQ(coarse_get_stats(ch).used_size, (size_t)0);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     coarse_delete(coarse_handle);
     umfMemoryProviderDestroy(malloc_memory_provider);
@@ -607,8 +607,8 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_basic_alloc_cb_fails) {
     ASSERT_EQ(umf_result, UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY);
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
-    ASSERT_EQ(coarse_get_stats(ch).alloc_size, 0);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 0);
+    ASSERT_EQ(coarse_get_stats(ch).alloc_size, (size_t)0);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)0);
 
     coarse_delete(ch);
     umfMemoryProviderDestroy(malloc_memory_provider);
@@ -636,7 +636,7 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_basic_free_cb_fails) {
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     coarse_delete(ch);
     umfMemoryProviderDestroy(malloc_memory_provider);
@@ -669,34 +669,34 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_split_cb_fails) {
     void *ptr = nullptr;
     const size_t alloc_size = 20 * MB;
 
-    ASSERT_EQ(coarse_get_stats(ch).used_size, 0);
-    ASSERT_EQ(coarse_get_stats(ch).alloc_size, 0);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 0);
+    ASSERT_EQ(coarse_get_stats(ch).used_size, (size_t)0);
+    ASSERT_EQ(coarse_get_stats(ch).alloc_size, (size_t)0);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)0);
 
     umf_result = coarse_add_memory_from_provider(ch, alloc_size);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     // coarse_alloc(alloc_size / 2, alignment = 0)
     umf_result = coarse_alloc(ch, alloc_size / 2, 0, &ptr);
     ASSERT_EQ(umf_result, UMF_RESULT_ERROR_USER_SPECIFIC);
     ASSERT_EQ(ptr, nullptr);
 
-    ASSERT_EQ(coarse_get_stats(ch).used_size, 0);
+    ASSERT_EQ(coarse_get_stats(ch).used_size, (size_t)0);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     // coarse_alloc(alloc_size / 2, alignment = 2 * MB)
     umf_result = coarse_alloc(ch, alloc_size / 2, 2 * MB, &ptr);
     ASSERT_EQ(umf_result, UMF_RESULT_ERROR_USER_SPECIFIC);
     ASSERT_EQ(ptr, nullptr);
 
-    ASSERT_EQ(coarse_get_stats(ch).used_size, 0);
+    ASSERT_EQ(coarse_get_stats(ch).used_size, (size_t)0);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     // coarse_alloc(alloc_size, alignment = 0) - OK
     umf_result = coarse_alloc(ch, alloc_size, 0, &ptr);
@@ -705,21 +705,21 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_split_cb_fails) {
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, alloc_size);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     umf_result = coarse_split(ch, ptr, alloc_size, alloc_size / 2);
     ASSERT_EQ(umf_result, UMF_RESULT_ERROR_USER_SPECIFIC);
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, alloc_size);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     umf_result = coarse_free(ch, ptr, alloc_size);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
 
-    ASSERT_EQ(coarse_get_stats(ch).used_size, 0);
+    ASSERT_EQ(coarse_get_stats(ch).used_size, (size_t)0);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     coarse_delete(coarse_handle);
     umfMemoryProviderDestroy(malloc_memory_provider);
@@ -749,7 +749,7 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_merge_cb_fails) {
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, buff_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     /* test coarse_merge */
     umf_result = coarse_alloc(ch, 3 * MB, 0, (void **)&ptr);
@@ -757,37 +757,37 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_merge_cb_fails) {
     ASSERT_NE(ptr, nullptr);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 3 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, buff_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 2);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)2);
 
     umf_result = coarse_split(ch, ptr, 3 * MB, 1 * MB);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 3 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, buff_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 3);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)3);
 
     umf_result = coarse_merge(ch, ptr, (ptr + 1 * MB), 3 * MB);
     ASSERT_EQ(umf_result, UMF_RESULT_ERROR_USER_SPECIFIC);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 3 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, buff_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 3);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)3);
 
     umf_result = coarse_free(ch, ptr, 3 * MB);
     ASSERT_EQ(umf_result, UMF_RESULT_ERROR_INVALID_ARGUMENT);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 3 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, buff_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 3);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)3);
 
     umf_result = coarse_free(ch, ptr, 1 * MB);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 2 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, buff_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 3);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)3);
 
     umf_result = coarse_free(ch, (ptr + 1 * MB), 2 * MB);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
-    ASSERT_EQ(coarse_get_stats(ch).used_size, 0);
+    ASSERT_EQ(coarse_get_stats(ch).used_size, (size_t)0);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, buff_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 3);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)3);
 
     coarse_delete(coarse_handle);
 }
@@ -808,15 +808,15 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_fixed_memory_alloc_set) {
     coarse_t *ch = coarse_handle;
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
-    ASSERT_EQ(coarse_get_stats(ch).alloc_size, 0);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 0);
+    ASSERT_EQ(coarse_get_stats(ch).alloc_size, (size_t)0);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)0);
 
     umf_result = coarse_add_memory_fixed(ch, buf, buff_size);
     ASSERT_EQ(umf_result, UMF_RESULT_ERROR_NOT_SUPPORTED);
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
-    ASSERT_EQ(coarse_get_stats(ch).alloc_size, 0);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 0);
+    ASSERT_EQ(coarse_get_stats(ch).alloc_size, (size_t)0);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)0);
 
     coarse_delete(ch);
 }
@@ -837,15 +837,15 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_fixed_memory_free_set) {
     coarse_t *ch = coarse_handle;
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
-    ASSERT_EQ(coarse_get_stats(ch).alloc_size, 0);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 0);
+    ASSERT_EQ(coarse_get_stats(ch).alloc_size, (size_t)0);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)0);
 
     umf_result = coarse_add_memory_fixed(ch, buf, buff_size);
     ASSERT_EQ(umf_result, UMF_RESULT_ERROR_NOT_SUPPORTED);
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
-    ASSERT_EQ(coarse_get_stats(ch).alloc_size, 0);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 0);
+    ASSERT_EQ(coarse_get_stats(ch).alloc_size, (size_t)0);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)0);
 
     coarse_delete(ch);
 }
@@ -864,15 +864,15 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_fixed_memory_alloc_free_set) {
     coarse_t *ch = coarse_handle;
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
-    ASSERT_EQ(coarse_get_stats(ch).alloc_size, 0);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 0);
+    ASSERT_EQ(coarse_get_stats(ch).alloc_size, (size_t)0);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)0);
 
     umf_result = coarse_add_memory_fixed(ch, buf, buff_size);
     ASSERT_EQ(umf_result, UMF_RESULT_ERROR_NOT_SUPPORTED);
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
-    ASSERT_EQ(coarse_get_stats(ch).alloc_size, 0);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 0);
+    ASSERT_EQ(coarse_get_stats(ch).alloc_size, (size_t)0);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)0);
 
     coarse_delete(ch);
 }
@@ -896,31 +896,31 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_provider_alloc_not_set) {
     void *ptr;
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
-    ASSERT_EQ(coarse_get_stats(ch).alloc_size, 0);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 0);
+    ASSERT_EQ(coarse_get_stats(ch).alloc_size, (size_t)0);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)0);
 
     umf_result = coarse_add_memory_from_provider(ch, alloc_size);
     ASSERT_EQ(umf_result, UMF_RESULT_ERROR_NOT_SUPPORTED);
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
-    ASSERT_EQ(coarse_get_stats(ch).alloc_size, 0);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 0);
+    ASSERT_EQ(coarse_get_stats(ch).alloc_size, (size_t)0);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)0);
 
     umf_result = coarse_alloc(ch, 2 * MB, 0, &ptr);
     ASSERT_EQ(umf_result, UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY);
     ASSERT_EQ(ptr, nullptr);
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
-    ASSERT_EQ(coarse_get_stats(ch).alloc_size, 0);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 0);
+    ASSERT_EQ(coarse_get_stats(ch).alloc_size, (size_t)0);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)0);
 
     umf_result = coarse_alloc(ch, 2 * MB, 2 * MB, &ptr);
     ASSERT_EQ(umf_result, UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY);
     ASSERT_EQ(ptr, nullptr);
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
-    ASSERT_EQ(coarse_get_stats(ch).alloc_size, 0);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 0);
+    ASSERT_EQ(coarse_get_stats(ch).alloc_size, (size_t)0);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)0);
 
     coarse_delete(ch);
     umfMemoryProviderDestroy(malloc_memory_provider);
@@ -957,7 +957,7 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_basic) {
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, init_buffer_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     // alloc 2x 2MB
     umf_result = coarse_alloc(ch, 2 * MB, 0, (void **)&p1);
@@ -965,14 +965,14 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_basic) {
     ASSERT_NE(p1, nullptr);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 2 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, init_buffer_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 2);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)2);
 
     umf_result = coarse_alloc(ch, 2 * MB, 0, (void **)&p2);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
     ASSERT_NE(p2, nullptr);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 4 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, init_buffer_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 3);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)3);
     ASSERT_NE(p1, p2);
 
     // swap pointers to get p1 < p2
@@ -988,14 +988,14 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_basic) {
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 2 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, init_buffer_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 3);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)3);
 
     umf_result = coarse_alloc(ch, 2 * MB, 0, (void **)&p1);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
     ASSERT_NE(p1, nullptr);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 4 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, init_buffer_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 3);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)3);
 
     // free all allocs
     // overall alloc size shouldn't change
@@ -1003,24 +1003,24 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_basic) {
     // and the remaining init block
     umf_result = coarse_free(ch, p1, 2 * MB);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 3);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)3);
     umf_result = coarse_free(ch, p2, 2 * MB);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, init_buffer_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     // test allocations with alignment
     // TODO: what about holes?
     umf_result = coarse_alloc(ch, 1 * MB - 4, 128, (void **)&p1);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
     ASSERT_NE(p1, nullptr);
-    ASSERT_EQ((uintptr_t)p1 & 127, 0);
+    ASSERT_EQ((uintptr_t)p1 & 127, 0ULL);
 
     umf_result = coarse_alloc(ch, 1 * MB - 4, 128, (void **)&p2);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
     ASSERT_NE(p2, nullptr);
-    ASSERT_EQ((uintptr_t)p2 & 127, 0);
+    ASSERT_EQ((uintptr_t)p2 & 127, 0ULL);
 
     umf_result = coarse_free(ch, p1, 1 * MB - 4);
     ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
@@ -1034,7 +1034,7 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_basic) {
     ASSERT_NE(p1, nullptr);
     ASSERT_EQ(coarse_get_stats(ch).used_size, init_buffer_size);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, init_buffer_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     // free all memory
     umf_result = coarse_free(ch, p1, init_buffer_size);
@@ -1045,7 +1045,7 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_basic) {
     ASSERT_NE(p1, nullptr);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 2 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, init_buffer_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 2);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)2);
 
     // alloc additional 2 MB
     // the non-used block should be used
@@ -1054,7 +1054,7 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_basic) {
     ASSERT_NE(p2, nullptr);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 4 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, init_buffer_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 3);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)3);
     ASSERT_NE(p1, p2);
 
     // make sure that p1 < p2
@@ -1069,12 +1069,12 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_basic) {
     coarse_free(ch, p1, 2 * MB);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, init_buffer_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     // alloc 10x 2 MB - this should occupy all allocated memory
-    constexpr int allocs_size = 10;
+    constexpr size_t allocs_size = 10;
     void *allocs[allocs_size] = {0};
-    for (int i = 0; i < allocs_size; i++) {
+    for (size_t i = 0; i < allocs_size; i++) {
         ASSERT_EQ(coarse_get_stats(ch).used_size, i * 2 * MB);
         umf_result = coarse_alloc(ch, 2 * MB, 0, &allocs[i]);
         ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
@@ -1086,12 +1086,12 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_basic) {
     ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, allocs_size);
 
     // free all memory
-    for (int i = 0; i < allocs_size; i++) {
+    for (size_t i = 0; i < allocs_size; i++) {
         umf_result = coarse_free(ch, allocs[i], 2 * MB);
         ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
     }
 
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, init_buffer_size);
 
@@ -1129,7 +1129,7 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_simple1) {
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, init_buffer_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     // test 1
 
@@ -1204,7 +1204,7 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_simple2) {
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, init_buffer_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     // test
     double sizes[] = {2, 4, 0.5, 1, 8, 0.25};
@@ -1249,10 +1249,10 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_alignment_provider) {
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     const int niter = 10;
-    const int size = 1 * MB;
+    const size_t size = 1 * MB;
     void *ptr[niter] = {0};
 
     for (int i = 0; i < niter; i++) {
@@ -1263,7 +1263,7 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_alignment_provider) {
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, niter * size);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, niter + 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)(niter + 1));
 
     for (int i = 0; i < niter; i += 2) {
         umf_result = coarse_free(ch, ptr[i], size);
@@ -1273,7 +1273,7 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_alignment_provider) {
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, niter * size / 2);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, niter + 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)(niter + 1));
 
     for (int i = 0; i < niter; i += 2) {
         ASSERT_EQ(ptr[i], nullptr);
@@ -1289,8 +1289,8 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_alignment_provider) {
         ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
     }
 
-    ASSERT_EQ(coarse_get_stats(ch).used_size, 0);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).used_size, (size_t)0);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     coarse_delete(ch);
     umfMemoryProviderDestroy(malloc_memory_provider);
@@ -1318,10 +1318,10 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_alignment_fixed_memory) {
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     const int niter = 10;
-    const int size = 1 * MB;
+    const size_t size = 1 * MB;
     void *ptr[niter] = {0};
 
     for (int i = 0; i < niter; i++) {
@@ -1332,7 +1332,7 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_alignment_fixed_memory) {
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, niter * size);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, niter + 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)(niter + 1));
 
     for (int i = 0; i < niter; i += 2) {
         umf_result = coarse_free(ch, ptr[i], size);
@@ -1342,7 +1342,7 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_alignment_fixed_memory) {
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, niter * size / 2);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, alloc_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, niter + 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)(niter + 1));
 
     for (int i = 0; i < niter; i += 2) {
         ASSERT_EQ(ptr[i], nullptr);
@@ -1358,8 +1358,8 @@ TEST_P(CoarseWithMemoryStrategyTest, coarseTest_alignment_fixed_memory) {
         ASSERT_EQ(umf_result, UMF_RESULT_SUCCESS);
     }
 
-    ASSERT_EQ(coarse_get_stats(ch).used_size, 0);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).used_size, (size_t)0);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     coarse_delete(ch);
 }
@@ -1396,7 +1396,7 @@ TEST_P(CoarseWithMemoryStrategyTest,
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, buf_non_aligned_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     umf_result = coarse_alloc(ch, buf_non_aligned_size, 0, (void **)&ptr);
     ASSERT_EQ(umf_result, UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY);
@@ -1404,7 +1404,7 @@ TEST_P(CoarseWithMemoryStrategyTest,
 
     ASSERT_EQ(coarse_get_stats(ch).used_size, 0 * MB);
     ASSERT_EQ(coarse_get_stats(ch).alloc_size, buf_non_aligned_size);
-    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, 1);
+    ASSERT_EQ(coarse_get_stats(ch).num_all_blocks, (size_t)1);
 
     coarse_delete(ch);
 }

--- a/test/ipcFixtures.hpp
+++ b/test/ipcFixtures.hpp
@@ -437,7 +437,7 @@ TEST_P(umfIpcTest, GetIPCHandleSize) {
 
     umf_result_t ret = umfPoolGetIPCHandleSize(pool.get(), &size);
     EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
-    EXPECT_GT(size, 0);
+    EXPECT_GT(size, (size_t)0);
 }
 
 TEST_P(umfIpcTest, GetIPCHandleSizeInvalidArgs) {
@@ -547,9 +547,9 @@ TEST_P(umfIpcTest, BasicFlow) {
     EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
 
     pool.reset(nullptr);
-    EXPECT_EQ(stat.getCount, 1);
+    EXPECT_EQ(stat.getCount, (size_t)1);
     EXPECT_EQ(stat.putCount, stat.getCount);
-    EXPECT_EQ(stat.openCount, 1);
+    EXPECT_EQ(stat.openCount, (size_t)1);
     EXPECT_EQ(stat.closeCount, stat.openCount);
 }
 
@@ -673,9 +673,9 @@ TEST_P(umfIpcTest, openInTwoIpcHandlers) {
 
     pool1.reset(nullptr);
     pool2.reset(nullptr);
-    EXPECT_EQ(stat.getCount, 1);
+    EXPECT_EQ(stat.getCount, (size_t)1);
     EXPECT_EQ(stat.putCount, stat.getCount);
-    EXPECT_EQ(stat.openCount, 2);
+    EXPECT_EQ(stat.openCount, (size_t)2);
     EXPECT_EQ(stat.closeCount, stat.openCount);
 }
 

--- a/test/memoryPoolAPI.cpp
+++ b/test/memoryPoolAPI.cpp
@@ -42,7 +42,7 @@ struct umfPoolWithCreateFlagsTest
 };
 
 TEST_P(umfPoolWithCreateFlagsTest, memoryPoolTrace) {
-    using calls_type = std::unordered_map<std::string, size_t>;
+    using calls_type = std::unordered_map<std::string, unsigned int>;
     calls_type poolCalls;
     calls_type providerCalls;
     auto tracePool = [](void *handler, const char *name) {
@@ -71,43 +71,43 @@ TEST_P(umfPoolWithCreateFlagsTest, memoryPoolTrace) {
     size_t provider_call_count = 0;
 
     umfPoolMalloc(tracingPool.get(), 0);
-    ASSERT_EQ(poolCalls["malloc"], 1);
+    ASSERT_EQ(poolCalls["malloc"], 1UL);
     ASSERT_EQ(poolCalls.size(), ++pool_call_count);
 
-    ASSERT_EQ(providerCalls["alloc"], 1);
+    ASSERT_EQ(providerCalls["alloc"], 1UL);
     ASSERT_EQ(providerCalls.size(), ++provider_call_count);
 
     umfPoolMallocUsableSize(tracingPool.get(), nullptr);
-    ASSERT_EQ(poolCalls["malloc_usable_size"], 1);
+    ASSERT_EQ(poolCalls["malloc_usable_size"], 1UL);
     ASSERT_EQ(poolCalls.size(), ++pool_call_count);
 
     ASSERT_EQ(providerCalls.size(), provider_call_count);
 
     umfPoolFree(tracingPool.get(), nullptr);
-    ASSERT_EQ(poolCalls["free"], 1);
+    ASSERT_EQ(poolCalls["free"], 1UL);
     ASSERT_EQ(poolCalls.size(), ++pool_call_count);
 
-    ASSERT_EQ(providerCalls["free"], 1);
+    ASSERT_EQ(providerCalls["free"], 1UL);
     ASSERT_EQ(providerCalls.size(), ++provider_call_count);
 
     umfPoolCalloc(tracingPool.get(), 0, 0);
-    ASSERT_EQ(poolCalls["calloc"], 1);
+    ASSERT_EQ(poolCalls["calloc"], 1UL);
     ASSERT_EQ(poolCalls.size(), ++pool_call_count);
 
     umfPoolRealloc(tracingPool.get(), nullptr, 0);
-    ASSERT_EQ(poolCalls["realloc"], 1);
+    ASSERT_EQ(poolCalls["realloc"], 1UL);
     ASSERT_EQ(poolCalls.size(), ++pool_call_count);
 
     umfPoolAlignedMalloc(tracingPool.get(), 0, 0);
-    ASSERT_EQ(poolCalls["aligned_malloc"], 1);
+    ASSERT_EQ(poolCalls["aligned_malloc"], 1UL);
     ASSERT_EQ(poolCalls.size(), ++pool_call_count);
 
-    ASSERT_EQ(providerCalls["alloc"], 2);
+    ASSERT_EQ(providerCalls["alloc"], 2UL);
     ASSERT_EQ(providerCalls.size(), provider_call_count);
 
     auto ret = umfPoolGetLastAllocationError(tracingPool.get());
     ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
-    ASSERT_EQ(poolCalls["get_last_native_error"], 1);
+    ASSERT_EQ(poolCalls["get_last_native_error"], 1UL);
     ASSERT_EQ(poolCalls.size(), ++pool_call_count);
 
     if (manuallyDestroyProvider) {

--- a/test/memoryProviderAPI.cpp
+++ b/test/memoryProviderAPI.cpp
@@ -14,7 +14,7 @@
 using umf_test::test;
 
 TEST_F(test, memoryProviderTrace) {
-    using calls_type = std::unordered_map<std::string, size_t>;
+    using calls_type = std::unordered_map<std::string, unsigned int>;
     calls_type calls;
     auto trace = [](void *handler, const char *name) {
         auto &calls = *static_cast<calls_type *>(handler);
@@ -30,47 +30,47 @@ TEST_F(test, memoryProviderTrace) {
     void *ptr;
     auto ret = umfMemoryProviderAlloc(tracingProvider.get(), 0, 0, &ptr);
     ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
-    ASSERT_EQ(calls["alloc"], 1);
+    ASSERT_EQ(calls["alloc"], 1UL);
     ASSERT_EQ(calls.size(), ++call_count);
 
     ret = umfMemoryProviderFree(tracingProvider.get(), nullptr, 0);
     ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
-    ASSERT_EQ(calls["free"], 1);
+    ASSERT_EQ(calls["free"], 1UL);
     ASSERT_EQ(calls.size(), ++call_count);
 
     umfMemoryProviderGetLastNativeError(tracingProvider.get(), nullptr,
                                         nullptr);
-    ASSERT_EQ(calls["get_last_native_error"], 1);
+    ASSERT_EQ(calls["get_last_native_error"], 1UL);
     ASSERT_EQ(calls.size(), ++call_count);
 
     size_t page_size;
     ret = umfMemoryProviderGetRecommendedPageSize(tracingProvider.get(), 0,
                                                   &page_size);
     ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
-    ASSERT_EQ(calls["get_recommended_page_size"], 1);
+    ASSERT_EQ(calls["get_recommended_page_size"], 1UL);
     ASSERT_EQ(calls.size(), ++call_count);
 
     ret = umfMemoryProviderGetMinPageSize(tracingProvider.get(), nullptr,
                                           &page_size);
     ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
-    ASSERT_EQ(calls["get_min_page_size"], 1);
+    ASSERT_EQ(calls["get_min_page_size"], 1UL);
     ASSERT_EQ(calls.size(), ++call_count);
 
     const char *pName = umfMemoryProviderGetName(tracingProvider.get());
-    ASSERT_EQ(calls["name"], 1);
+    ASSERT_EQ(calls["name"], 1UL);
     ASSERT_EQ(calls.size(), ++call_count);
     ASSERT_EQ(std::string(pName), std::string("null"));
 
     ret = umfMemoryProviderPurgeLazy(tracingProvider.get(), &page_size,
                                      sizeof(page_size));
     ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
-    ASSERT_EQ(calls["purge_lazy"], 1);
+    ASSERT_EQ(calls["purge_lazy"], 1UL);
     ASSERT_EQ(calls.size(), ++call_count);
 
     ret = umfMemoryProviderPurgeForce(tracingProvider.get(), &page_size,
                                       sizeof(page_size));
     ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
-    ASSERT_EQ(calls["purge_force"], 1);
+    ASSERT_EQ(calls["purge_force"], 1UL);
     ASSERT_EQ(calls.size(), ++call_count);
 
     void *lowPtr = (void *)0xBAD;
@@ -78,14 +78,14 @@ TEST_F(test, memoryProviderTrace) {
     ret = umfMemoryProviderAllocationMerge(tracingProvider.get(), lowPtr,
                                            highPtr, 2 * 4096);
     ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
-    ASSERT_EQ(calls["allocation_merge"], 1);
+    ASSERT_EQ(calls["allocation_merge"], 1UL);
     ASSERT_EQ(calls.size(), ++call_count);
 
     ptr = (void *)0xBAD;
     ret = umfMemoryProviderAllocationSplit(tracingProvider.get(), ptr, 2 * 4096,
                                            4096);
     ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
-    ASSERT_EQ(calls["allocation_split"], 1);
+    ASSERT_EQ(calls["allocation_split"], 1UL);
     ASSERT_EQ(calls.size(), ++call_count);
 }
 

--- a/test/pools/disjoint_pool.cpp
+++ b/test/pools/disjoint_pool.cpp
@@ -63,7 +63,7 @@ TEST_F(test, internals) {
     umf_result_t res = ops->initialize(provider_handle, params, (void **)&pool);
     EXPECT_EQ(res, UMF_RESULT_SUCCESS);
     EXPECT_NE(pool, nullptr);
-    EXPECT_EQ(pool->provider_min_page_size, 1024);
+    EXPECT_EQ(pool->provider_min_page_size, (size_t)1024);
 
     // check buckets sizes
     size_t expected_size = DEFAULT_DISJOINT_MIN_BUCKET_SIZE;
@@ -95,16 +95,16 @@ TEST_F(test, internals) {
     EXPECT_NE(bucket, nullptr);
 
     // check bucket stats
-    EXPECT_EQ(bucket->alloc_count, 1);
+    EXPECT_EQ(bucket->alloc_count, (size_t)1);
 
     // first allocation will always use external memory (newly added to the
     // pool) and this is counted as allocation from the outside of the pool
-    EXPECT_EQ(bucket->alloc_pool_count, 0);
-    EXPECT_EQ(bucket->curr_slabs_in_use, 1);
+    EXPECT_EQ(bucket->alloc_pool_count, (size_t)0);
+    EXPECT_EQ(bucket->curr_slabs_in_use, (size_t)1);
 
     // check slab - there should be only single slab allocated
     EXPECT_NE(bucket->available_slabs, nullptr);
-    EXPECT_EQ(bucket->available_slabs_num, 1);
+    EXPECT_EQ(bucket->available_slabs_num, (size_t)1);
     EXPECT_EQ(bucket->available_slabs->next, nullptr);
     slab_t *slab = bucket->available_slabs->val;
 
@@ -243,8 +243,8 @@ TEST_F(test, sharedLimits) {
     ret = umfDisjointPoolParamsDestroy(params);
     EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
 
-    EXPECT_EQ(0, numAllocs);
-    EXPECT_EQ(0, numFrees);
+    EXPECT_EQ((size_t)0, numAllocs);
+    EXPECT_EQ((size_t)0, numFrees);
 
     std::vector<std::unique_ptr<void, decltype(&umfFree)>> ptrs;
     for (size_t i = 0; i < MaxSize / SlabMinSize; i++) {
@@ -253,7 +253,7 @@ TEST_F(test, sharedLimits) {
     }
 
     EXPECT_EQ(MaxSize / SlabMinSize * 2, numAllocs);
-    EXPECT_EQ(0, numFrees);
+    EXPECT_EQ((size_t)0, numFrees);
 
     ptrs.clear();
 

--- a/test/test_base_alloc_linear.cpp
+++ b/test/test_base_alloc_linear.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Intel Corporation
+ * Copyright (C) 2024-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -40,11 +40,11 @@ TEST_F(test, baseAllocLinearPoolContainsPointer) {
     ASSERT_NE(ptr, nullptr);
     memset(ptr, 0, size);
     // assert pool contains pointer ptr
-    ASSERT_NE(umf_ba_linear_pool_contains_pointer(pool.get(), ptr), 0);
+    ASSERT_NE(umf_ba_linear_pool_contains_pointer(pool.get(), ptr), (size_t)0);
 
     // assert pool does NOT contain pointer 0x0123
     ASSERT_EQ(umf_ba_linear_pool_contains_pointer(pool.get(), (void *)0x0123),
-              0);
+              (size_t)0);
 
     umf_ba_linear_free(pool.get(), ptr);
 }


### PR DESCRIPTION
This is a fix for the failing test_installation.py on Windows, introduced by #1285. The failures are related to the `--target install` command, which is not properly recognized on Windows. This pull request reverts the installation command to the previous version, which uses `--install` for Windows.

example of passed Windows Ninja job:
https://github.com/oneapi-src/unified-memory-framework/actions/runs/14972212328/job/42055589833?pr=1310

and Windows NMake job:
https://github.com/oneapi-src/unified-memory-framework/actions/runs/14972212328/job/42055589878?pr=1310

full nightly run:
https://github.com/oneapi-src/unified-memory-framework/actions/runs/15117728112