### PR TITLE
[CMake] Update deprecated msg for hwloc option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ list(APPEND UMF_OPTIONS_LIST UMF_PROXY_LIB_BASED_ON_POOL)
 if(UMF_DISABLE_HWLOC)
     message(
         WARNING
-            "UMF_DISABLE_HWLOC option is now deprecated and will be removed in v0.12.0 UMF release!"
+            "UMF_DISABLE_HWLOC option is now deprecated and will be removed in v1.1.0 UMF release!"
     )
 endif()
 


### PR DESCRIPTION
ref. #1228 - merged on main - we'll be removed in the next UMF version -- 0.12 is not planned.