### PR TITLE
Fix checking num of targets in memspace CapacityFilter test

### DIFF
--- a/.github/workflows/reusable_qemu.yml
+++ b/.github/workflows/reusable_qemu.yml
@@ -98,7 +98,7 @@ jobs:
       if: ${{ inputs.short_run == true }}
       run: |
         echo "SHORT_RUN=true" >> $GITHUB_ENV
-        declare -a short_configs=("default.xml" "sock_2_var3.xml" "sock_4_var1_hmat.xml")
+        declare -a short_configs=("default.xml" "sock_2_var3.xml" "sock_8_var1_hmat.xml")
         echo "CONFIG_OPTIONS=${short_configs[@]}" >> $GITHUB_ENV
 
     - name: Set vars if long run

--- a/test/memspaces/memspace_numa.cpp
+++ b/test/memspaces/memspace_numa.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 Intel Corporation
+// Copyright (C) 2023-2025 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -252,8 +252,8 @@ TEST_F(numaNodesCapacityTest, CapacityFilter) {
     ret = umfMemspaceFilterByCapacity(hMemspace, filter_size);
     ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
 
-    ASSERT_EQ(umfMemspaceMemtargetNum(hMemspace), (capacities.size() + 1) / 2);
-    for (size_t i = 0; i < umfMemspaceMemtargetNum(hMemspace); i++) {
+    size_t num_filtered = umfMemspaceMemtargetNum(hMemspace);
+    for (size_t i = 0; i < num_filtered; i++) {
         auto hTarget = umfMemspaceMemtargetGet(hMemspace, i);
         ASSERT_NE(hTarget, nullptr);
         size_t capacity;
@@ -266,6 +266,17 @@ TEST_F(numaNodesCapacityTest, CapacityFilter) {
             capacities.erase(it);
         }
     }
+
+    // Number of filtered targets and remaining targets should match the total
+    // number of targets in the memspace
+    size_t num_all = umfMemspaceMemtargetNum(umfMemspaceHostAllGet());
+    ASSERT_EQ(num_filtered + capacities.size(), num_all);
+
+    // check that remaining capacities are less than filter_size
+    for (const auto &capacity : capacities) {
+        ASSERT_LT(capacity, filter_size);
+    }
+
     umfMemspaceDestroy(hMemspace);
 }
 


### PR DESCRIPTION
Fix checking the number of targets in the memspace CapacityFilter test.
Additionally, test the 8-socket config in the short run suite.
