### PR TITLE
Rename ctl internal header file

### DIFF
--- a/include/umf/providers/provider_cuda.h
+++ b/include/umf/providers/provider_cuda.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 */
 
-#ifndef UMF_PROVIDER_CUDA_H
-#define UMF_PROVIDER_CUDA_H
+#ifndef UMF_CUDA_PROVIDER_H
+#define UMF_CUDA_PROVIDER_H
 
 #include <umf/memory_provider_gpu.h>
 
@@ -67,4 +67,4 @@ const umf_memory_provider_ops_t *umfCUDAMemoryProviderOps(void);
 }
 #endif
 
-#endif /* UMF_PROVIDER_CUDA_H */
+#endif /* UMF_CUDA_PROVIDER_H */

--- a/include/umf/providers/provider_level_zero.h
+++ b/include/umf/providers/provider_level_zero.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 */
 
-#ifndef UMF_PROVIDER_LEVEL_ZERO_H
-#define UMF_PROVIDER_LEVEL_ZERO_H
+#ifndef UMF_LEVEL_ZERO_PROVIDER_H
+#define UMF_LEVEL_ZERO_PROVIDER_H
 
 #include <umf/memory_provider_gpu.h>
 
@@ -97,4 +97,4 @@ const umf_memory_provider_ops_t *umfLevelZeroMemoryProviderOps(void);
 }
 #endif
 
-#endif /* UMF_PROVIDER_LEVEL_ZERO_H */
+#endif /* UMF_LEVEL_ZERO_PROVIDER_H */

--- a/src/ctl/ctl.c
+++ b/src/ctl/ctl.c
@@ -16,8 +16,6 @@
  *    the library's internal state
  */
 
-#include "ctl.h"
-
 #include <ctype.h>
 #include <limits.h>
 #include <stdint.h>
@@ -27,6 +25,7 @@
 #include <umf/base.h>
 
 #include "base_alloc/base_alloc_global.h"
+#include "ctl_internal.h"
 #include "utils/utils_common.h"
 #include "utlist.h"
 

--- a/src/ctl/ctl_internal.h
+++ b/src/ctl/ctl_internal.h
@@ -12,11 +12,11 @@
 /* Copyright 2016-2020, Intel Corporation */
 
 /*
- * ctl.h -- internal declaration of statistics and control related structures
+ * ctl_internal.h -- internal declaration of statistics and control related structures
  */
 
-#ifndef UMF_CTL_H
-#define UMF_CTL_H 1
+#ifndef UMF_CTL_INTERNAL_H
+#define UMF_CTL_INTERNAL_H 1
 
 #include <errno.h>
 #include <stddef.h>
@@ -245,4 +245,4 @@ umf_result_t ctl_query(struct ctl *ctl, void *ctx,
 }
 #endif
 
-#endif
+#endif /* UMF_CTL_INTERNAL_H */

--- a/src/memory_pool.c
+++ b/src/memory_pool.c
@@ -15,7 +15,7 @@
 #include <string.h>
 
 #include "base_alloc_global.h"
-#include "ctl/ctl.h"
+#include "ctl/ctl_internal.h"
 #include "libumf.h"
 #include "memory_pool_internal.h"
 #include "memory_provider_internal.h"

--- a/src/memory_provider_internal.h
+++ b/src/memory_provider_internal.h
@@ -14,7 +14,7 @@
 
 #include <umf/memory_provider.h>
 
-#include "ctl/ctl.h"
+#include "ctl/ctl_internal.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/pool/pool_disjoint.c
+++ b/src/pool/pool_disjoint.c
@@ -18,7 +18,7 @@
 #include <umf/memory_provider.h>
 
 #include "base_alloc_global.h"
-#include "ctl/ctl.h"
+#include "ctl/ctl_internal.h"
 #include "pool_disjoint_internal.h"
 #include "provider/provider_tracking.h"
 #include "uthash/utlist.h"

--- a/src/pool/pool_scalable.c
+++ b/src/pool/pool_scalable.c
@@ -19,7 +19,7 @@
 #include <umf/pools/pool_scalable.h>
 
 #include "base_alloc_global.h"
