### PR TITLE
Test FetchContent of UMF on Linux and Windows in CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -109,6 +109,9 @@ jobs:
 
   # Build and test UMF with different CMake generators on Windows
   Windows-generators:
+    env:
+      VCPKG_PATH: "${{github.workspace}}/build/vcpkg/packages/hwloc_x64-windows;${{github.workspace}}/build/vcpkg/packages/tbb_x64-windows;${{github.workspace}}/build/vcpkg/packages/jemalloc_x64-windows"
+      VCPKG_PATH_NO_HWLOC: "${{github.workspace}}/build/vcpkg/packages/tbb_x64-windows;${{github.workspace}}/build/vcpkg/packages/jemalloc_x64-windows"
     strategy:
       matrix:
         build_type: [Debug, Release]
@@ -127,18 +130,12 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set VCPKG_PATH with hwloc
-      if: matrix.static_hwloc == 'OFF'
-      run: echo "VCPKG_PATH=${{github.workspace}}/build/vcpkg/packages/hwloc_x64-windows;${{github.workspace}}/build/vcpkg/packages/tbb_x64-windows;${{github.workspace}}/build/vcpkg/packages/jemalloc_x64-windows" >> $env:GITHUB_ENV
-
     - name: Set VCPKG_PATH without hwloc
       if: matrix.static_hwloc == 'ON'
-      run: echo "VCPKG_PATH=${{github.workspace}}/build/vcpkg/packages/tbb_x64-windows;${{github.workspace}}/build/vcpkg/packages/jemalloc_x64-windows" >> $env:GITHUB_ENV
+      run: echo "VCPKG_PATH=${{env.VCPKG_PATH_NO_HWLOC}}" >> $env:GITHUB_ENV
 
     - name: Initialize vcpkg
       uses: lukka/run-vcpkg@5e0cab206a5ea620130caf672fce3e4a6b5666a1 # v11.5
-      env: 
-        VCPKG_PATH: ${{env.VCPKG_PATH}}
       with:
         vcpkgGitCommitId: ea2a964f9303270322cf3f2d51c265ba146c422d # 1.04.2025
         vcpkgDirectory: ${{env.BUILD_DIR}}/vcpkg
@@ -200,6 +197,30 @@ jobs:
         ${{ matrix.shared_library == 'ON' && '--proxy --shared-library' || '' }}
         ${{ matrix.umfd_lib == 'ON' && '--umfd-lib' || ''}}
         ${{ matrix.static_hwloc == 'ON' && '--hwloc' || '' }}
+
+    - name: Configure the fetch_content example
+      if: matrix.static_hwloc == 'OFF'
+      working-directory: ${{github.workspace}}/examples/fetch_content
+      # Fetch_Content the UMF code from the current repository (-DUMF_REPO="${{github.workspace}}")
+      run: >
+        cmake
+        -B build
+        -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+        -DCMAKE_PREFIX_PATH="${{env.VCPKG_PATH}}"
+        -DUMF_REPO="${{github.workspace}}"
+        -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
+        -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
+        -G "${{matrix.generator}}"
+
+    - name: Build the fetch_content example
+      if: matrix.static_hwloc == 'OFF'
+      working-directory: ${{github.workspace}}/examples/fetch_content
+      run: cmake --build build --config ${{matrix.build_type}} -j $env:NUMBER_OF_PROCESSORS
+
+    - name: Run the fetch_content example
+      if: matrix.static_hwloc == 'OFF'
+      working-directory: ${{github.workspace}}/examples/fetch_content/build
+      run: ctest -V
 
   # Build and test UMF with Intel C++ Compiler (ICX) on Windows
   Windows-icx:

