### PR TITLE
Fix Coverity issue COPY_INSTEAD_OF_MOVE

### DIFF
--- a/test/ctl/ctl_api.cpp
+++ b/test/ctl/ctl_api.cpp
@@ -311,8 +311,8 @@ TEST_F(CtlTest, ctlNameValidation) {
         auto ret = p.instantiatePool(umfDisjointPoolOps(), params);
         ASSERT_EQ(ret, 0);
 
-        p.validateQuery(umfCtlGet, "umf.pool.by_handle.disjoint.name", std::move(value),
-                        UMF_RESULT_SUCCESS);
+        p.validateQuery(umfCtlGet, "umf.pool.by_handle.disjoint.name",
+                        std::move(value), UMF_RESULT_SUCCESS);
     } catch (...) {
         GTEST_FAIL() << "Unknown exception!";
     }


### PR DESCRIPTION
Fix Coverity issue COPY_INSTEAD_OF_MOVE in /test/ctl/ctl_api.cpp at line 314
Creating a copy of a variable that is no longer used instead of using std::move().
