### PR TITLE
disable windows ASAN tests in CI

### DIFF
--- a/.github/workflows/reusable_sanitizers.yml
+++ b/.github/workflows/reusable_sanitizers.yml
@@ -74,66 +74,67 @@ jobs:
       run: |
         ctest --output-on-failure
 
-  windows-build:
-    env:
-      VCPKG_PATH: "${{github.workspace}}/build/vcpkg/packages/hwloc_x64-windows;${{github.workspace}}/build/vcpkg/packages/tbb_x64-windows;${{github.workspace}}/build/vcpkg/packages/jemalloc_x64-windows"
-    strategy:
-      matrix:
-        # TODO restore clang-cl tests
-        # {c: clang-cl, cxx: clang-cl}
-        compiler: [{c: cl, cxx: cl}]
-        # Only ASAN is supported
-        sanitizers: [{asan: ON}]
-    name: Sanitizers (windows-latest, compilers=${{matrix.compiler.c}}/${{matrix.compiler.cxx}}, asan=${{matrix.sanitizers.asan}})
-    runs-on: windows-latest
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        fetch-depth: 0
-
-    # Ensure that the required environment is set
-    # Note: No need to specify version, the latest one will be used and should work fine
-    - name: Setup MSVC dev command prompt
-      uses: TheMrMilchmann/setup-msvc-dev@fb19abb8a41b3cf0340f5d1be17d420309232be6 # v3.0.1
-      with:
-        arch: x64
-
-    - name: Initialize vcpkg
-      uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5
-      with:
-        vcpkgGitCommitId: ea2a964f9303270322cf3f2d51c265ba146c422d # 1.04.2025
-        vcpkgDirectory: ${{env.BUILD_DIR}}/vcpkg
-        vcpkgJsonGlob: '**/vcpkg.json'
-
-    - name: Install dependencies
-      run: vcpkg install --triplet x64-windows
-      shell: pwsh
-
-    - name: Configure build
-      run: >
-        cmake
-        -B ${{env.BUILD_DIR}}
-        -DCMAKE_INSTALL_PREFIX="${{env.INSTL_DIR}}"
-        -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
-        -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
-        -DCMAKE_PREFIX_PATH="${{env.VCPKG_PATH}}"
-        -DUMF_BUILD_SHARED_LIBRARY=OFF
-        -DUMF_FORMAT_CODE_STYLE=OFF
-        -DUMF_DEVELOPER_MODE=OFF
-        -DUMF_USE_ASAN=${{matrix.sanitizers.asan}}
-        -DUMF_BUILD_EXAMPLES=ON
-        -DUMF_BUILD_LEVEL_ZERO_PROVIDER=ON
-        -DUMF_BUILD_CUDA_PROVIDER=OFF
-        -DUMF_TESTS_FAIL_ON_SKIP=ON
-
-    - name: Build UMF
-      run: cmake --build ${{env.BUILD_DIR}} --config Debug -j $Env:NUMBER_OF_PROCESSORS
-
-    - name: Run tests
-      working-directory: ${{env.BUILD_DIR}}
-      env:
-        ASAN_OPTIONS: allocator_may_return_null=1
-        TSAN_OPTIONS: allocator_may_return_null=1
-      run: ctest -C Debug --output-on-failure
+  # TODO restore ASAN tests on Windows
+  #windows-build:
+  #  env:
+  #    VCPKG_PATH: "${{github.workspace}}/build/vcpkg/packages/hwloc_x64-windows;${{github.workspace}}/build/vcpkg/packages/tbb_x64-windows;${{github.workspace}}/build/vcpkg/packages/jemalloc_x64-windows"
+  #  strategy:
+  #    matrix:
+  #
+  #      # {c: clang-cl, cxx: clang-cl}
+  #      compiler: [{c: cl, cxx: cl}]
+  #      # Only ASAN is supported
+  #      sanitizers: [{asan: OFF}]
+  #  name: Sanitizers (windows-latest, compilers=${{matrix.compiler.c}}/${{matrix.compiler.cxx}}, asan=${{matrix.sanitizers.asan}})
+  #  runs-on: windows-latest
+  #
+  #  steps:
+  #  - name: Checkout
+  #    uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  #    with:
+  #      fetch-depth: 0
+  #
+  #  # Ensure that the required environment is set
+  #  # Note: No need to specify version, the latest one will be used and should work fine
+  #  - name: Setup MSVC dev command prompt
+  #    uses: TheMrMilchmann/setup-msvc-dev@fb19abb8a41b3cf0340f5d1be17d420309232be6 # v3.0.1
+  #    with:
+  #      arch: x64
+  #
+  #  - name: Initialize vcpkg
+  #    uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5
+  #    with:
+  #      vcpkgGitCommitId: ea2a964f9303270322cf3f2d51c265ba146c422d # 1.04.2025
+  #      vcpkgDirectory: ${{env.BUILD_DIR}}/vcpkg
+  #      vcpkgJsonGlob: '**/vcpkg.json'
+  #
+  #  - name: Install dependencies
+  #    run: vcpkg install --triplet x64-windows
+  #    shell: pwsh
+  #
+  #  - name: Configure build
+  #    run: >
+  #      cmake
+  #      -B ${{env.BUILD_DIR}}
+  #      -DCMAKE_INSTALL_PREFIX="${{env.INSTL_DIR}}"
+  #      -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
+  #      -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
+  #      -DCMAKE_PREFIX_PATH="${{env.VCPKG_PATH}}"
+  #      -DUMF_BUILD_SHARED_LIBRARY=OFF
+  #      -DUMF_FORMAT_CODE_STYLE=OFF
+  #      -DUMF_DEVELOPER_MODE=OFF
+  #      -DUMF_USE_ASAN=${{matrix.sanitizers.asan}}
+  #      -DUMF_BUILD_EXAMPLES=ON
+  #      -DUMF_BUILD_LEVEL_ZERO_PROVIDER=ON
+  #      -DUMF_BUILD_CUDA_PROVIDER=OFF
+  #      -DUMF_TESTS_FAIL_ON_SKIP=ON
+  #
+  #  - name: Build UMF
+  #    run: cmake --build ${{env.BUILD_DIR}} --config Debug -j $Env:NUMBER_OF_PROCESSORS
+  #
+  #  - name: Run tests
+  #    working-directory: ${{env.BUILD_DIR}}
+  #    env:
+  #      ASAN_OPTIONS: allocator_may_return_null=1
+  #      TSAN_OPTIONS: allocator_may_return_null=1
+  #    run: ctest -C Debug --output-on-failure


### PR DESCRIPTION
disable windows ASAN tests in CI

see https://github.com/oneapi-src/unified-memory-framework/issues/1394 
the fails are observed for both Clang and MSVC compilers
