### PR TITLE
fix incompatible function pointer on windows

### DIFF
--- a/src/libumf_windows.c
+++ b/src/libumf_windows.c
@@ -33,6 +33,8 @@ void libumfInit(void) {
 
 INIT_ONCE init_once_flag = INIT_ONCE_STATIC_INIT;
 
+static void umfTearDownWrapper(void) { (void)umfTearDown(); }
+
 BOOL CALLBACK initOnceCb(PINIT_ONCE InitOnce, PVOID Parameter,
                          PVOID *lpContext) {
     (void)InitOnce;  // unused
@@ -40,7 +42,7 @@ BOOL CALLBACK initOnceCb(PINIT_ONCE InitOnce, PVOID Parameter,
     (void)lpContext; // unused
 
     umf_result_t ret = umfInit();
-    atexit(umfTearDown);
+    atexit(umfTearDownWrapper);
     return (ret == UMF_RESULT_SUCCESS) ? TRUE : FALSE;
 }
 


### PR DESCRIPTION
// Failing nightly CI: https://github.com/oneapi-src/unified-memory-framework/actions/runs/15989654467/job/45100430704

<!-- Provide a short summary of your changes in the Title above -->

### Description
<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [ ] Code compiles without errors locally
- [ ] All tests pass locally
- [ ] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->

<!-- You can remove these entries, if they don't apply -->
- [ ] CI workflows, not executed per PR (e.g. Nightly), execute properly <!-- this can be checked, e.g., on your fork -->
- [ ] New tests added, especially if they will fail without my changes
- [ ] Added/extended example(s) to cover this functionality
- [ ] Extended the README/documentation
- [ ] All newly added source files have a license
- [ ] All newly added source files are referenced in CMake files
- [ ] Logger (with debug/info/... messages) is used
- [ ] All API changes are reflected in docs and def/map files, and are tested
