### PR TITLE
Fix Coverity issue BUFFER_SIZE

### DIFF
--- a/src/memory_pool.c
+++ b/src/memory_pool.c
@@ -65,7 +65,9 @@ static int CTL_SUBTREE_HANDLER(default)(void *ctx,
             if (CTL_DEFAULT_ENTRIES[i][0] == '\0' ||
                 strcmp(CTL_DEFAULT_ENTRIES[i], extra_name) == 0) {
                 strncpy(CTL_DEFAULT_ENTRIES[i], extra_name, UMF_DEFAULT_LEN);
+                CTL_DEFAULT_ENTRIES[i][UMF_DEFAULT_LEN - 1] = '\0';
                 strncpy(CTL_DEFAULT_VALUES[i], arg, UMF_DEFAULT_LEN);
+                CTL_DEFAULT_VALUES[i][UMF_DEFAULT_LEN - 1] = '\0';
                 break;
             }
         }


### PR DESCRIPTION
Fix Coverity issue BUFFER_SIZE in /src/memory_pool.c at line 67
The string buffer may not have a null terminator if the source string&#39;s length is equal to the buffer size
