### PR TITLE
update CI sycl tag to nightly-2025-07-09 (UMF v1.0.0-rc1)

### DIFF
--- a/.github/workflows/reusable_sycl.yml
+++ b/.github/workflows/reusable_sycl.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        llvm_tag: ["latest", "nightly-2025-03-15"] # "latest" or llvm with UMF v0.11.0-dev4
+        llvm_tag: ["latest", "nightly-2025-07-09"] # "latest" or llvm with UMF v1.0.0-rc1
 
     steps:
     # 1. Install sycl


### PR DESCRIPTION
update CI sycl tag to nightly-2025-07-09 (UMF v1.0.0-rc1)

passing Nightly / SYCL / nightly-2025-07-09 llvm build (pull_request):
https://github.com/oneapi-src/unified-memory-framework/actions/runs/16168352316/job/45635473006?pr=1425
