### PR TITLE
Add test for FetchContent of UMF on Linux and Windows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -201,6 +201,30 @@ jobs:
         ${{ matrix.umfd_lib == 'ON' && '--umfd-lib' || ''}}
         ${{ matrix.static_hwloc == 'ON' && '--hwloc' || '' }}
 
+    - name: Set VCPKG_PATH with hwloc for the fetch_content example
+      run: echo "VCPKG_PATH=${{github.workspace}}/build/vcpkg/packages/hwloc_x64-windows;${{github.workspace}}/build/vcpkg/packages/tbb_x64-windows;${{github.workspace}}/build/vcpkg/packages/jemalloc_x64-windows" >> $env:GITHUB_ENV
+
+    - name: Configure the fetch_content example
+      working-directory: ${{github.workspace}}/examples/fetch_content
+      # Fetch_Content the UMF code from the current repository (-DUMF_REPO="${{github.workspace}}")
+      run: >
+        cmake
+        -B ${{github.workspace}}/examples/fetch_content/build
+        -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+        -DCMAKE_PREFIX_PATH="${{env.VCPKG_PATH}}"
+        -DUMF_REPO="${{github.workspace}}"
+        -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
+        -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
+        -G "${{matrix.generator}}"
+
+    - name: Build the fetch_content example
+      working-directory: ${{github.workspace}}/examples/fetch_content
+      run: cmake --build ${{github.workspace}}/examples/fetch_content/build --config ${{matrix.build_type}} -j $env:NUMBER_OF_PROCESSORS
+
+    - name: Run the fetch_content example
+      working-directory: ${{github.workspace}}/examples/fetch_content/build
+      run: ctest -V
+
   # Build and test UMF with Intel C++ Compiler (ICX) on Windows
   Windows-icx:
    env:

