### PR TITLE
Run dependabot updates less often for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/third_party" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "monthly"
     ignore:
       - dependency-name: "clang-format"
       - dependency-name: "cmake-format"
@@ -17,7 +17,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/.github/workflows/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     groups:
       actions-dependencies:
         applies-to: version-updates


### PR DESCRIPTION
As UMF is a little slowed down for the moment, it's not required to update dependencies as often (to not spam our history with just deps' updates).