### PR TITLE
Minor CI changes

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -24,9 +24,9 @@ on:
         description: Runner
         type: choice
         required: true
-        default: 'L0_PERF'
+        default: 'L0_PERF_PVC'
         options:
-          - L0_PERF
+          - L0_PERF_PVC
 
 permissions:
   contents: read

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -382,7 +382,7 @@ jobs:
         --preset Minimal
         --exit-on-failure
       runner: 'L0_PERF_ARC'
-      compatibility: 1
+      compatibility: '1'
 
   SYCL:
     uses: ./.github/workflows/reusable_sycl.yml

--- a/.github/workflows/reusable_benchmarks.yml
+++ b/.github/workflows/reusable_benchmarks.yml
@@ -25,7 +25,7 @@ on:
       compatibility:
         required: false
         type: string
-        default: 0
+        default: '0'
         description: |
           Set it to 1 to run compatibility sycl benchmarks
 

--- a/.github/workflows/reusable_sycl.yml
+++ b/.github/workflows/reusable_sycl.yml
@@ -28,10 +28,11 @@ jobs:
     - name: Download llvm daily release
       run: |
         if [ "${{ matrix.llvm_tag }}" == "latest" ]; then
-          llvm_tag=$(curl -s https://api.github.com/repos/intel/llvm/releases | awk -F'"' '/"tag_name":/ {print $4; exit}')
+          llvm_tag=$(curl -s https://api.github.com/repos/intel/llvm/releases | awk -F'"' '/"tag_name": "nightly/ {print $4; exit}')
         else
           llvm_tag="${{ matrix.llvm_tag }}"
         fi
+        echo "llvm tag: $llvm_tag"
         download_url="https://github.com/intel/llvm/releases/download/${llvm_tag}/sycl_linux.tar.gz"
         wget --no-verbose $download_url -O sycl_linux.tar.gz
 


### PR DESCRIPTION
Includes update for nightly sycl build, to avoid: https://github.com/oneapi-src/unified-memory-framework/actions/runs/15104034834/job/42449512722#step:3:12

The issue above was caused by a sycl release, which:
- uses different file name with sycl release, and
- has the codebase from November, expecting different UMF version.

\
// preview of nightly job: https://github.com/oneapi-src/unified-memory-framework/actions/runs/15116081326?pr=1321