### PR TITLE
quiet brew install up-to-date warnings

### DIFF
--- a/.github/workflows/reusable_basic.yml
+++ b/.github/workflows/reusable_basic.yml
@@ -492,11 +492,11 @@ jobs:
         python3 -m pip install -r third_party/requirements.txt
 
     - name: Install dependencies
-      run: brew install jemalloc tbb automake libtool
+      run: brew install --quiet jemalloc tbb automake libtool
 
     - name: Install hwloc
       if: ${{ matrix.static_hwloc == 'OFF' }}
-      run: brew install hwloc
+      run: brew install --quiet hwloc
 
     - name: Get UMF version
       run: |


### PR DESCRIPTION
quiet brew install up-to-date warnings

Basic builds / Basic (macos-13, static_hwloc=OFF)
hwloc 2.12.1 is already installed and up-to-date. To reinstall 2.12.1, run: brew reinstall hwloc

Basic builds / Basic (macos-13, static_hwloc=OFF)
libtool 2.5.4 is already installed and up-to-date. To reinstall 2.5.4, run: brew reinstall libtool
