### PR TITLE
Add CMake integration steps and all devs' deps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,27 @@ an issue or a Pull Request, please read [Contribution Guide](./CONTRIBUTING.md).
 To enable logging in UMF source files please follow the guide in the
 [web documentation](https://oneapi-src.github.io/unified-memory-framework/introduction.html#logging).
 
+## CMake integration
+
+Integration of UMF into another project via CMake's
+[FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html),
+is possible with:
+
+```cmake
+include(FetchContent)
+
+FetchContent_Declare(
+    unified-memory-framework
+    GIT_REPOSITORY https://github.com/oneapi-src/unified-memory-framework.git
+    GIT_TAG main  # This will pull the latest (potentially unstable) changes from the main branch
+)
+FetchContent_MakeAvailable(unified-memory-framework)
+
+add_executable(some_example some_example.cpp)
+target_include_directories(some_example PRIVATE ${unified-memory-framework_SOURCE_DIR}/include)
+target_link_libraries(some_example PRIVATE umf::umf umf::headers)
+```
+
 ## Notices
 
 The contents of this repository may have been developed with support from one or more Intel-operated generative artificial intelligence solutions.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ For development and contributions:
 - cmake-format-0.6 (can be installed with `python -m pip install cmake-format==0.6.13`)
 - black (can be installed with `python -m pip install black==24.3.0`)
 
+> **Note**: All devs dependencies are defined in `third-party/requirements.txt`
+> and can be installed, for example: `pip install -r third_party/requirements.txt`.
+
 For building tests and multithreaded benchmarks:
 
 - C++ compiler with C++17 support

--- a/third_party/requirements.txt
+++ b/third_party/requirements.txt
@@ -1,9 +1,10 @@
 # Python requirements modules
 # Formatting the source code
-bandit==1.8.6
 black==24.3.0
 clang-format==15.0.7
 cmake-format==0.6.13
+# Linting the source code
+bandit==1.8.6
 # Tests
 packaging==25.0
 # Generating HTML documentation


### PR DESCRIPTION
Since we are about to test it and assure it's working, we can add it to the README file.

ref. https://github.com/oneapi-src/unified-memory-framework/pull/1384