--- a/examples/fetch_content/CMakeLists.txt
+++ b/examples/fetch_content/CMakeLists.txt
@@ -1,0 +1,73 @@
+# Copyright (C) 2025 Intel Corporation
+# Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+cmake_minimum_required(VERSION 3.14.0 FATAL_ERROR)
+project(umf_example_fetch_content LANGUAGES C)
+enable_testing()
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    set(LINUX TRUE)
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    set(WINDOWS TRUE)
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(MACOSX TRUE)
+else()
+    message(FATAL_ERROR "Unknown OS type")
+endif()
+
+set(UMF_EXAMPLE_DIR "${CMAKE_SOURCE_DIR}/..")
+list(APPEND CMAKE_MODULE_PATH "${UMF_EXAMPLE_DIR}/cmake")
+message(STATUS "CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}")
+
+include("fetch_umf.cmake")
+
+find_package(PkgConfig)
+pkg_check_modules(LIBHWLOC hwloc>=2.3.0)
+if(NOT LIBHWLOC_FOUND)
+    find_package(LIBHWLOC 2.3.0 REQUIRED hwloc)
+endif()
+
+pkg_check_modules(TBB tbb)
+if(NOT TBB_FOUND)
+    find_package(TBB REQUIRED tbb)
+endif()
+
+# build the example
+set(EXAMPLE_NAME umf_example_fetch_content)
+# reusing the basic.c source file from the basic example
+add_executable(${EXAMPLE_NAME} ${CMAKE_SOURCE_DIR}/../basic/basic.c)
+target_include_directories(${EXAMPLE_NAME} PRIVATE ${LIBUMF_INCLUDE_DIRS})
+target_link_directories(${EXAMPLE_NAME} PRIVATE ${LIBHWLOC_LIBRARY_DIRS})
+target_link_libraries(${EXAMPLE_NAME} PRIVATE ${LIBUMF_LIBRARIES} hwloc)
+
+# an optional part - adds a test of this example
+add_test(
+    NAME ${EXAMPLE_NAME}
+    COMMAND ${EXAMPLE_NAME}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+set_tests_properties(${EXAMPLE_NAME} PROPERTIES LABELS "example-standalone")
+
+if(LINUX)
+    # set LD_LIBRARY_PATH
+    set_property(
+        TEST ${EXAMPLE_NAME}
+        PROPERTY
+            ENVIRONMENT_MODIFICATION
+            "LD_LIBRARY_PATH=path_list_append:${LIBUMF_LIBRARY_DIRS};LD_LIBRARY_PATH=path_list_append:${LIBHWLOC_LIBRARY_DIRS}"
+    )
+elseif(WINDOWS)
+    # add PATH to DLL on Windows
+    set(DLL_PATH_LIST
+        "${DLL_PATH_LIST};PATH=path_list_append:${LIBHWLOC_DLL_DIRS};PATH=path_list_append:${TBB_DLL_DIRS}"
+    )
+
+    message(STATUS "DLL_PATH_LIST=${DLL_PATH_LIST}")
+
+    # append PATH to DLLs NOTE: this would work only for the CMake ver >= #
+    # 3.22. For the older versions, the PATH variable should be set in the test
+    # script)
+    set_property(TEST ${EXAMPLE_NAME} PROPERTY ENVIRONMENT_MODIFICATION
+                                               "${DLL_PATH_LIST}")
+endif()

--- a/examples/fetch_content/fetch_umf.cmake
+++ b/examples/fetch_content/fetch_umf.cmake
@@ -1,0 +1,64 @@
+# Copyright (C) 2025 Intel Corporation
+# Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+message(STATUS "Downloading Unified Memory Framework ...")
+
+include(FetchContent)
+
+if(NOT DEFINED UMF_REPO)
+    set(UMF_REPO "https://github.com/oneapi-src/unified-memory-framework.git")
+elseif(WINDOWS)
+    string(REPLACE "\\" "/" OUT_UMF_REPO "${UMF_REPO}")
+    message(
+        STATUS
+            "Replaced \"${UMF_REPO}\" with \"${OUT_UMF_REPO}\" for Windows compatibility"
+    )
+    set(UMF_REPO "${OUT_UMF_REPO}")
+endif()
+
+if(NOT DEFINED UMF_TAG)
+    set(UMF_TAG HEAD)
+endif()
+
+message(
+    STATUS
+        "Will fetch Unified Memory Framework from ${UMF_REPO} at ${UMF_TAG} ..."
+)
+message(STATUS "CMAKE_GENERATOR: ${CMAKE_GENERATOR}")
+
+FetchContent_Declare(
+    unified-memory-framework
+    GIT_REPOSITORY ${UMF_REPO}
+    GIT_TAG ${UMF_TAG})
+
+set(UMF_BUILD_TESTS
+    OFF
+    CACHE INTERNAL "Do not build UMF tests")
+set(UMF_BUILD_EXAMPLES
+    OFF
+    CACHE INTERNAL "Do not build UMF examples")
+set(UMF_BUILD_SHARED_LIBRARY
+    OFF
+    CACHE INTERNAL "Build UMF shared library")
+set(UMF_BUILD_LIBUMF_POOL_DISJOINT
+    ON
+    CACHE INTERNAL "Build Disjoint Pool")
+set(UMF_BUILD_CUDA_PROVIDER
+    OFF
+    CACHE INTERNAL "Do not build CUDA provider")
+set(UMF_BUILD_LEVEL_ZERO_PROVIDER
+    OFF
+    CACHE INTERNAL "Do not build L0 provider")
+set(UMF_DISABLE_HWLOC
+    OFF
+    CACHE INTERNAL "Enable HWLOC support")
+set(UMF_LINK_HWLOC_STATICALLY
+    OFF
+    CACHE INTERNAL "UMF_LINK_HWLOC_STATICALLY=OFF")
+
+FetchContent_MakeAvailable(unified-memory-framework)
+FetchContent_GetProperties(unified-memory-framework)
+
+set(LIBUMF_INCLUDE_DIRS ${unified-memory-framework_SOURCE_DIR}/include)
+set(LIBUMF_LIBRARIES umf::umf umf::headers)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -672,11 +672,11 @@ if(LINUX
     set(EXAMPLES "")
 
     if(UMF_POOL_SCALABLE_ENABLED)
-        set(EXAMPLES ${EXAMPLES} basic custom_file_provider)
+        set(EXAMPLES ${EXAMPLES} basic fetch_content custom_file_provider)
     else()
         message(
             STATUS
-                "The basic and custom_file_provider examples require TBB to be installed and added to the default library search path - skipping"
+                "The basic, fetch_content and custom_file_provider examples require TBB to be installed and added to the default library search path - skipping"
         )
     endif()
 


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

Test FetchContent of UMF on Linux and Windows -
on Windows with the 'Ninja' and 'NMake Makefiles' generators.

Add the fetch_content example based on the basic example.

Nightly CI build: https://github.com/ldorau/unified-memory-framework/actions/runs/16030235338

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
