### PR TITLE
Fix implicit cast between ze and usm enums

### DIFF
--- a/src/provider/provider_level_zero.c
+++ b/src/provider/provider_level_zero.c
@@ -129,6 +129,32 @@ static umf_result_t ze2umf_result(ze_result_t result) {
     }
 }
 
+static umf_usm_memory_type_t ze2umf_memory_type(ze_memory_type_t memory_type) {
+    switch (memory_type) {
+    case ZE_MEMORY_TYPE_HOST:
+        return UMF_MEMORY_TYPE_HOST;
+    case ZE_MEMORY_TYPE_DEVICE:
+        return UMF_MEMORY_TYPE_DEVICE;
+    case ZE_MEMORY_TYPE_SHARED:
+        return UMF_MEMORY_TYPE_SHARED;
+    default:
+        return UMF_MEMORY_TYPE_UNKNOWN;
+    }
+}
+
+static ze_memory_type_t umf2ze_memory_type(umf_usm_memory_type_t memory_type) {
+    switch (memory_type) {
+    case UMF_MEMORY_TYPE_HOST:
+        return ZE_MEMORY_TYPE_HOST;
+    case UMF_MEMORY_TYPE_DEVICE:
+        return ZE_MEMORY_TYPE_DEVICE;
+    case UMF_MEMORY_TYPE_SHARED:
+        return ZE_MEMORY_TYPE_SHARED;
+    default:
+        return ZE_MEMORY_TYPE_UNKNOWN;
+    }
+}
+
 static void init_ze_global_state(void) {
 #ifdef _WIN32
     const char *lib_name = "ze_loader.dll";
@@ -343,7 +369,7 @@ static umf_result_t ze_memory_provider_alloc(void *provider, size_t size,
     ze_memory_provider_t *ze_provider = (ze_memory_provider_t *)provider;
 
     ze_result_t ze_result = ZE_RESULT_SUCCESS;
-    switch (ze_provider->memory_type) {
+    switch (ze2umf_memory_type(ze_provider->memory_type)) {
     case UMF_MEMORY_TYPE_HOST: {
         ze_host_mem_alloc_desc_t host_desc = {
             .stype = ZE_STRUCTURE_TYPE_HOST_MEM_ALLOC_DESC,
@@ -502,7 +528,7 @@ static umf_result_t ze_memory_provider_initialize(const void *params,
 
     ze_provider->context = ze_params->level_zero_context_handle;
     ze_provider->device = ze_params->level_zero_device_handle;
-    ze_provider->memory_type = (ze_memory_type_t)ze_params->memory_type;
+    ze_provider->memory_type = umf2ze_memory_type(ze_params->memory_type);
     ze_provider->freePolicyFlags =
         umfFreePolicyToZePolicy(ze_params->freePolicy);
     ze_provider->min_page_size = 0;


### PR DESCRIPTION

### Description

This PR fixes following error:
```
provider_level_zero.c
         Running Code Analysis for C/C++...
     9>C:\actions-runner\_work\unified-memory-framework\unified-memory-framework\src\provider\provider_level_zero.c(347,10): error C2220: the following warning is treated as an error [C:\actions-runner\_work\unified-memory-framework\unified-memory-framework\build\src\umf.vcxproj]
     9>C:\actions-runner\_work\unified-memory-framework\unified-memory-framework\src\provider\provider_level_zero.c(347,10): warning C5286: implicit conversion from enum type 'umf_usm_memory_type_t' to enum type '_ze_memory_type_t'; use an explicit cast to silence this warning [C:\actions-runner\_work\unified-memory-framework\unified-memory-framework\build\src\umf.vcxproj]
             C:\actions-runner\_work\unified-memory-framework\unified-memory-framework\src\provider\provider_level_zero.c(347,10):
             to simplify migration, consider the temporary use of /Wv:18 flag with the version of the compiler with which you used to build without warnings
         
     9>C:\actions-runner\_work\unified-memory-framework\unified-memory-framework\src\provider\provider_level_zero.c([356](https://github.com/luszczewskakasia1/unified-memory-framework/actions/runs/15319734031/job/43101588740#step:4:357),10): warning C5286: implicit conversion from enum type 'umf_usm_memory_type_t' to enum type '_ze_memory_type_t'; use an explicit cast to silence this warning [C:\actions-runner\_work\unified-memory-framework\unified-memory-framework\build\src\umf.vcxproj]
             C:\actions-runner\_work\unified-memory-framework\unified-memory-framework\src\provider\provider_level_zero.c(356,10):
             to simplify migration, consider the temporary use of /Wv:18 flag with the version of the compiler with which you used to build without warnings
         
     9>C:\actions-runner\_work\unified-memory-framework\unified-memory-framework\src\provider\provider_level_zero.c(369,10): warning C5286: implicit conversion from enum type 'umf_usm_memory_type_t' to enum type '_ze_memory_type_t'; use an explicit cast to silence this warning [C:\actions-runner\_work\unified-memory-framework\unified-memory-framework\build\src\umf.vcxproj]
             C:\actions-runner\_work\unified-memory-framework\unified-memory-framework\src\provider\provider_level_zero.c(369,10):
             to simplify migration, consider the temporary use of /Wv:18 flag with the version of the compiler with which you used to build without warnings
```

Log taken from: https://github.com/luszczewskakasia1/unified-memory-framework/actions/runs/15319734031/job/43101588740

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
- [ ] All API changes are reflected in docs and def/map files, and are tested
