### PR TITLE
reset BA destroy flag on BA create

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,11 +59,11 @@ jobs:
 
       - name: Run regular tests
         working-directory: ${{github.workspace}}/build
-        run: ctest -C ${{matrix.build_type}} --output-on-failure -E "fuzz|test_init_teardown"
+        run: ctest -C ${{matrix.build_type}} --output-on-failure -E "fuzz"
 
       - name: Run regular tests with proxy library
         working-directory: ${{env.BUILD_DIR}}
-        run: LD_PRELOAD=./lib/libumf_proxy.so ctest -C ${{matrix.build_type}} --output-on-failure -E "fuzz|test_init_teardown"
+        run: LD_PRELOAD=./lib/libumf_proxy.so ctest -C ${{matrix.build_type}} --output-on-failure -E "fuzz"
 
       - name: Fuzz long test
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/reusable_multi_numa.yml
+++ b/.github/workflows/reusable_multi_numa.yml
@@ -57,12 +57,11 @@ jobs:
         # On RHEL/SLES, hwloc version is just a little too low.
         # Skip some tests until we upgrade hwloc and update CMake to properly handle local hwloc installation.
         # TODO: fix issue #560
-        # TODO: add issue for -E test_init_teardown - it is not clear why it fails
       - name: Run tests (on RHEL/SLES)
         if: (matrix.os == 'rhel-9.1') || (matrix.os == 'sles-15')
         working-directory: ${{github.workspace}}/build
         run: |
-          ctest --output-on-failure --test-dir test -E "test_provider_os_memory_multiple_numa_nodes|test_init_teardown"
+          ctest --output-on-failure --test-dir test -E "test_provider_os_memory_multiple_numa_nodes"
           ./test/test_provider_os_memory_multiple_numa_nodes \
             --gtest_filter="-*checkModeLocal/*:*checkModePreferredEmptyNodeset/*:testNuma.checkModeInterleave"
 

--- a/src/base_alloc/base_alloc_global.c
+++ b/src/base_alloc/base_alloc_global.c
@@ -41,6 +41,7 @@ struct base_alloc_t {
 static struct base_alloc_t BASE_ALLOC = {.ac_sizes = ALLOCATION_CLASSES};
 
 void umf_ba_destroy_global(void) {
+    LOG_DEBUG("destroying global base allocator");
     ba_is_destroyed = true;
 
     for (int i = 0; i < NUM_ALLOCATION_CLASSES; i++) {
@@ -73,7 +74,8 @@ static void umf_ba_create_global(void) {
     size_t smallestSize = BASE_ALLOC.ac_sizes[0];
     BASE_ALLOC.smallest_ac_size_log2 = utils_msb64(smallestSize);
 
-    LOG_DEBUG("UMF base allocator created");
+    LOG_DEBUG("global base allocator created");
+    ba_is_destroyed = false;
 }
 
 // returns index of the allocation class for a given size

--- a/src/provider/provider_tracking.c
+++ b/src/provider/provider_tracking.c
@@ -729,9 +729,8 @@ static umf_result_t trackingFree(void *hProvider, void *ptr, size_t size) {
 
         if (umfMemoryTrackerAdd(p->hTracker, p->pool, ptr, size) !=
             UMF_RESULT_SUCCESS) {
-            LOG_ERR(
-                "cannot add memory back to the tracker, ptr = %p, size = %zu",
-                ptr, size);
+            LOG_ERR("cannot add memory back to the tracker, ptr=%p, size=%zu",
+                    ptr, size);
         }
         return ret;
     }
@@ -770,6 +769,10 @@ static void check_if_tracker_is_empty(umf_memory_tracker_handle_t hTracker,
                                  FIND_G, &rkey, (void **)&rvalue)) {
             if (rvalue->pool == pool || pool == NULL) {
                 n_items++;
+                LOG_DEBUG(
+                    "found abandoned allocation in the tracking provider: "
+                    "pool=%p, ptr=%p, size=%zu",
+                    (void *)rvalue->pool, (void *)rkey, (size_t)rvalue->size);
             }
 
             last_key = rkey;


### PR DESCRIPTION
This PR ensures the global base allocator’s destroyed flag is reset on creation and re-enables the test_init_teardown in CI.

- Reset ba_is_destroyed to false in umf_ba_create_global
- Add and adjust debug logs in the memory tracker and base allocator
- Remove exclusion of test_init_teardown from CI workflows