### PR TITLE
[CMake] Don't configure and build L0 loader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,11 +430,13 @@ if(UMF_BUILD_LEVEL_ZERO_PROVIDER)
                 GIT_TAG ${LEVEL_ZERO_LOADER_TAG})
             FetchContent_Populate(level-zero-loader)
         else()
+            # 'non-existing-dir' is set to avoid configuring L0 loader. Ref.
+            # https://gitlab.kitware.com/cmake/cmake/-/issues/26220
             FetchContent_Declare(
                 level-zero-loader
                 GIT_REPOSITORY ${LEVEL_ZERO_LOADER_REPO}
                 GIT_TAG ${LEVEL_ZERO_LOADER_TAG}
-                EXCLUDE_FROM_ALL)
+                EXCLUDE_FROM_ALL SOURCE_SUBDIR "non-existing-dir")
             FetchContent_MakeAvailable(level-zero-loader)
         endif()
 


### PR DESCRIPTION
We only require source files.

It fixes the nigthly build.
// fail: https://github.com/oneapi-src/unified-memory-framework/actions/runs/15989654467/job/45100430665
// after fixes: https://github.com/lukaszstolarczuk/unified-memory-framework/actions/runs/16003100695/job/45142932077