### PR TITLE
Add assert in `poolCreateExtUnique()` after `EXPECT_*()`

### DIFF
--- a/test/poolFixtures.hpp
+++ b/test/poolFixtures.hpp
@@ -40,6 +40,10 @@ umf_test::pool_unique_handle_t poolCreateExtUnique(poolCreateExtParams params) {
                                   &upstream_provider);
     EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
     EXPECT_NE(upstream_provider, nullptr);
+    if (ret != UMF_RESULT_SUCCESS || upstream_provider == nullptr) {
+        assert(false && "Failed to create a memory provider");
+        return umf_test::pool_unique_handle_t(nullptr, nullptr);
+    }
 
     provider = upstream_provider;
 
@@ -54,6 +58,10 @@ umf_test::pool_unique_handle_t poolCreateExtUnique(poolCreateExtParams params) {
                         UMF_POOL_CREATE_FLAG_OWN_PROVIDER, &hPool);
     EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
     EXPECT_NE(hPool, nullptr);
+    if (ret != UMF_RESULT_SUCCESS || hPool == nullptr) {
+        assert(false && "Failed to create a memory pool");
+        return umf_test::pool_unique_handle_t(nullptr, nullptr);
+    }
 
     // we do not need params anymore
     if (poolParamsDestroy) {


### PR DESCRIPTION
<!-- Provide a short summary of your changes in the Title above -->

### Description

Add assert in `poolCreateExtUnique()` after `EXPECT_*()`.

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
