### PR TITLE
remove unused UMF_NO_*_PROVIDER compile defs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,20 +115,22 @@ set(UMF_SOURCES_LINUX libumf_linux.c)
 set(UMF_SOURCES_MACOSX libumf_linux.c)
 set(UMF_SOURCES_WINDOWS libumf_windows.c)
 
-# Add compile definitions to handle unsupported functions
-if(NOT UMF_BUILD_CUDA_PROVIDER)
+if(UMF_BUILD_LEVEL_ZERO_PROVIDER)
+    if(LINUX)
+        # WA for error ze_api.h:14234:20: no newline at end of file
+        # [-Werror,-Wnewline-eof]
+        set_source_files_properties(
+            provider/provider_level_zero.c
+            PROPERTIES APPEND_STRING PROPERTY COMPILE_FLAGS "-Wno-newline-eof")
+    endif()
+
     set(UMF_COMMON_COMPILE_DEFINITIONS ${UMF_COMMON_COMPILE_DEFINITIONS}
-                                       "UMF_NO_CUDA_PROVIDER=1")
+                                       "UMF_BUILD_LEVEL_ZERO_PROVIDER=1")
 endif()
-if(NOT UMF_BUILD_LEVEL_ZERO_PROVIDER)
+
+if(UMF_BUILD_CUDA_PROVIDER)
     set(UMF_COMMON_COMPILE_DEFINITIONS ${UMF_COMMON_COMPILE_DEFINITIONS}
-                                       "UMF_NO_LEVEL_ZERO_PROVIDER=1")
-endif()
-if(UMF_DISABLE_HWLOC OR WINDOWS)
-    set(UMF_COMMON_COMPILE_DEFINITIONS ${UMF_COMMON_COMPILE_DEFINITIONS}
-                                       "UMF_NO_DEVDAX_PROVIDER=1")
-    set(UMF_COMMON_COMPILE_DEFINITIONS ${UMF_COMMON_COMPILE_DEFINITIONS}
-                                       "UMF_NO_FILE_PROVIDER=1")
+                                       "UMF_BUILD_CUDA_PROVIDER=1")
 endif()
 
 if(LINUX)
@@ -196,24 +198,6 @@ endif()
 
 if(NOT WINDOWS AND UMF_POOL_JEMALLOC_ENABLED)
     add_dependencies(umf jemalloc)
-endif()
-
-if(UMF_BUILD_LEVEL_ZERO_PROVIDER)
-    if(LINUX)
-        # WA for error ze_api.h:14234:20: no newline at end of file
-        # [-Werror,-Wnewline-eof]
-        set_source_files_properties(
-            provider/provider_level_zero.c
-            PROPERTIES APPEND_STRING PROPERTY COMPILE_FLAGS "-Wno-newline-eof")
-    endif()
-
-    set(UMF_COMPILE_DEFINITIONS ${UMF_COMPILE_DEFINITIONS}
-                                "UMF_BUILD_LEVEL_ZERO_PROVIDER=1")
-endif()
-
-if(UMF_BUILD_CUDA_PROVIDER)
-    set(UMF_COMPILE_DEFINITIONS ${UMF_COMPILE_DEFINITIONS}
-                                "UMF_BUILD_CUDA_PROVIDER=1")
 endif()
 
 add_library(${PROJECT_NAME}::umf ALIAS umf)

--- a/src/provider/provider_cuda.c
+++ b/src/provider/provider_cuda.c
@@ -25,62 +25,7 @@ void fini_cu_global_state(void) {
     }
 }
 
