### PR TITLE
Add LOG_FATAL() when memory leaks in base allocator occurred

### DIFF
--- a/src/base_alloc/base_alloc.c
+++ b/src/base_alloc/base_alloc.c
@@ -304,12 +304,14 @@ void umf_ba_destroy(umf_ba_pool_t *pool) {
 #ifndef NDEBUG
     ba_debug_checks(pool);
     if (pool->metadata.n_allocs) {
-        LOG_ERR("number of base allocator memory leaks: %zu",
-                pool->metadata.n_allocs);
-
 #ifdef UMF_DEVELOPER_MODE
+        LOG_FATAL("number of base allocator memory leaks: %zu",
+                  pool->metadata.n_allocs);
         assert(pool->metadata.n_allocs == 0 &&
                "memory leaks in base allocator occurred");
+#else
+        LOG_ERR("number of base allocator memory leaks: %zu",
+                pool->metadata.n_allocs);
 #endif
     }
 #endif /* NDEBUG */


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

Add LOG_FATAL() when memory leaks in base allocator occurred.

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
