### PR TITLE
fix umfMemspaceFilterHelper leak

### DIFF
--- a/src/memspace.c
+++ b/src/memspace.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2025 Intel Corporation
+ * Copyright (C) 2023-2026 Intel Corporation
  *
  * Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -455,7 +455,11 @@ static int umfMemspaceFilterHelper(umf_memspace_handle_t memspace,
             LOG_ERR("filter function failed");
             goto free_mem;
         } else if (ret == 0) {
-            nodesToRemove[idx++] = memspace->nodes[i];
+            ret = umfMemtargetClone(memspace->nodes[i], &nodesToRemove[idx]);
+            if (ret != UMF_RESULT_SUCCESS) {
+                goto free_mem;
+            }
+            idx++;
         }
     }
 
@@ -467,8 +471,8 @@ static int umfMemspaceFilterHelper(umf_memspace_handle_t memspace,
         }
     }
 
-    umf_ba_global_free(nodesToRemove);
-    return UMF_RESULT_SUCCESS;
+    ret = UMF_RESULT_SUCCESS;
+    goto free_mem;
 
 re_add:
     // If target removal failed, add back previously removed targets.
@@ -481,6 +485,9 @@ re_add:
         }
     }
 free_mem:
+    for (size_t j = 0; j < idx; j++) {
+        umfMemtargetDestroy(nodesToRemove[j]);
+    }
     umf_ba_global_free(nodesToRemove);
     return ret;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2025 Intel Corporation
