### PR TITLE
Decrease number of iterations for sanitizers looped job to 400

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -10,6 +10,7 @@ on:
 env:
   BUILD_DIR : "${{github.workspace}}/build"
   INSTL_DIR : "${{github.workspace}}/install-dir"
+  N_ITER_SAN : 400 # Number of iterations for sanitizers looped job
 
 permissions:
   contents: read
@@ -72,4 +73,4 @@ jobs:
       env:
         ASAN_OPTIONS: allocator_may_return_null=1
         TSAN_OPTIONS: allocator_may_return_null=1
-      run: for i in {1..600}; do echo ">>> ITERATION no. ${i}" ; ctest --output-on-failure || exit 1; date; done
+      run: for i in {1..${{env.N_ITER_SAN}}}; do echo ">>> ITERATION no. ${i}" ; ctest --output-on-failure || exit 1; date; done


### PR DESCRIPTION

<!-- Provide a short summary of your changes in the Title above -->

### Description

Decrease number of iterations for sanitizers looped job to 400, 
since 449 is the hard limit for one of jobs ("Sanitizers looped (gcc, g++, OFF, OFF, ON)"): 
https://github.com/oneapi-src/unified-memory-framework/actions/runs/15790722805/job/44515871707

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
