### PR TITLE
Turn off UMF_DEVELOPER_MODE in CI Sanitizers jobs

### DIFF
--- a/.github/workflows/reusable_sanitizers.yml
+++ b/.github/workflows/reusable_sanitizers.yml
@@ -53,7 +53,7 @@ jobs:
         -DUMF_BUILD_LEVEL_ZERO_PROVIDER=ON
         -DUMF_BUILD_CUDA_PROVIDER=ON
         -DUMF_FORMAT_CODE_STYLE=OFF
-        -DUMF_DEVELOPER_MODE=ON
+        -DUMF_DEVELOPER_MODE=OFF
         -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
         -DUMF_USE_ASAN=${{matrix.sanitizers.asan}}
         -DUMF_USE_UBSAN=${{matrix.sanitizers.ubsan}}
@@ -125,7 +125,7 @@ jobs:
         -DCMAKE_PREFIX_PATH="${{env.VCPKG_PATH}}"
         -DUMF_BUILD_SHARED_LIBRARY=OFF
         -DUMF_FORMAT_CODE_STYLE=OFF
-        -DUMF_DEVELOPER_MODE=ON
+        -DUMF_DEVELOPER_MODE=OFF
         -DUMF_USE_ASAN=${{matrix.sanitizers.asan}}
         -DUMF_BUILD_EXAMPLES=ON
         -DUMF_BUILD_LEVEL_ZERO_PROVIDER=OFF

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -54,7 +54,7 @@ jobs:
         -DUMF_BUILD_LEVEL_ZERO_PROVIDER=ON
         -DUMF_BUILD_CUDA_PROVIDER=ON
         -DUMF_FORMAT_CODE_STYLE=OFF
-        -DUMF_DEVELOPER_MODE=ON
+        -DUMF_DEVELOPER_MODE=OFF
         -DUMF_BUILD_LIBUMF_POOL_JEMALLOC=ON
         -DUMF_USE_ASAN=${{matrix.sanitizers.asan}}
         -DUMF_USE_UBSAN=${{matrix.sanitizers.ubsan}}


### PR DESCRIPTION

<!-- Provide a short summary of your changes in the Title above -->

### Description

The UMF_DEVELOPER_MODE option turns on various additional debug checks that should be turned off in all Valgrind and Sanitizers builds, because we do not want to look for races in additional debug checks.

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