-#if defined(UMF_NO_CUDA_PROVIDER)
-
-umf_result_t umfCUDAMemoryProviderParamsCreate(
-    umf_cuda_memory_provider_params_handle_t *hParams) {
-    (void)hParams;
-    LOG_ERR("CUDA provider is disabled (UMF_BUILD_CUDA_PROVIDER is OFF)!");
-    return UMF_RESULT_ERROR_NOT_SUPPORTED;
-}
-
-umf_result_t umfCUDAMemoryProviderParamsDestroy(
-    umf_cuda_memory_provider_params_handle_t hParams) {
-    (void)hParams;
-    LOG_ERR("CUDA provider is disabled (UMF_BUILD_CUDA_PROVIDER is OFF)!");
-    return UMF_RESULT_ERROR_NOT_SUPPORTED;
-}
-
-umf_result_t umfCUDAMemoryProviderParamsSetContext(
-    umf_cuda_memory_provider_params_handle_t hParams, void *hContext) {
-    (void)hParams;
-    (void)hContext;
-    LOG_ERR("CUDA provider is disabled (UMF_BUILD_CUDA_PROVIDER is OFF)!");
-    return UMF_RESULT_ERROR_NOT_SUPPORTED;
-}
-
-umf_result_t umfCUDAMemoryProviderParamsSetDevice(
-    umf_cuda_memory_provider_params_handle_t hParams, int hDevice) {
-    (void)hParams;
-    (void)hDevice;
-    LOG_ERR("CUDA provider is disabled (UMF_BUILD_CUDA_PROVIDER is OFF)!");
-    return UMF_RESULT_ERROR_NOT_SUPPORTED;
-}
-
-umf_result_t umfCUDAMemoryProviderParamsSetMemoryType(
-    umf_cuda_memory_provider_params_handle_t hParams,
-    umf_usm_memory_type_t memoryType) {
-    (void)hParams;
-    (void)memoryType;
-    LOG_ERR("CUDA provider is disabled (UMF_BUILD_CUDA_PROVIDER is OFF)!");
-    return UMF_RESULT_ERROR_NOT_SUPPORTED;
-}
-
-umf_result_t umfCUDAMemoryProviderParamsSetAllocFlags(
-    umf_cuda_memory_provider_params_handle_t hParams, unsigned int flags) {
-    (void)hParams;
-    (void)flags;
-    LOG_ERR("CUDA provider is disabled (UMF_BUILD_CUDA_PROVIDER is OFF)!");
-    return UMF_RESULT_ERROR_NOT_SUPPORTED;
-}
-
-const umf_memory_provider_ops_t *umfCUDAMemoryProviderOps(void) {
-    // not supported
-    LOG_ERR("CUDA provider is disabled (UMF_BUILD_CUDA_PROVIDER is OFF)!");
-    return NULL;
-}
-
-#else // !defined(UMF_NO_CUDA_PROVIDER)
+#if UMF_BUILD_CUDA_PROVIDER
 
 // disable warning 4201: nonstandard extension used: nameless struct/union
 #if defined(_MSC_VER)
@@ -759,4 +704,59 @@ const umf_memory_provider_ops_t *umfCUDAMemoryProviderOps(void) {
     return &UMF_CUDA_MEMORY_PROVIDER_OPS;
 }
 
-#endif // !defined(UMF_NO_CUDA_PROVIDER)
+#else // !UMF_BUILD_CUDA_PROVIDER
+
+umf_result_t umfCUDAMemoryProviderParamsCreate(
+    umf_cuda_memory_provider_params_handle_t *hParams) {
+    (void)hParams;
+    LOG_ERR("CUDA provider is disabled (UMF_BUILD_CUDA_PROVIDER is OFF)!");
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+}
+
+umf_result_t umfCUDAMemoryProviderParamsDestroy(
+    umf_cuda_memory_provider_params_handle_t hParams) {
+    (void)hParams;
+    LOG_ERR("CUDA provider is disabled (UMF_BUILD_CUDA_PROVIDER is OFF)!");
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+}
+
+umf_result_t umfCUDAMemoryProviderParamsSetContext(
+    umf_cuda_memory_provider_params_handle_t hParams, void *hContext) {
+    (void)hParams;
+    (void)hContext;
+    LOG_ERR("CUDA provider is disabled (UMF_BUILD_CUDA_PROVIDER is OFF)!");
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+}
+
+umf_result_t umfCUDAMemoryProviderParamsSetDevice(
+    umf_cuda_memory_provider_params_handle_t hParams, int hDevice) {
+    (void)hParams;
+    (void)hDevice;
+    LOG_ERR("CUDA provider is disabled (UMF_BUILD_CUDA_PROVIDER is OFF)!");
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+}
+
+umf_result_t umfCUDAMemoryProviderParamsSetMemoryType(
+    umf_cuda_memory_provider_params_handle_t hParams,
+    umf_usm_memory_type_t memoryType) {
+    (void)hParams;
+    (void)memoryType;
+    LOG_ERR("CUDA provider is disabled (UMF_BUILD_CUDA_PROVIDER is OFF)!");
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+}
+
+umf_result_t umfCUDAMemoryProviderParamsSetAllocFlags(
+    umf_cuda_memory_provider_params_handle_t hParams, unsigned int flags) {
+    (void)hParams;
+    (void)flags;
+    LOG_ERR("CUDA provider is disabled (UMF_BUILD_CUDA_PROVIDER is OFF)!");
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+}
+
+const umf_memory_provider_ops_t *umfCUDAMemoryProviderOps(void) {
+    // not supported
+    LOG_ERR("CUDA provider is disabled (UMF_BUILD_CUDA_PROVIDER is OFF)!");
+    return NULL;
+}
+
+#endif // !UMF_BUILD_CUDA_PROVIDER

