### PR TITLE
Fix null pointer dereference in createDevDaxParams()

### DIFF
--- a/examples/dram_and_fsdax/dram_and_fsdax.c
+++ b/examples/dram_and_fsdax/dram_and_fsdax.c
@@ -96,7 +96,7 @@ int main(void) {
     // - the UMF_TESTS_FSDAX_PATH environment variable to contain
     //   a path to a file on this FSDAX device.
     char *path = getenv("UMF_TESTS_FSDAX_PATH");
-    if (path == NULL || path[0] == 0) {
+    if (path == NULL || path[0] == '\0') {
         fprintf(
             stderr,
             "Warning: UMF_TESTS_FSDAX_PATH is not set, skipping testing ...\n");

--- a/test/ipc_devdax_prov_consumer.c
+++ b/test/ipc_devdax_prov_consumer.c
@@ -23,13 +23,13 @@ int main(int argc, char *argv[]) {
     int port = atoi(argv[1]);
 
     char *path = getenv("UMF_TESTS_DEVDAX_PATH");
-    if (path == NULL || path[0] == 0) {
+    if (path == NULL || path[0] == '\0') {
         fprintf(stderr, "Test skipped, UMF_TESTS_DEVDAX_PATH is not set\n");
         return 0;
     }
 
     char *size = getenv("UMF_TESTS_DEVDAX_SIZE");
-    if (size == NULL || size[0] == 0) {
+    if (size == NULL || size[0] == '\0') {
         fprintf(stderr, "Test skipped, UMF_TESTS_DEVDAX_SIZE is not set\n");
         return 0;
     }

--- a/test/ipc_devdax_prov_producer.c
+++ b/test/ipc_devdax_prov_producer.c
@@ -23,13 +23,13 @@ int main(int argc, char *argv[]) {
     int port = atoi(argv[1]);
 
     char *path = getenv("UMF_TESTS_DEVDAX_PATH");
-    if (path == NULL || path[0] == 0) {
+    if (path == NULL || path[0] == '\0') {
         fprintf(stderr, "Test skipped, UMF_TESTS_DEVDAX_PATH is not set\n");
         return 0;
     }
 
     char *size = getenv("UMF_TESTS_DEVDAX_SIZE");
-    if (size == NULL || size[0] == 0) {
+    if (size == NULL || size[0] == '\0') {
         fprintf(stderr, "Test skipped, UMF_TESTS_DEVDAX_SIZE is not set\n");
         return 0;
     }

--- a/test/pools/jemalloc_coarse_devdax.cpp
+++ b/test/pools/jemalloc_coarse_devdax.cpp
@@ -10,7 +10,8 @@
 bool devDaxEnvSet() {
     char *path = getenv("UMF_TESTS_DEVDAX_PATH");
     char *size = getenv("UMF_TESTS_DEVDAX_SIZE");
-    if (path == nullptr || path[0] == 0 || size == nullptr || size[0] == 0) {
+    if (path == nullptr || path[0] == '\0' || size == nullptr ||
+        size[0] == '\0') {
         return false;
     }
 
@@ -20,7 +21,8 @@ bool devDaxEnvSet() {
 void *createDevDaxParams() {
     char *path = getenv("UMF_TESTS_DEVDAX_PATH");
     char *size = getenv("UMF_TESTS_DEVDAX_SIZE");
-    if (path == nullptr || path[0] == 0 || size == nullptr || size[0] == 0) {
+    if (path == nullptr || path[0] == '\0' || size == nullptr ||
+        size[0] == '\0') {
         return nullptr;
     }
 

--- a/test/pools/jemalloc_coarse_devdax.cpp
+++ b/test/pools/jemalloc_coarse_devdax.cpp
@@ -20,6 +20,9 @@ bool devDaxEnvSet() {
 void *createDevDaxParams() {
     char *path = getenv("UMF_TESTS_DEVDAX_PATH");
     char *size = getenv("UMF_TESTS_DEVDAX_SIZE");
+    if (path == nullptr || path[0] == 0 || size == nullptr || size[0] == 0) {
+        return nullptr;
+    }
 
     umf_devdax_memory_provider_params_handle_t params = NULL;
     umf_result_t res =

--- a/test/pools/scalable_coarse_devdax.cpp
+++ b/test/pools/scalable_coarse_devdax.cpp
@@ -10,7 +10,8 @@
 bool devDaxEnvSet() {
     char *path = getenv("UMF_TESTS_DEVDAX_PATH");
     char *size = getenv("UMF_TESTS_DEVDAX_SIZE");
-    if (path == nullptr || path[0] == 0 || size == nullptr || size[0] == 0) {
+    if (path == nullptr || path[0] == '\0' || size == nullptr ||
+        size[0] == '\0') {
         return false;
     }
 
@@ -20,7 +21,8 @@ bool devDaxEnvSet() {
 void *createDevDaxParams() {
     char *path = getenv("UMF_TESTS_DEVDAX_PATH");
     char *size = getenv("UMF_TESTS_DEVDAX_SIZE");
-    if (path == nullptr || path[0] == 0 || size == nullptr || size[0] == 0) {
+    if (path == nullptr || path[0] == '\0' || size == nullptr ||
+        size[0] == '\0') {
         return nullptr;
     }
 

--- a/test/pools/scalable_coarse_devdax.cpp
+++ b/test/pools/scalable_coarse_devdax.cpp
@@ -20,6 +20,9 @@ bool devDaxEnvSet() {
 void *createDevDaxParams() {
     char *path = getenv("UMF_TESTS_DEVDAX_PATH");
     char *size = getenv("UMF_TESTS_DEVDAX_SIZE");
+    if (path == nullptr || path[0] == 0 || size == nullptr || size[0] == 0) {
+        return nullptr;
+    }
 
     umf_devdax_memory_provider_params_handle_t params = NULL;
     umf_result_t res =

--- a/test/provider_devdax_memory.cpp
+++ b/test/provider_devdax_memory.cpp
@@ -123,7 +123,7 @@ TEST_F(test, test_if_mapped_with_MAP_SYNC) {
     umf_result_t umf_result;
 
     char *path = getenv("UMF_TESTS_DEVDAX_PATH");
-    if (path == nullptr || path[0] == 0) {
+    if (path == nullptr || path[0] == '\0') {
         GTEST_SKIP() << "Test skipped, UMF_TESTS_DEVDAX_PATH is not set";
     }
 
@@ -169,7 +169,8 @@ using devdax_params_unique_handle_t =
 devdax_params_unique_handle_t create_devdax_params() {
     char *path = getenv("UMF_TESTS_DEVDAX_PATH");
     char *size = getenv("UMF_TESTS_DEVDAX_SIZE");
-    if (path == nullptr || path[0] == 0 || size == nullptr || size[0] == 0) {
+    if (path == nullptr || path[0] == '\0' || size == nullptr ||
+        size[0] == '\0') {
         return devdax_params_unique_handle_t(
             nullptr, &umfDevDaxMemoryProviderParamsDestroy);
     }

--- a/test/provider_devdax_memory_ipc.cpp
+++ b/test/provider_devdax_memory_ipc.cpp
@@ -18,7 +18,8 @@ using umf_test::test;
 bool devDaxEnvSet() {
     char *path = getenv("UMF_TESTS_DEVDAX_PATH");
     char *size = getenv("UMF_TESTS_DEVDAX_SIZE");
-    if (path == nullptr || path[0] == 0 || size == nullptr || size[0] == 0) {
+    if (path == nullptr || path[0] == '\0' || size == nullptr ||
+        size[0] == '\0') {
         return false;
     }
 
@@ -28,7 +29,8 @@ bool devDaxEnvSet() {
 void *defaultDevDaxParamsCreate() {
     char *path = getenv("UMF_TESTS_DEVDAX_PATH");
     char *size = getenv("UMF_TESTS_DEVDAX_SIZE");
-    if (path == nullptr || path[0] == 0 || size == nullptr || size[0] == 0) {
+    if (path == nullptr || path[0] == '\0' || size == nullptr ||
+        size[0] == '\0') {
         return nullptr;
     }
 

--- a/test/provider_file_memory.cpp
+++ b/test/provider_file_memory.cpp
@@ -119,7 +119,7 @@ TEST_F(test, test_if_mapped_with_MAP_SYNC) {
     umf_result_t umf_result;
 
     char *path = getenv("UMF_TESTS_FSDAX_PATH");
-    if (path == nullptr || path[0] == 0) {
+    if (path == nullptr || path[0] == '\0') {
         GTEST_SKIP() << "Test skipped, UMF_TESTS_FSDAX_PATH is not set";
     }
 

--- a/test/provider_file_memory_ipc.cpp
+++ b/test/provider_file_memory_ipc.cpp
@@ -114,7 +114,7 @@ static std::vector<ipcTestParams> getIpcFsDaxTestParamsList(void) {
     std::vector<ipcTestParams> ipcFsDaxTestParamsList = {};
 
     char *path = getenv("UMF_TESTS_FSDAX_PATH");
-    if (path == nullptr || path[0] == 0) {
+    if (path == nullptr || path[0] == '\0') {
         // skipping the test, UMF_TESTS_FSDAX_PATH is not set
         return ipcFsDaxTestParamsList;
     }


### PR DESCRIPTION

<!-- Provide a short summary of your changes in the Title above -->

### Description

Fix null pointer dereference in createDevDaxParams().
It fixes the Coverity issue no. 485528.

<!--
Describe your changes in detail.
For contribution process guide, look into CONTRIBUTING.md in the main directory

Remember: one PR should fix or enhance one thing.
    Consider splitting large PR into a few smaller PRs.

If this is a relatively **large or complex** change:
 - BEFORE creating a PR, try finding an existing issue or start a new discussion,
 - if the discussion is concluded, go ahead with this PR,
 - perhaps describe what alternatives you considered.

If this PR references or fixes an open issue, please link it here
    using "Ref. #<number>" or "Fixes: #<number>".
-->

### Checklist
<!--
Put an 'x' in the boxes that are checked.
Before checking all the boxes please mark the PR as draft.
-->

- [x] Code compiles without errors locally
- [x] All tests pass locally
- [x] CI workflows execute properly
<!-- If you have more tasks to do before merging this PR, simply add them here -->
