### PR TITLE
Check for null pointer dereference in umfPoolDestroy()

### DIFF
--- a/src/memory_pool.c
+++ b/src/memory_pool.c
@@ -277,6 +277,11 @@ err_provider_create:
 }
 
 umf_result_t umfPoolDestroy(umf_memory_pool_handle_t hPool) {
+    if (hPool == NULL) {
+        LOG_ERR("memory pool handle is NULL");
+        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
     if (umf_ba_global_is_destroyed()) {
         return UMF_RESULT_ERROR_UNKNOWN;
     }

--- a/test/poolFixtures.hpp
+++ b/test/poolFixtures.hpp
@@ -122,6 +122,11 @@ GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(umfMemTest);
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(umfPoolTest);
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(umfMultiPoolTest);
 
+TEST_P(umfPoolTest, destroyNullptr) {
+    auto ret = umfPoolDestroy(nullptr);
+    ASSERT_EQ(ret, UMF_RESULT_ERROR_INVALID_ARGUMENT);
+}
+
 TEST_P(umfPoolTest, allocFree) {
     static constexpr size_t allocSize = 64;
     auto *ptr = umfPoolMalloc(pool.get(), allocSize);


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

Check for null pointer dereference in `umfPoolDestroy()`.

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