--- a/examples/fetch_content/CMakeLists.txt
+++ b/examples/fetch_content/CMakeLists.txt
@@ -1,0 +1,82 @@
+# Copyright (C) 2025 Intel Corporation
+# Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This example shows and tests usage of FetchContent module. It downloads and
+# builds the UMF library defined in UMF_REPO CMake variable (or UMF from
+# upstream repo URL, by default).
+
+cmake_minimum_required(VERSION 3.14.0 FATAL_ERROR)
+project(umf_example_fetch_content LANGUAGES C)
+enable_testing()
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    set(LINUX TRUE)
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    set(WINDOWS TRUE)
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(MACOSX TRUE)
+else()
+    message(FATAL_ERROR "Unknown OS type")
+endif()
+
+set(UMF_EXAMPLE_DIR "${CMAKE_SOURCE_DIR}/..")
+list(APPEND CMAKE_MODULE_PATH "${UMF_EXAMPLE_DIR}/cmake")
+message(STATUS "CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}")
+
+include("fetch_umf.cmake")
+
+find_package(PkgConfig)
+pkg_check_modules(LIBHWLOC hwloc>=2.3.0)
+if(NOT LIBHWLOC_FOUND)
+    find_package(LIBHWLOC 2.3.0 REQUIRED hwloc)
+endif()
+
+pkg_check_modules(TBB tbb)
+if(NOT TBB_FOUND)
+    find_package(TBB REQUIRED tbb)
+endif()
+
+# build the example
+set(EXAMPLE_NAME umf_example_fetch_content)
+# reusing the basic.c source file from the basic example
+add_executable(${EXAMPLE_NAME} ${CMAKE_SOURCE_DIR}/../basic/basic.c)
+target_include_directories(${EXAMPLE_NAME} PRIVATE ${LIBUMF_INCLUDE_DIRS})
+target_link_directories(${EXAMPLE_NAME} PRIVATE ${LIBHWLOC_LIBRARY_DIRS})
+target_link_libraries(${EXAMPLE_NAME} PRIVATE ${LIBUMF_LIBRARIES} hwloc)
+
+message(STATUS "LIBUMF_INCLUDE_DIRS=${LIBUMF_INCLUDE_DIRS}")
+message(STATUS "LIBUMF_LIBRARIES=${LIBUMF_LIBRARIES}")
+message(STATUS "LIBUMF_LIBRARY_DIRS=${LIBUMF_LIBRARY_DIRS}")
+message(STATUS "LIBHWLOC_LIBRARY_DIRS=${LIBHWLOC_LIBRARY_DIRS}")
+
+# an optional part - adds a test of this example
+add_test(
+    NAME ${EXAMPLE_NAME}
+    COMMAND ${EXAMPLE_NAME}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+set_tests_properties(${EXAMPLE_NAME} PROPERTIES LABELS "example-standalone")
+
+if(LINUX)
+    # set LD_LIBRARY_PATH
+    set_property(
+        TEST ${EXAMPLE_NAME}
+        PROPERTY
+            ENVIRONMENT_MODIFICATION
+            "LD_LIBRARY_PATH=path_list_append:${LIBUMF_LIBRARY_DIRS};LD_LIBRARY_PATH=path_list_append:${LIBHWLOC_LIBRARY_DIRS}"
+    )
+elseif(WINDOWS)
+    # add PATH to DLL on Windows
+    set(DLL_PATH_LIST
+        "${DLL_PATH_LIST};PATH=path_list_append:${LIBHWLOC_DLL_DIRS};PATH=path_list_append:${TBB_DLL_DIRS}"
+    )
+
+    message(STATUS "DLL_PATH_LIST=${DLL_PATH_LIST}")
+
+    # append PATH to DLLs NOTE: this would work only for the CMake ver >= #
+    # 3.22. For the older versions, the PATH variable should be set in the test
+    # script)
+    set_property(TEST ${EXAMPLE_NAME} PROPERTY ENVIRONMENT_MODIFICATION
+                                               "${DLL_PATH_LIST}")
+endif()

--- a/examples/fetch_content/fetch_umf.cmake
+++ b/examples/fetch_content/fetch_umf.cmake
@@ -1,0 +1,63 @@
+# Copyright (C) 2025 Intel Corporation
+# Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+message(STATUS "Downloading Unified Memory Framework ...")
+
+include(FetchContent)
+
+if(NOT DEFINED UMF_REPO)
+    set(UMF_REPO "https://github.com/oneapi-src/unified-memory-framework.git")
+elseif(WINDOWS)
+    string(REPLACE "\\" "/" OUT_UMF_REPO "${UMF_REPO}")
+    message(
+        STATUS
+            "Replaced \"${UMF_REPO}\" with \"${OUT_UMF_REPO}\" for Windows compatibility"
+    )
+    set(UMF_REPO "${OUT_UMF_REPO}")
+endif()
+
+if(NOT DEFINED UMF_TAG)
+    set(UMF_TAG HEAD)
+endif()
+
+message(
+    STATUS
+        "Will fetch Unified Memory Framework from ${UMF_REPO} at ${UMF_TAG} ..."
+)
+message(STATUS "CMAKE_GENERATOR: ${CMAKE_GENERATOR}")
+
+FetchContent_Declare(
+    unified-memory-framework
+    GIT_REPOSITORY ${UMF_REPO}
+    GIT_TAG ${UMF_TAG})
+
+set(UMF_BUILD_TESTS
+    OFF
+    CACHE INTERNAL "Do not build UMF tests")
+set(UMF_BUILD_EXAMPLES
+    OFF
+    CACHE INTERNAL "Do not build UMF examples")
+set(UMF_BUILD_SHARED_LIBRARY
+    OFF
+    CACHE INTERNAL "Build UMF shared library")
+set(UMF_BUILD_LIBUMF_POOL_DISJOINT
+    ON
+    CACHE INTERNAL "Build Disjoint Pool")
+set(UMF_BUILD_CUDA_PROVIDER
+    OFF
+    CACHE INTERNAL "Do not build CUDA provider")
+set(UMF_BUILD_LEVEL_ZERO_PROVIDER
+    OFF
+    CACHE INTERNAL "Do not build L0 provider")
+set(UMF_DISABLE_HWLOC
+    OFF
+    CACHE INTERNAL "Enable HWLOC support")
+set(UMF_LINK_HWLOC_STATICALLY
+    OFF
+    CACHE INTERNAL "UMF_LINK_HWLOC_STATICALLY=OFF")
+
+FetchContent_MakeAvailable(unified-memory-framework)
+
+set(LIBUMF_INCLUDE_DIRS ${unified-memory-framework_SOURCE_DIR}/include)
+set(LIBUMF_LIBRARIES umf::umf umf::headers)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -677,11 +677,11 @@ if(LINUX
     set(EXAMPLES "")
 
     if(UMF_POOL_SCALABLE_ENABLED)
-        set(EXAMPLES ${EXAMPLES} basic custom_file_provider)
+        set(EXAMPLES ${EXAMPLES} basic fetch_content custom_file_provider)
     else()
         message(
             STATUS
-                "The basic and custom_file_provider examples require TBB to be installed and added to the default library search path - skipping"
+                "The basic, fetch_content, and custom_file_provider examples require TBB to be installed and added to the default library search path - skipping"
         )
     endif()
 


### PR DESCRIPTION
Add the fetch_content example based on the 'basic' example.

- on Windows test in Nightly CI job with the 'Ninja' and 'NMake Makefiles' generators.
- on Linux in standalone examples' test.

// Continuation of #1384, with changes from my review, incl.
- get rid of `FetchContent_GetProperties`
- added extra CMake printing
- added a short description of the example
- run this example in nightly workflow only if the VCPKG_PATH set (with hwloc)

// nightly passing: https://github.com/lukaszstolarczuk/unified-memory-framework/actions/runs/16217653089