### PR TITLE
Update intel/llvm benchmarks used in CI

### DIFF
--- a/.github/workflows/reusable_benchmarks.yml
+++ b/.github/workflows/reusable_benchmarks.yml
@@ -126,9 +126,9 @@ jobs:
         repository: intel/llvm
         # Note: The same ref is used in docs build (for dashboard generation)!
         #
-        # 15.04.2025
+        # 27.06.2025
         # branch: sycl
-        ref: 08d11bcae0cc2daec903f222c9b3e3af92f3b806
+        ref: 3b04aeb7d1d4ad5bbe64fb257f4ca6e5284ec5d0
         path: sc
         sparse-checkout: |
           devops/scripts/benchmarks
@@ -239,7 +239,7 @@ jobs:
             body: body
           })
 
-    - name: Commit data.json and results directory
+    - name: Commit data.json, data_archive.json, and results directory
       working-directory: results-repo
       if: inputs.compatibility == 0
       run: |
@@ -249,11 +249,12 @@ jobs:
         for attempt in {1..5}; do
           echo "Attempt #$attempt to push changes"
 
-          rm -f data.json
+          rm -f data.json data_archive.json
           cp ${{ github.workspace }}/sc/devops/scripts/benchmarks/html/data.json .
+          cp ${{ github.workspace }}/sc/devops/scripts/benchmarks/html/data_archive.json .
 
-          git add data.json results/
-          git commit -m "Add benchmark results and data.json"
+          git add data.json data_archive.json results/
+          git commit -m "Add benchmark results, data.json, and data_archive.json"
 
           results_file=$(git diff HEAD~1 --name-only -- results/ | head -n 1)
 
@@ -274,7 +275,7 @@ jobs:
             mv ${{ github.workspace }}/temp_$(basename $results_file) $new_file
           fi
 
-          echo "Regenerating data.json"
+          echo "Regenerating data.json and data_archive.json"
           (cd ${{ github.workspace }} && ${{ github.workspace }}/sc/devops/scripts/benchmarks/main.py ~/bench_workdir_umf --dry-run --results-dir ${{ github.workspace }}/results-repo --output-html remote)
 
         done

--- a/.github/workflows/reusable_docs_build.yml
+++ b/.github/workflows/reusable_docs_build.yml
@@ -54,9 +54,9 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         repository: intel/llvm
-        # 15.04.2025
+        # 27.06.2025
         # branch: sycl
-        ref: 08d11bcae0cc2daec903f222c9b3e3af92f3b806
+        ref: 3b04aeb7d1d4ad5bbe64fb257f4ca6e5284ec5d0
         path: sc
         sparse-checkout: |
           devops/scripts/benchmarks
@@ -73,7 +73,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build/docs_build/generated/html
       run: |
         cat << 'EOF' > ./performance/config.js
-        remoteDataUrl = 'https://raw.githubusercontent.com/oneapi-src/unified-memory-framework/refs/heads/benchmark-results/data.json';
+        remoteDataUrl = 'https://raw.githubusercontent.com/oneapi-src/unified-memory-framework/refs/heads/benchmark-results/';
         defaultCompareNames = ["Baseline_PVC"];
         EOF
 


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description
Update intel/llvm benchmarks framework used to the latest one.
Adjust benchmarking CI to the latest changes regarding data archiving.

This one corresponds with changes up to PR https://github.com/intel/llvm/pull/19128 which introduces a split of benchmark data: current and archived.

Other notable changes:
- updated Compute Runtime to 25.22.33944.8
- chart annotations displaying changes in drivers/benchmarks versions
- added Finalize Graph benchmark (Compute Benchmarks)
- fixed LD_LIBRARY_PATH for Compute Runtime
- skip unpacking of oneAPI if already installed
- more user-friendly Compute Benchmarks charts naming
- improvements in data loading of the dashboard
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
