### PR TITLE
[CMake] Bump L0 loader to v1.22.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -389,7 +389,7 @@ if(UMF_BUILD_LEVEL_ZERO_PROVIDER)
     else()
         set(LEVEL_ZERO_LOADER_REPO
             "https://github.com/oneapi-src/level-zero.git")
-        set(LEVEL_ZERO_LOADER_TAG v1.21.9)
+        set(LEVEL_ZERO_LOADER_TAG v1.22.4)
 
         message(STATUS "Fetching Level Zero loader (${LEVEL_ZERO_LOADER_TAG}) "
                        "from ${LEVEL_ZERO_LOADER_REPO} ...")


### PR DESCRIPTION
It's aligned with version currently used in SYCL.