### PR TITLE
load libcuda.so.1 instead of libcuda.so on linux

### DIFF
--- a/src/provider/provider_cuda.c
+++ b/src/provider/provider_cuda.c
@@ -149,7 +149,7 @@ static void init_cu_global_state(void) {
 #ifdef _WIN32
     const char *lib_name = "nvcuda.dll";
 #else
-    const char *lib_name = "libcuda.so";
+    const char *lib_name = "libcuda.so.1";
 #endif
     // The CUDA shared library should be already loaded by the user
     // of the CUDA provider. UMF just want to reuse it

--- a/test/providers/cuda_helpers.cpp
+++ b/test/providers/cuda_helpers.cpp
@@ -110,7 +110,7 @@ int InitCUDAOps() {
 #ifdef _WIN32
     const char *lib_name = "nvcuda.dll";
 #else
-    const char *lib_name = "libcuda.so";
+    const char *lib_name = "libcuda.so.1";
 #endif
     // CUDA symbols
 #if OPEN_CU_LIBRARY_GLOBAL


### PR DESCRIPTION
load libcuda.so.1 instead of libcuda.so on linux