+# Copyright (C) 2022-2026 Intel Corporation
 # Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -377,8 +377,10 @@ if(LINUX) # OS-specific functions are implemented
         LIBS ${LIBNUMA_LIBRARIES})
     add_umf_test(
         NAME memtarget
-        SRCS memspaces/memtarget.cpp
-        LIBS ${LIBNUMA_LIBRARIES} ${UMF_HWLOC_NAME})
+        SRCS memspaces/memtarget.cpp ${UMF_SRC_DIR}/memtarget.c
+             ${UMF_SRC_DIR}/libumf_linux.c
+        LIBS ${UMF_UTILS_FOR_TEST} ${UMF_BA_FOR_TEST} ${LIBNUMA_LIBRARIES}
+             ${UMF_HWLOC_NAME})
     add_umf_test(
         NAME provider_devdax_memory
         SRCS provider_devdax_memory.cpp

--- a/test/memspaces/memtarget.cpp
+++ b/test/memspaces/memtarget.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2025 Intel Corporation
+// Copyright (C) 2024-2026 Intel Corporation
 // Under the Apache License v2.0 with LLVM Exceptions. See LICENSE.TXT.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
@@ -9,7 +9,142 @@
 #include <umf/experimental/memspace.h>
 #include <umf/experimental/memtarget.h>
 
+#include "memtarget_internal.h"
+#include "memtarget_ops.h"
+
 using umf_test::test;
+
+namespace {
+
+struct fake_target_t {
+    unsigned id;
+};
+
+int finalizeCount;
+
+umf_result_t fakeInitialize(void *params, void **memoryTarget) {
+    if (!params || !memoryTarget) {
+        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
+    auto target = static_cast<fake_target_t *>(malloc(sizeof(fake_target_t)));
+    if (!target) {
+        return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    target->id = *static_cast<unsigned *>(params);
+    *memoryTarget = target;
+    return UMF_RESULT_SUCCESS;
+}
+
+void fakeFinalize(void *memoryTarget) {
+    finalizeCount++;
+    free(memoryTarget);
+}
+
+umf_result_t fakeClone(void *memoryTarget, void **outMemoryTarget) {
+    if (!memoryTarget || !outMemoryTarget) {
+        return UMF_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
+    auto source = static_cast<fake_target_t *>(memoryTarget);
+    auto target = static_cast<fake_target_t *>(malloc(sizeof(fake_target_t)));
+    if (!target) {
+        return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    target->id = source->id;
+    *outMemoryTarget = target;
+    return UMF_RESULT_SUCCESS;
+}
+
+umf_result_t fakePoolCreateFromMemspace(umf_const_memspace_handle_t memspace,
+                                        void **memoryTargets, size_t numTargets,
+                                        umf_const_mempolicy_handle_t policy,
+                                        umf_memory_pool_handle_t *pool) {
+    (void)memspace;
+    (void)memoryTargets;
+    (void)numTargets;
+    (void)policy;
+    (void)pool;
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+}
+
+umf_result_t
+fakeMemoryProviderCreateFromMemspace(umf_const_memspace_handle_t memspace,
+                                     void **memoryTargets, size_t numTargets,
+                                     umf_const_mempolicy_handle_t policy,
+                                     umf_memory_provider_handle_t *provider) {
+    (void)memspace;
+    (void)memoryTargets;
+    (void)numTargets;
+    (void)policy;
+    (void)provider;
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+}
+
+umf_result_t fakeGetCapacity(void *memoryTarget, size_t *capacity) {
+    (void)memoryTarget;
+    *capacity = 4096;
+    return UMF_RESULT_SUCCESS;
+}
+
+umf_result_t fakeGetBandwidth(void *srcMemoryTarget, void *dstMemoryTarget,
+                              size_t *bandwidth) {
+    (void)srcMemoryTarget;
+    (void)dstMemoryTarget;
+    *bandwidth = 1;
+    return UMF_RESULT_SUCCESS;
+}
+
+umf_result_t fakeGetLatency(void *srcMemoryTarget, void *dstMemoryTarget,
+                            size_t *latency) {
+    (void)srcMemoryTarget;
+    (void)dstMemoryTarget;
+    *latency = 1;
+    return UMF_RESULT_SUCCESS;
+}
+
+umf_result_t fakeGetType(void *memoryTarget, umf_memtarget_type_t *type) {
+    (void)memoryTarget;
+    *type = UMF_MEMTARGET_TYPE_NUMA;
+    return UMF_RESULT_SUCCESS;
+}
+
+umf_result_t fakeGetId(void *memoryTarget, unsigned *id) {
+    *id = static_cast<fake_target_t *>(memoryTarget)->id;
+    return UMF_RESULT_SUCCESS;
+}
+
+umf_result_t fakeCompare(void *memTarget, void *otherMemTarget, int *result) {
+    auto left = static_cast<fake_target_t *>(memTarget);
+    auto right = static_cast<fake_target_t *>(otherMemTarget);
+
+    if (finalizeCount > 0 && left->id == 2 && right->id == 2) {
+        return UMF_RESULT_ERROR_UNKNOWN;
+    }
+
+    *result = left->id == right->id ? 0 : 1;
+    return UMF_RESULT_SUCCESS;
+}
+
+const umf_memtarget_ops_t FAKE_OPS = {
+    .version = UMF_MEMTARGET_OPS_VERSION_CURRENT,
+    .initialize = fakeInitialize,
+    .finalize = fakeFinalize,
+    .clone = fakeClone,
+    .pool_create_from_memspace = fakePoolCreateFromMemspace,
+    .memory_provider_create_from_memspace =
+        fakeMemoryProviderCreateFromMemspace,
+    .get_capacity = fakeGetCapacity,
+    .get_bandwidth = fakeGetBandwidth,
+    .get_latency = fakeGetLatency,
+    .get_type = fakeGetType,
+    .get_id = fakeGetId,
+    .compare = fakeCompare,
+};
+
+} // namespace
 
 TEST_F(test, memTargetNuma) {
     auto memspace = umfMemspaceHostAllGet();
@@ -171,4 +306,130 @@ TEST_F(test, memTargetRemoveAll) {
 
     ret = umfMemspaceDestroy(memspace);
     EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
+}
+
+TEST_F(test, memTargetFilterRollback) {
+    finalizeCount = 0;
+
+    umf_memspace_handle_t memspace = nullptr;
+    umf_result_t ret = umfMemspaceNew(&memspace);
+    ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+    ASSERT_NE(memspace, nullptr);
+
+    umf_memtarget_handle_t target1 = nullptr;
+    umf_memtarget_handle_t target2 = nullptr;
+    umf_memtarget_handle_t target3 = nullptr;
+    unsigned id1 = 1;
+    unsigned id2 = 2;
+    unsigned id3 = 3;
+
+    ret = umfMemtargetCreate(&FAKE_OPS, &id1, &target1);
+    ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+    ret = umfMemtargetCreate(&FAKE_OPS, &id2, &target2);
+    ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+    ret = umfMemtargetCreate(&FAKE_OPS, &id3, &target3);
+    ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+
+    ret = umfMemspaceMemtargetAdd(memspace, target1);
+    ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+    ret = umfMemspaceMemtargetAdd(memspace, target2);
+    ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+    ret = umfMemspaceMemtargetAdd(memspace, target3);
+    ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+
+    ret = umfMemspaceUserFilter(
+        memspace,
+        [](umf_const_memspace_handle_t, umf_const_memtarget_handle_t,
+           void *) -> int {
+            // filter everything
+            return 0;
+        },
+        nullptr);
+    EXPECT_EQ(ret, UMF_RESULT_ERROR_UNKNOWN);
+    ASSERT_EQ(umfMemspaceMemtargetNum(memspace), 3u);
+
+    std::vector<unsigned> ids;
+    for (size_t targetIdx = 0; targetIdx < umfMemspaceMemtargetNum(memspace);
+         targetIdx++) {
+        auto target = umfMemspaceMemtargetGet(memspace, targetIdx);
+        ASSERT_NE(target, nullptr);
+
+        unsigned id = 0;
+        ret = umfMemtargetGetId(target, &id);
+        ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+        ids.push_back(id);
+    }
+
+    std::sort(ids.begin(), ids.end());
+    EXPECT_EQ(ids, (std::vector<unsigned>{1, 2, 3}));
+
+    ret = umfMemspaceDestroy(memspace);
+    EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
+    umfMemtargetDestroy(target1);
+    umfMemtargetDestroy(target2);
+    umfMemtargetDestroy(target3);
+}
+
+TEST_F(test, memTargetFilterRemoveOnlyId2) {
+    finalizeCount = 0;
+
+    umf_memspace_handle_t memspace = nullptr;
+    umf_result_t ret = umfMemspaceNew(&memspace);
+    ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+    ASSERT_NE(memspace, nullptr);
+
+    umf_memtarget_handle_t target1 = nullptr;
+    umf_memtarget_handle_t target2 = nullptr;
+    umf_memtarget_handle_t target3 = nullptr;
+    unsigned id1 = 1;
+    unsigned id2 = 2;
+    unsigned id3 = 3;
+
+    ret = umfMemtargetCreate(&FAKE_OPS, &id1, &target1);
+    ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+    ret = umfMemtargetCreate(&FAKE_OPS, &id2, &target2);
+    ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+    ret = umfMemtargetCreate(&FAKE_OPS, &id3, &target3);
+    ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+
+    ret = umfMemspaceMemtargetAdd(memspace, target1);
+    ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+    ret = umfMemspaceMemtargetAdd(memspace, target2);
+    ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+    ret = umfMemspaceMemtargetAdd(memspace, target3);
+    ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+
+    ret = umfMemspaceUserFilter(
+        memspace,
+        [](umf_const_memspace_handle_t, umf_const_memtarget_handle_t target,
+           void *args) -> int {
+            // filter out target with id passed in args, keep the rest
+            unsigned targetId = 0;
+            (void)umfMemtargetGetId(target, &targetId);
+            return targetId == *static_cast<unsigned *>(args) ? 0 : 1;
+        },
+        &id2);
+    EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
+    ASSERT_EQ(umfMemspaceMemtargetNum(memspace), 2u);
+
+    std::vector<unsigned> ids;
+    for (size_t targetIdx = 0; targetIdx < umfMemspaceMemtargetNum(memspace);
+         targetIdx++) {
+        auto target = umfMemspaceMemtargetGet(memspace, targetIdx);
+        ASSERT_NE(target, nullptr);
+
+        unsigned id = 0;
+        ret = umfMemtargetGetId(target, &id);
+        ASSERT_EQ(ret, UMF_RESULT_SUCCESS);
+        ids.push_back(id);
+    }
+
+    std::sort(ids.begin(), ids.end());
+    EXPECT_EQ(ids, (std::vector<unsigned>{1, 3}));
+
+    ret = umfMemspaceDestroy(memspace);
+    EXPECT_EQ(ret, UMF_RESULT_SUCCESS);
+    umfMemtargetDestroy(target1);
+    umfMemtargetDestroy(target2);
+    umfMemtargetDestroy(target3);
 }


### PR DESCRIPTION
Fix for potential crash in umfMemspaceFilterHelper:
- clone memspace nodes before removal
- add memTargetFilterRollback test
