### PR TITLE
remove invalid noexcept from IPC test helper func

### DIFF
--- a/test/ipcAPI.cpp
+++ b/test/ipcAPI.cpp
@@ -143,7 +143,7 @@ struct provider_mock_ipc_huge_handle : public provider_mock_ipc {
     }
 
     umf_result_t ext_get_ipc_handle(const void *ptr, size_t size,
-                                    void *providerIpcData) noexcept {
+                                    void *providerIpcData) {
         (void)ptr;
         (void)size;
         (void)providerIpcData;


### PR DESCRIPTION
remove invalid noexcept from IPC test helper func "ext_get_ipc_handle"

fixes Coverity https://scan3.scan.coverity.com/#/project-view/65229/15141?selectedIssue=910054
