### PR TITLE
[CI][QEMU] Bump latest Ubuntu version used

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -357,7 +357,7 @@ jobs:
       short_run: false
       # Beside the 2 LTS Ubuntu, we also test this on the latest Ubuntu -  to be updated
       # every 6 months, so we verify the latest version of packages (compilers, etc.).
-      os: "['ubuntu-22.04', 'ubuntu-24.04', 'ubuntu-24.10']"
+      os: "['ubuntu-22.04', 'ubuntu-24.04', 'ubuntu-25.04']"
 
   Benchmarks:
     uses: ./.github/workflows/reusable_benchmarks.yml


### PR DESCRIPTION
Bump the latest (non-LTS) Ubuntu version in QEMU CI job.

// Preview on my fork: https://github.com/lukaszstolarczuk/unified-memory-framework/actions/runs/15184572304/job/42701871803