### PR TITLE
Bump Level Zero version to v1.31.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,7 +408,7 @@ if(UMF_BUILD_LEVEL_ZERO_PROVIDER)
     else()
         set(LEVEL_ZERO_LOADER_REPO
             "https://github.com/oneapi-src/level-zero.git")
-        set(LEVEL_ZERO_LOADER_TAG v1.26.3)
+        set(LEVEL_ZERO_LOADER_TAG v1.31.0)
 
         message(STATUS "Fetching Level Zero loader (${LEVEL_ZERO_LOADER_TAG}) "
                        "from ${LEVEL_ZERO_LOADER_REPO} ...")


### PR DESCRIPTION
It's already used in SYCL ([link](https://github.com/intel/llvm/blob/sycl/devops/dependencies.json#L22)).