### PR TITLE
[disjoint] Set default parameters for disjoint pool

### DIFF
--- a/examples/ipc_level_zero/ipc_level_zero.c
+++ b/examples/ipc_level_zero/ipc_level_zero.c
@@ -76,6 +76,13 @@ int create_level_zero_pool(ze_context_handle_t context,
         goto provider_destroy;
     }
 
+    // Set max poolable size to 0
+    umf_result = umfDisjointPoolParamsSetMaxPoolableSize(disjoint_params, 0);
+    if (umf_result != UMF_RESULT_SUCCESS) {
+        fprintf(stderr, "ERROR: Failed to set max poolable size!\n");
+        goto provider_destroy;
+    }
+
     // create pool
     umf_pool_create_flags_t flags = UMF_POOL_CREATE_FLAG_OWN_PROVIDER;
     umf_result = umfPoolCreate(umfDisjointPoolOps(), provider, disjoint_params,

--- a/include/umf/pools/pool_disjoint.h
+++ b/include/umf/pools/pool_disjoint.h
@@ -53,6 +53,7 @@ umf_result_t
 umfDisjointPoolParamsDestroy(umf_disjoint_pool_params_handle_t hParams);
 
 /// @brief Set minimum allocation size that will be requested from the memory provider.
+/// @details Default value for minimum size of slab's is 64KB.
 /// @param hParams handle to the parameters of the disjoint pool.
 /// @param slabMinSize minimum allocation size.
 /// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
@@ -61,6 +62,7 @@ umfDisjointPoolParamsSetSlabMinSize(umf_disjoint_pool_params_handle_t hParams,
                                     size_t slabMinSize);
 
 /// @brief Set size limit for allocations that are subject to pooling.
+/// @details Default value for maximum poolable size is 2MB.
 /// @param hParams handle to the parameters of the disjoint pool.
 /// @param maxPoolableSize maximum poolable size.
 /// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
@@ -69,6 +71,7 @@ umf_result_t umfDisjointPoolParamsSetMaxPoolableSize(
 
 /// @brief Set maximum capacity of each bucket. Each bucket will hold a
 ///        max of \p maxCapacity unfreed slabs.
+/// @details Default value for capacity is 4.
 /// @param hParams handle to the parameters of the disjoint pool.
 /// @param maxCapacity maximum capacity of each bucket.
 /// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
@@ -77,6 +80,7 @@ umfDisjointPoolParamsSetCapacity(umf_disjoint_pool_params_handle_t hParams,
                                  size_t maxCapacity);
 
 /// @brief Set minimum bucket allocation size.
+/// @details Default value for minimum bucket size is 8.
 /// @param hParams handle to the parameters of the disjoint pool.
 /// @param minBucketSize minimum bucket size. Must be power of 2.
 /// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure.
@@ -85,6 +89,7 @@ umfDisjointPoolParamsSetMinBucketSize(umf_disjoint_pool_params_handle_t hParams,
                                       size_t minBucketSize);
 
 /// @brief Set trace level for pool usage statistics.
+/// @details Default value for pool trace is 0 (no traces).
 /// @param hParams handle to the parameters of the disjoint pool.
 /// @param poolTrace trace level.
 /// @return UMF_RESULT_SUCCESS on success or appropriate error code on failure.

--- a/src/pool/pool_disjoint.c
+++ b/src/pool/pool_disjoint.c
@@ -1102,9 +1102,9 @@ umfDisjointPoolParamsCreate(umf_disjoint_pool_params_handle_t *hParams) {
     }
 
     *params = (umf_disjoint_pool_params_t){
-        .slab_min_size = 0,
-        .max_poolable_size = 0,
-        .capacity = 0,
+        .slab_min_size = 64 * 1024,           // 64K
+        .max_poolable_size = 2 * 1024 * 1024, // 2MB
+        .capacity = 4,
         .min_bucket_size = UMF_DISJOINT_POOL_MIN_BUCKET_DEFAULT_SIZE,
         .cur_pool_size = 0,
         .pool_trace = 0,

--- a/src/pool/pool_disjoint_internal.h
+++ b/src/pool/pool_disjoint_internal.h
@@ -110,23 +110,23 @@ typedef struct umf_disjoint_pool_shared_limits_t {
 
 typedef struct umf_disjoint_pool_params_t {
     // Minimum allocation size that will be requested from the memory provider.
-    size_t slab_min_size;
+    size_t slab_min_size; // Default: 64KB
 
     // Allocations up to this limit will be subject to chunking/pooling
-    size_t max_poolable_size;
+    size_t max_poolable_size; // Default: 2MB
 
     // When pooling, each bucket will hold a max of 'capacity' unfreed slabs
-    size_t capacity;
+    size_t capacity; // Default: 4
 
     // Holds the minimum bucket size valid for allocation of a memory type.
     // This value must be a power of 2.
-    size_t min_bucket_size;
+    size_t min_bucket_size; // Default: 8
 
     // Holds size of the pool managed by the allocator.
-    size_t cur_pool_size;
+    size_t cur_pool_size; // Default: 0
 
     // Whether to print pool usage statistics
-    int pool_trace;
+    int pool_trace; // Default: 0
 
     // Memory limits that can be shared between multiple pool instances,
     // i.e. if multiple pools use the same shared_limits sum of those pools'


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

fixes https://github.com/oneapi-src/unified-memory-framework/issues/804

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
- [ ] All API changes are reflected in docs and def/map files, and are tested