-#include "ctl/ctl.h"
+#include "ctl/ctl_internal.h"
 #include "libumf.h"
 #include "memory_pool_internal.h"
 #include "pool_scalable_internal.h"

--- a/src/pool/pool_scalable_internal.h
+++ b/src/pool/pool_scalable_internal.h
@@ -7,4 +7,9 @@
  *
  */
 
+#ifndef UMF_POOL_SCALABLE_INTERNAL_H
+#define UMF_POOL_SCALABLE_INTERNAL_H 1
+
 void fini_tbb_global_state(void);
+
+#endif /* UMF_POOL_SCALABLE_INTERNAL_H */

--- a/src/provider/provider_ctl_stats_impl.h
+++ b/src/provider/provider_ctl_stats_impl.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-#include "ctl/ctl.h"
+#include "ctl/ctl_internal.h"
 #include "utils/utils_assert.h"
 
 static umf_result_t CTL_READ_HANDLER(peak_memory)(
@@ -106,4 +106,5 @@ static inline void provider_ctl_stats_free(CTL_PROVIDER_TYPE *provider,
 #ifdef __cplusplus
 }
 #endif
-#endif
+
+#endif /* UMF_PROVIDER_CTL_STATS_IMPL_H */

--- a/src/provider/provider_ctl_stats_type.h
+++ b/src/provider/provider_ctl_stats_type.h
@@ -22,4 +22,5 @@ typedef struct ctl_stats_t {
 #ifdef __cplusplus
 }
 #endif
-#endif
+
+#endif /* UMF_PROVIDER_CTL_STATS_TYPE_H */

--- a/src/provider/provider_cuda_internal.h
+++ b/src/provider/provider_cuda_internal.h
@@ -7,4 +7,9 @@
  *
  */
 
+#ifndef UMF_CUDA_PROVIDER_INTERNAL_H
+#define UMF_CUDA_PROVIDER_INTERNAL_H 1
+
 void fini_cu_global_state(void);
+
+#endif /* UMF_CUDA_PROVIDER_INTERNAL_H */

--- a/src/provider/provider_level_zero_internal.h
+++ b/src/provider/provider_level_zero_internal.h
@@ -7,4 +7,9 @@
  *
  */
 
+#ifndef UMF_LEVEL_ZERO_PROVIDER_INTERNAL_H
+#define UMF_LEVEL_ZERO_PROVIDER_INTERNAL_H 1
+
 void fini_ze_global_state(void);
+
+#endif /* UMF_LEVEL_ZERO_PROVIDER_INTERNAL_H */

--- a/src/provider/provider_os_memory.c
+++ b/src/provider/provider_os_memory.c
@@ -19,7 +19,7 @@
 #include <umf/memory_provider_ops.h>
 #include <umf/providers/provider_os_memory.h>
 
-#include "ctl/ctl.h"
+#include "ctl/ctl_internal.h"
 #include "utils_assert.h"
 // OS Memory Provider requires HWLOC
 #if defined(UMF_NO_HWLOC)

--- a/test/ctl/ctl_debug.h
+++ b/test/ctl/ctl_debug.h
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2024 Intel Corporation
+ * Copyright (C) 2024-2025 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -8,13 +8,13 @@
  */
 
 /*
- * ctl_debug.h -- definitions for CTL test
+ * ctl_debug.h -- definitions for CTL tests
  */
 
-#ifndef UMF_CTL_DEBUG_H
-#define UMF_CTL_DEBUG_H 1
+#ifndef UMF_TEST_CTL_DEBUG_H
+#define UMF_TEST_CTL_DEBUG_H 1
 
-#include "../src/ctl/ctl.h"
+#include "ctl/ctl_internal.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -29,4 +29,4 @@ void deinitialize_debug_ctl(void);
 }
 #endif
 
-#endif
+#endif /* UMF_TEST_CTL_DEBUG_H */

--- a/test/ctl/ctl_unittest.cpp
+++ b/test/ctl/ctl_unittest.cpp
@@ -8,8 +8,8 @@
  */
 
 #include "../common/base.hpp"
-#include "ctl/ctl.h"
 #include "ctl/ctl_debug.h"
+#include "ctl/ctl_internal.h"
 
 using namespace umf_test;
 


### PR DESCRIPTION
and clean up header guards in several header files.