### PR TITLE
fix __builtin_strncpy truncated compilation error

### DIFF
--- a/src/provider/provider_devdax_memory.c
+++ b/src/provider/provider_devdax_memory.c
@@ -417,7 +417,7 @@ static umf_result_t devdax_get_ipc_handle(void *provider, const void *ptr,
         (devdax_memory_provider_t *)provider;
 
     devdax_ipc_data_t *devdax_ipc_data = (devdax_ipc_data_t *)providerIpcData;
-    strncpy(devdax_ipc_data->path, devdax_provider->path, PATH_MAX - 1);
+    strncpy(devdax_ipc_data->path, devdax_provider->path, PATH_MAX);
     devdax_ipc_data->path[PATH_MAX - 1] = '\0';
     devdax_ipc_data->protection = devdax_provider->protection;
     devdax_ipc_data->offset =

--- a/src/provider/provider_file_memory.c
+++ b/src/provider/provider_file_memory.c
@@ -745,7 +745,7 @@ static umf_result_t file_get_ipc_handle(void *provider, const void *ptr,
     file_ipc_data_t *file_ipc_data = (file_ipc_data_t *)providerIpcData;
     file_ipc_data->offset_fd = (size_t)value - 1;
     file_ipc_data->size = size;
-    strncpy(file_ipc_data->path, file_provider->path, PATH_MAX - 1);
+    strncpy(file_ipc_data->path, file_provider->path, PATH_MAX);
     file_ipc_data->path[PATH_MAX - 1] = '\0';
     file_ipc_data->protection = file_provider->protection;
     file_ipc_data->visibility = file_provider->visibility;


### PR DESCRIPTION
error: ‘__builtin_strncpy’ output may be truncated copying 4095 bytes from a string of length 4095 [-Werror=stringop-truncation]

<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
- [ ] All API changes are reflected in docs and def/map files, and are tested