--- a/src/provider/provider_level_zero.c
+++ b/src/provider/provider_level_zero.c
@@ -27,89 +27,7 @@ void fini_ze_global_state(void) {
     }
 }
 
-#if defined(UMF_NO_LEVEL_ZERO_PROVIDER)
-
-umf_result_t umfLevelZeroMemoryProviderParamsCreate(
-    umf_level_zero_memory_provider_params_handle_t *hParams) {
-    (void)hParams;
-    LOG_ERR("L0 memory provider is disabled! (UMF_BUILD_LEVEL_ZERO_PROVIDER is "
-            "OFF)");
-    return UMF_RESULT_ERROR_NOT_SUPPORTED;
-}
-
-umf_result_t umfLevelZeroMemoryProviderParamsDestroy(
-    umf_level_zero_memory_provider_params_handle_t hParams) {
-    (void)hParams;
-    LOG_ERR("L0 memory provider is disabled! (UMF_BUILD_LEVEL_ZERO_PROVIDER is "
-            "OFF)");
-    return UMF_RESULT_ERROR_NOT_SUPPORTED;
-}
-
-umf_result_t umfLevelZeroMemoryProviderParamsSetContext(
-    umf_level_zero_memory_provider_params_handle_t hParams,
-    ze_context_handle_t hContext) {
-    (void)hParams;
-    (void)hContext;
-    LOG_ERR("L0 memory provider is disabled! (UMF_BUILD_LEVEL_ZERO_PROVIDER is "
-            "OFF)");
-    return UMF_RESULT_ERROR_NOT_SUPPORTED;
-}
-
-umf_result_t umfLevelZeroMemoryProviderParamsSetDevice(
-    umf_level_zero_memory_provider_params_handle_t hParams,
-    ze_device_handle_t hDevice) {
-    (void)hParams;
-    (void)hDevice;
-    LOG_ERR("L0 memory provider is disabled! (UMF_BUILD_LEVEL_ZERO_PROVIDER is "
-            "OFF)");
-    return UMF_RESULT_ERROR_NOT_SUPPORTED;
-}
-
-umf_result_t umfLevelZeroMemoryProviderParamsSetMemoryType(
-    umf_level_zero_memory_provider_params_handle_t hParams,
-    umf_usm_memory_type_t memoryType) {
-    (void)hParams;
-    (void)memoryType;
-    LOG_ERR("L0 memory provider is disabled! (UMF_BUILD_LEVEL_ZERO_PROVIDER is "
-            "OFF)");
-    return UMF_RESULT_ERROR_NOT_SUPPORTED;
-}
-
-umf_result_t umfLevelZeroMemoryProviderParamsSetResidentDevices(
-    umf_level_zero_memory_provider_params_handle_t hParams,
-    ze_device_handle_t *hDevices, uint32_t deviceCount) {
-    (void)hParams;
-    (void)hDevices;
-    (void)deviceCount;
-    LOG_ERR("L0 memory provider is disabled! (UMF_BUILD_LEVEL_ZERO_PROVIDER is "
-            "OFF)");
-    return UMF_RESULT_ERROR_NOT_SUPPORTED;
-}
-
-umf_result_t umfLevelZeroMemoryProviderParamsSetFreePolicy(
-    umf_level_zero_memory_provider_params_handle_t hParams,
-    umf_level_zero_memory_provider_free_policy_t policy) {
-    (void)hParams;
-    (void)policy;
-    return UMF_RESULT_ERROR_NOT_SUPPORTED;
-}
-
-umf_result_t umfLevelZeroMemoryProviderParamsSetDeviceOrdinal(
-    umf_level_zero_memory_provider_params_handle_t hParams,
-    uint32_t deviceOrdinal) {
-    (void)hParams;
-    (void)deviceOrdinal;
-    return UMF_RESULT_ERROR_NOT_SUPPORTED;
-}
-
-const umf_memory_provider_ops_t *umfLevelZeroMemoryProviderOps(void) {
-    // not supported
-    LOG_ERR("L0 memory provider is disabled! (UMF_BUILD_LEVEL_ZERO_PROVIDER is "
-            "OFF)");
-    return NULL;
-}
-
-#else // !defined(UMF_NO_LEVEL_ZERO_PROVIDER)
+#if UMF_BUILD_LEVEL_ZERO_PROVIDER
 
 #include "base_alloc_global.h"
 #include "libumf.h"
