### PR TITLE
[CI] Don't use trap caching in CodeQL job

### DIFF
--- a/.github/workflows/reusable_codeql.yml
+++ b/.github/workflows/reusable_codeql.yml
@@ -44,6 +44,7 @@ jobs:
       uses: github/codeql-action/init@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
       with:
         languages: cpp
+        trap-caching: false
 
     - name: "[Win] Initialize vcpkg"
       if: matrix.os == 'windows-latest'


### PR DESCRIPTION
CodeQL caching seem to have no effect on the speed, but it takes quite a lot of our cache storage space.

// no step "upload TRAP cache..." https://github.com/lukaszstolarczuk/unified-memory-framework/actions/runs/16369095173/job/46253062138#step:11:479