@@ -867,4 +785,86 @@ const umf_memory_provider_ops_t *umfLevelZeroMemoryProviderOps(void) {
     return &UMF_LEVEL_ZERO_MEMORY_PROVIDER_OPS;
 }
 
-#endif // !defined(UMF_NO_LEVEL_ZERO_PROVIDER)
+#else // !UMF_BUILD_LEVEL_ZERO_PROVIDER
+
+umf_result_t umfLevelZeroMemoryProviderParamsCreate(
+    umf_level_zero_memory_provider_params_handle_t *hParams) {
+    (void)hParams;
+    LOG_ERR("L0 memory provider is disabled! (UMF_BUILD_LEVEL_ZERO_PROVIDER is "
+            "OFF)");
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+}
+
+umf_result_t umfLevelZeroMemoryProviderParamsDestroy(
+    umf_level_zero_memory_provider_params_handle_t hParams) {
+    (void)hParams;
+    LOG_ERR("L0 memory provider is disabled! (UMF_BUILD_LEVEL_ZERO_PROVIDER is "
+            "OFF)");
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+}
+
+umf_result_t umfLevelZeroMemoryProviderParamsSetContext(
+    umf_level_zero_memory_provider_params_handle_t hParams,
+    ze_context_handle_t hContext) {
+    (void)hParams;
+    (void)hContext;
+    LOG_ERR("L0 memory provider is disabled! (UMF_BUILD_LEVEL_ZERO_PROVIDER is "
+            "OFF)");
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+}
+
+umf_result_t umfLevelZeroMemoryProviderParamsSetDevice(
+    umf_level_zero_memory_provider_params_handle_t hParams,
+    ze_device_handle_t hDevice) {
+    (void)hParams;
+    (void)hDevice;
+    LOG_ERR("L0 memory provider is disabled! (UMF_BUILD_LEVEL_ZERO_PROVIDER is "
+            "OFF)");
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+}
+
+umf_result_t umfLevelZeroMemoryProviderParamsSetMemoryType(
+    umf_level_zero_memory_provider_params_handle_t hParams,
+    umf_usm_memory_type_t memoryType) {
+    (void)hParams;
+    (void)memoryType;
+    LOG_ERR("L0 memory provider is disabled! (UMF_BUILD_LEVEL_ZERO_PROVIDER is "
+            "OFF)");
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+}
+
+umf_result_t umfLevelZeroMemoryProviderParamsSetResidentDevices(
+    umf_level_zero_memory_provider_params_handle_t hParams,
+    ze_device_handle_t *hDevices, uint32_t deviceCount) {
+    (void)hParams;
+    (void)hDevices;
+    (void)deviceCount;
+    LOG_ERR("L0 memory provider is disabled! (UMF_BUILD_LEVEL_ZERO_PROVIDER is "
+            "OFF)");
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+}
+
+umf_result_t umfLevelZeroMemoryProviderParamsSetFreePolicy(
+    umf_level_zero_memory_provider_params_handle_t hParams,
+    umf_level_zero_memory_provider_free_policy_t policy) {
+    (void)hParams;
+    (void)policy;
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+}
+
+umf_result_t umfLevelZeroMemoryProviderParamsSetDeviceOrdinal(
+    umf_level_zero_memory_provider_params_handle_t hParams,
+    uint32_t deviceOrdinal) {
+    (void)hParams;
+    (void)deviceOrdinal;
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+}
+
+const umf_memory_provider_ops_t *umfLevelZeroMemoryProviderOps(void) {
+    // not supported
+    LOG_ERR("L0 memory provider is disabled! (UMF_BUILD_LEVEL_ZERO_PROVIDER is "
+            "OFF)");
+    return NULL;
+}
+
+#endif // !UMF_BUILD_LEVEL_ZERO_PROVIDER


### PR DESCRIPTION

### Description

So far, we have two sets of mutually exclusive compilation definitions in our CMake:

- UMF_NO_LEVEL_ZERO_PROVIDER
- UMF_NO_CUDA_PROVIDER
- UMF_NO_DEVDAX_PROVIDER
- UMF_NO_FILE_PROVIDER

and:

- UMF_BUILD_LEVEL_ZERO_PROVIDER
- UMF_BUILD_CUDA_PROVIDER

This PR removes the UMF_BUILD_NO_* definitions. Also, note that UMF_NO_DEVDAX_PROVIDER and UMF_NO_FILE_PROVIDER were never used.

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

